### PR TITLE
fix(deploy): nginx healthchecks probe 127.0.0.1, not localhost

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -90,7 +90,9 @@ services:
     depends_on:
       - backend
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8081/"]
+      # 127.0.0.1, not localhost: nginx listens on IPv4 only (`listen 8081;`),
+      # but localhost resolves to ::1 first in this image -> false unhealthy.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8081/"]
       interval: 30s
       timeout: 3s
       retries: 3
@@ -133,7 +135,9 @@ services:
     volumes:
       - ./nginx/gateway.conf:/etc/nginx/conf.d/default.conf:ro
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:6688/"]
+      # 127.0.0.1, not localhost: nginx listens on IPv4 only (`listen 6688;`),
+      # but localhost resolves to ::1 first in this image -> false unhealthy.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:6688/"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,7 +32,9 @@ RUN adduser -S -u 10002 -G nginx marauder \
 USER marauder:nginx
 EXPOSE 8081
 
+# 127.0.0.1, not localhost: nginx listens on IPv4 only; localhost resolves
+# to ::1 first in this image, which would falsely report unhealthy.
 HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
-  CMD wget -qO- http://localhost:8081/ >/dev/null 2>&1 || exit 1
+  CMD wget -qO- http://127.0.0.1:8081/ >/dev/null 2>&1 || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

The `frontend` and `gateway` containers reported **unhealthy** despite serving traffic correctly (the app responds 200 through the gateway).

Their healthchecks ran `wget http://localhost:<port>/`, but in these alpine/nginx images `localhost` resolves to `::1` (IPv6) first, while nginx is configured **IPv4-only** (`listen 8081;` / `listen 6688;`). The probe hit a closed IPv6 socket → `connection refused` → false unhealthy.

Fix: point the probes at `127.0.0.1` explicitly — the frontend + gateway compose healthchecks and the frontend image `HEALTHCHECK`. Backend/cfsolver were unaffected because Go binds dual-stack on `:port`.

## Test plan
- [x] Rebuilt frontend + recreated frontend/gateway; both flip to `healthy` within one interval.
- [x] In-container probe confirms `127.0.0.1:8081`/`127.0.0.1:6688` return 200 while `localhost` was refused.
- [x] App still serves through the gateway (`GET /` and `/api/v1/system/info` → 200).