### PR TITLE
Uniform client base download folder + category subfolder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,15 @@ techdebt/       Debt-tracking files (one per issue, see global rule)
    on errors, capped at 6h) and writes the run summary metrics.
 
 **Per-topic delivery:** `sendViaClient` passes `domain.AddOptions{DownloadDir:
-t.DownloadDir, Category: t.Category}` to the client plugin, so each topic can
-target its own save folder and (qBittorrent) category. Transmission ignores
-`Category`. Both fields are editable via `PUT /topics/{id}`.
+t.DownloadDir, Category: t.Category}` to the client plugin. Category is a
+**path segment, not a client-native label**: each client config carries an
+optional base `download_dir`, and every client resolves the save path via
+`registry.EffectiveDownloadDir(base, opts.DownloadDir, opts.Category)` —
+`topic.DownloadDir` (explicit full path) overrides, else
+`path.Join(clientBase, category)`. This works uniformly across qBittorrent,
+Transmission, Deluge and downloadfolder (µTorrent still can't set a per-add
+path). qBittorrent's old native-`category` config field was removed. Both
+fields are editable via `PUT /topics/{id}`.
 
 **Errored-topic retry:** `DueForCheck` selects `WHERE status IN
 ('active','error')`, so a topic that errors keeps retrying on its already-

--- a/backend/internal/plugins/clients/deluge/deluge.go
+++ b/backend/internal/plugins/clients/deluge/deluge.go
@@ -38,6 +38,10 @@ import (
 type Config struct {
 	URL      string `json:"url"` // e.g. http://deluge:8112
 	Password string `json:"password"`
+	// DownloadDir is the base save folder. A topic's category nests under it
+	// (see registry.EffectiveDownloadDir); a topic's explicit DownloadDir
+	// overrides both.
+	DownloadDir string `json:"download_dir"`
 }
 
 type plugin struct {
@@ -62,8 +66,9 @@ func (p *plugin) ConfigSchema() map[string]any {
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type":    "object",
 		"properties": map[string]any{
-			"url":      map[string]any{"type": "string", "title": "Web URL", "format": "uri"},
-			"password": map[string]any{"type": "string", "title": "Password", "format": "password"},
+			"url":          map[string]any{"type": "string", "title": "Web URL", "format": "uri"},
+			"password":     map[string]any{"type": "string", "title": "Password", "format": "password"},
+			"download_dir": map[string]any{"type": "string", "title": "Base download folder (optional)"},
 		},
 		"required": []string{"url", "password"},
 	}
@@ -92,8 +97,8 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 	}
 
 	dlOpts := map[string]any{}
-	if opts.DownloadDir != "" {
-		dlOpts["download_location"] = opts.DownloadDir
+	if dir := registry.EffectiveDownloadDir(c.DownloadDir, opts.DownloadDir, opts.Category); dir != "" {
+		dlOpts["download_location"] = dir
 	}
 	if opts.Paused {
 		dlOpts["add_paused"] = true

--- a/backend/internal/plugins/clients/downloadfolder/downloadfolder.go
+++ b/backend/internal/plugins/clients/downloadfolder/downloadfolder.go
@@ -65,9 +65,12 @@ func (p *plugin) Add(_ context.Context, rawConfig []byte, payload *domain.Payloa
 	if err := json.Unmarshal(rawConfig, &c); err != nil {
 		return fmt.Errorf("bad config: %w", err)
 	}
-	dir := c.Path
-	if opts.DownloadDir != "" {
-		dir = opts.DownloadDir
+	// c.Path is the base folder; a topic's category nests under it and an
+	// explicit per-topic DownloadDir overrides both — uniform with the
+	// networked clients.
+	dir := registry.EffectiveDownloadDir(c.Path, opts.DownloadDir, opts.Category)
+	if dir == "" {
+		dir = c.Path
 	}
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err

--- a/backend/internal/plugins/clients/downloadfolder/downloadfolder_test.go
+++ b/backend/internal/plugins/clients/downloadfolder/downloadfolder_test.go
@@ -69,6 +69,19 @@ func TestAddMagnet(t *testing.T) {
 	}
 }
 
+func TestAddNestsCategoryUnderBase(t *testing.T) {
+	p := &plugin{}
+	base := t.TempDir()
+	cfg, _ := json.Marshal(Config{Path: base})
+	payload := &domain.Payload{TorrentFile: []byte("xx"), FileName: "f.torrent"}
+	if err := p.Add(context.Background(), cfg, payload, domain.AddOptions{Category: "Movies"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "Movies", "f.torrent")); err != nil {
+		t.Fatalf("file not nested under category: %v", err)
+	}
+}
+
 func TestAddRespectsOptOverrideDir(t *testing.T) {
 	p := &plugin{}
 	defaultDir := t.TempDir()

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
@@ -30,7 +30,10 @@ type Config struct {
 	URL      string `json:"url"` // e.g. http://qbittorrent:8080
 	Username string `json:"username"`
 	Password string `json:"password"`
-	Category string `json:"category"`
+	// DownloadDir is the base save folder. A topic's category nests under it
+	// (see registry.EffectiveDownloadDir); a topic's explicit DownloadDir
+	// overrides both.
+	DownloadDir string `json:"download_dir"`
 }
 
 type plugin struct {
@@ -57,10 +60,10 @@ func (p *plugin) ConfigSchema() map[string]any {
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type":    "object",
 		"properties": map[string]any{
-			"url":      map[string]any{"type": "string", "format": "uri", "title": "URL"},
-			"username": map[string]any{"type": "string", "title": "Username"},
-			"password": map[string]any{"type": "string", "title": "Password", "format": "password"},
-			"category": map[string]any{"type": "string", "title": "Category (optional)"},
+			"url":          map[string]any{"type": "string", "format": "uri", "title": "URL"},
+			"username":     map[string]any{"type": "string", "title": "Username"},
+			"password":     map[string]any{"type": "string", "title": "Password", "format": "password"},
+			"download_dir": map[string]any{"type": "string", "title": "Base download folder (optional)"},
 		},
 		"required": []string{"url", "username", "password"},
 	}
@@ -116,11 +119,8 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 	default:
 		return errors.New("empty payload (no magnet and no torrent file)")
 	}
-	if opts.DownloadDir != "" {
-		_ = mw.WriteField("savepath", opts.DownloadDir)
-	}
-	if cfg.Category != "" {
-		_ = mw.WriteField("category", cfg.Category)
+	if dir := registry.EffectiveDownloadDir(cfg.DownloadDir, opts.DownloadDir, opts.Category); dir != "" {
+		_ = mw.WriteField("savepath", dir)
 	}
 	if opts.Paused {
 		_ = mw.WriteField("paused", "true")

--- a/backend/internal/plugins/clients/transmission/transmission.go
+++ b/backend/internal/plugins/clients/transmission/transmission.go
@@ -30,6 +30,11 @@ type Config struct {
 	URL      string `json:"url"`
 	Username string `json:"username"`
 	Password string `json:"password"`
+	// DownloadDir is the base save folder. A topic's category nests under it
+	// (see registry.EffectiveDownloadDir); a topic's explicit DownloadDir
+	// overrides both. This is how a category reaches Transmission, which has
+	// no native category concept of its own.
+	DownloadDir string `json:"download_dir"`
 }
 
 type plugin struct {
@@ -53,9 +58,10 @@ func (p *plugin) ConfigSchema() map[string]any {
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type":    "object",
 		"properties": map[string]any{
-			"url":      map[string]any{"type": "string", "title": "RPC URL", "format": "uri"},
-			"username": map[string]any{"type": "string", "title": "Username (optional)"},
-			"password": map[string]any{"type": "string", "title": "Password (optional)", "format": "password"},
+			"url":          map[string]any{"type": "string", "title": "RPC URL", "format": "uri"},
+			"username":     map[string]any{"type": "string", "title": "Username (optional)"},
+			"password":     map[string]any{"type": "string", "title": "Password (optional)", "format": "password"},
+			"download_dir": map[string]any{"type": "string", "title": "Base download folder (optional)"},
 		},
 		"required": []string{"url"},
 	}
@@ -88,8 +94,8 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 	default:
 		return errors.New("empty payload")
 	}
-	if opts.DownloadDir != "" {
-		args["download-dir"] = opts.DownloadDir
+	if dir := registry.EffectiveDownloadDir(c.DownloadDir, opts.DownloadDir, opts.Category); dir != "" {
+		args["download-dir"] = dir
 	}
 	if opts.Paused {
 		args["paused"] = true

--- a/backend/internal/plugins/clients/transmission/transmission_test.go
+++ b/backend/internal/plugins/clients/transmission/transmission_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 type fakeServer struct {
-	sessionID   string
-	addCalls    int32
-	requireAuth bool
+	sessionID    string
+	addCalls     int32
+	requireAuth  bool
+	lastDownload string
 }
 
 func newFakeServer(t *testing.T) (*httptest.Server, *fakeServer) {
@@ -44,6 +45,9 @@ func newFakeServer(t *testing.T) (*httptest.Server, *fakeServer) {
 			w.Write([]byte(`{"result":"success","arguments":{"version":"4.0.6"}}`))
 		case "torrent-add":
 			atomic.AddInt32(&f.addCalls, 1)
+			if args, ok := req["arguments"].(map[string]any); ok {
+				f.lastDownload, _ = args["download-dir"].(string)
+			}
 			w.WriteHeader(200)
 			w.Write([]byte(`{"result":"success","arguments":{"torrent-added":{"id":1,"hashString":"abc"}}}`))
 		default:
@@ -110,6 +114,32 @@ func TestAddTorrentFile(t *testing.T) {
 	}
 	if atomic.LoadInt32(&fake.addCalls) != 1 {
 		t.Errorf("addCalls = %d", fake.addCalls)
+	}
+}
+
+func TestAddNestsCategoryUnderBaseDownloadDir(t *testing.T) {
+	srv, fake := newFakeServer(t)
+	p := newPlugin()
+	cfg, _ := json.Marshal(Config{URL: srv.URL, DownloadDir: "/downloads"})
+	payload := &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:abc"}
+	if err := p.Add(context.Background(), cfg, payload, domain.AddOptions{Category: "Movies"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if fake.lastDownload != "/downloads/Movies" {
+		t.Errorf("download-dir = %q, want /downloads/Movies", fake.lastDownload)
+	}
+}
+
+func TestAddExplicitDirOverridesBase(t *testing.T) {
+	srv, fake := newFakeServer(t)
+	p := newPlugin()
+	cfg, _ := json.Marshal(Config{URL: srv.URL, DownloadDir: "/downloads"})
+	payload := &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:abc"}
+	if err := p.Add(context.Background(), cfg, payload, domain.AddOptions{DownloadDir: "/explicit", Category: "Movies"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if fake.lastDownload != "/explicit" {
+		t.Errorf("download-dir = %q, want /explicit", fake.lastDownload)
 	}
 }
 

--- a/backend/internal/plugins/registry/downloaddir.go
+++ b/backend/internal/plugins/registry/downloaddir.go
@@ -1,0 +1,52 @@
+package registry
+
+import (
+	"path"
+	"strings"
+)
+
+// EffectiveDownloadDir resolves the save path a client plugin should use for
+// a topic, unifying the per-topic override, the client's base download folder,
+// and the topic's category across every client.
+//
+// Precedence:
+//
+//  1. override (the topic's explicit DownloadDir) wins outright when set;
+//  2. otherwise the category nests under the client's base folder:
+//     join(base, category);
+//  3. with no override and no category, the client's base folder is used.
+//
+// Paths use forward slashes because they address remote torrent clients
+// (qBittorrent savepath, Transmission download-dir, …); we deliberately use
+// path.Join, not filepath.Join, so behaviour is identical regardless of the
+// host OS Marauder runs on.
+//
+// The category is treated as a relative segment and cannot escape the base:
+// it is cleaned as if rooted ("../../etc" -> "etc"), guarding against path
+// traversal in user-supplied category values.
+func EffectiveDownloadDir(base, override, category string) string {
+	if override != "" {
+		return override
+	}
+	category = sanitizeCategory(category)
+	if category == "" {
+		return base
+	}
+	return path.Join(base, category)
+}
+
+// sanitizeCategory normalises a user-supplied category into a safe relative
+// path segment that cannot traverse above its base folder.
+func sanitizeCategory(category string) string {
+	category = strings.TrimSpace(category)
+	if category == "" {
+		return ""
+	}
+	// Root, clean, then strip the leading slash: this collapses any ".."
+	// components so the result can never climb above the base it is joined to.
+	cleaned := strings.TrimPrefix(path.Clean("/"+category), "/")
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
+}

--- a/backend/internal/plugins/registry/downloaddir_test.go
+++ b/backend/internal/plugins/registry/downloaddir_test.go
@@ -1,0 +1,35 @@
+package registry
+
+import "testing"
+
+func TestEffectiveDownloadDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		override string
+		category string
+		want     string
+	}{
+		{"all empty", "", "", "", ""},
+		{"base only", "/downloads", "", "", "/downloads"},
+		{"category nests under base", "/downloads", "", "Movies", "/downloads/Movies"},
+		{"nested category", "/downloads", "", "tv/hd", "/downloads/tv/hd"},
+		{"override wins over base+category", "/downloads", "/explicit", "Movies", "/explicit"},
+		{"override wins with no base", "", "/explicit", "", "/explicit"},
+		{"category only, no base", "", "", "Movies", "Movies"},
+		{"trailing slash on base is cleaned", "/downloads/", "", "Movies", "/downloads/Movies"},
+		{"category traversal is confined", "/downloads", "", "../../etc", "/downloads/etc"},
+		{"leading slash category is relative", "/downloads", "", "/abs/Movies", "/downloads/abs/Movies"},
+		{"whitespace category is empty", "/downloads", "", "   ", "/downloads"},
+		{"dot category is empty", "/downloads", "", ".", "/downloads"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EffectiveDownloadDir(tt.base, tt.override, tt.category)
+			if got != tt.want {
+				t.Errorf("EffectiveDownloadDir(%q, %q, %q) = %q, want %q",
+					tt.base, tt.override, tt.category, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/superpowers/specs/2026-05-30-topic-metadata-delivery-folders-design.md
+++ b/docs/superpowers/specs/2026-05-30-topic-metadata-delivery-folders-design.md
@@ -1,0 +1,183 @@
+# Topic Metadata, Delivery Tracking & Uniform Folders — Design
+
+**Date:** 2026-05-30
+**Status:** Approved (brainstorm), pending implementation
+**Goal:** Make topics self-describing (real title + poster image, auto-resolved per
+tracker), show what each topic has delivered to its client (with optional live
+download progress), and give every client a base download folder that topic
+*categories* nest under uniformly.
+
+This bundles five user-requested adjustments into three independently shippable
+stages (PR-A, PR-B, PR-C).
+
+---
+
+## Unifying model
+
+Three structural decisions tie the five requests together:
+
+1. **One tracker capability resolves human metadata.** A new optional interface
+   `WithMetadata` returns `{Title, ImageURL}` for a URL. It serves the "real
+   display name" request (#3), the "show an image" request (#2), and the
+   "redundant source in name" request (#5) — because once the title is the real
+   show/release name, the existing source badge makes any tracker prefix
+   obsolete. Each tracker plugin owns its own extraction (the "abstraction"
+   the user asked for).
+
+2. **One deliveries record underpins both progress tiers.** A new
+   `topic_deliveries` table stores, per push, `{topic_id, infohash, label,
+   client_id, delivered_at}`. Tier 1 (always) reads it to list "delivered"
+   items with human-readable labels (`S01E05`). Tier 2 (where supported) feeds
+   those infohashes to the client's status query for a live percent/finished
+   badge. The **BitTorrent infohash is the universal key**: Marauder already
+   parses the BTIH of every torrent it pushes; qBittorrent queries by `hashes=`
+   and Transmission's `torrent-get` accepts `hashString` — same identifier.
+
+3. **Category is a path segment, not a client-native label.** Each client config
+   gains an optional base `download_dir`. The effective save path is computed
+   once, in the scheduler:
+   `effective = topic.DownloadDir (explicit override) || join(client.download_dir, topic.Category)`.
+   Every client that already honors `opts.DownloadDir` then behaves identically,
+   including Transmission (which has no native category). qBittorrent's
+   native-category config field is **removed** in favor of this model.
+
+---
+
+## Stage PR-A — Uniform client folder + category subfolder (#4)
+
+**Scope:** smallest, pure wiring; `Topic.DownloadDir`/`Topic.Category` and
+`AddOptions{DownloadDir, Category}` already exist.
+
+### Backend
+- **Client config schema:** add optional `download_dir` (base folder) to each
+  plugin's `ConfigSchema()` and config struct. Remove qBittorrent's `category`
+  config field.
+- **Scheduler `sendViaClient`:** compute the effective save path
+  `topic.DownloadDir || path.Join(clientBaseDir, topic.Category)` (forward
+  slashes; `path.Join`, not `filepath`, since these are remote client paths) and
+  pass it as `opts.DownloadDir`. Stop relying on per-client category.
+- **Clients that honor DownloadDir:** qBittorrent (`savepath`), Transmission
+  (`download-dir`), Deluge (`download_location`), downloadfolder (`path`). µTorrent
+  still cannot set a path per add — document that it ignores the base folder.
+- The base folder lives inside the encrypted config blob; no new column.
+
+### Frontend
+- **Client form (`Clients.tsx` `fieldsForPlugin`):** add a "Base download folder"
+  field to every plugin's field list. Remove qBittorrent's category field.
+- **Topic form:** `category` input stays; relabel its helper text to "nested
+  under the client's base folder".
+- **i18n:** new keys `clients.field.downloadDir(.hint)`, updated
+  `topics.add.category` hint.
+
+### Success check
+qBittorrent + Transmission both deliver into `<base>/<category>`; a topic with an
+explicit `DownloadDir` overrides; backend `go test -race ./...` green; client
+config round-trips the new field.
+
+---
+
+## Stage PR-B — Auto title + poster image (#2, #3, #5)
+
+### Backend
+- **DB `0005`:** `ALTER TABLE topics ADD COLUMN image_url TEXT;` Add
+  `domain.Topic.ImageURL string` (no json tag, PascalCase-read like its siblings).
+  Update `scanTopic`, insert, and update SQL/repo.
+- **Registry `WithMetadata`:**
+  ```go
+  type Metadata struct { Title string; ImageURL string }
+  type WithMetadata interface {
+      ResolveMetadata(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (*Metadata, error)
+  }
+  ```
+- **Trackers:** RuTracker (first-post `<title>` cleaned of ` :: RuTracker.org`;
+  first content `<img>` / `<var class="postImg">` src) and LostFilm (series
+  `<title>` cleaned; poster image from the series page) implement `WithMetadata`.
+  Reuse the page-fetch helpers they already call in `Check`.
+- **Create handler:** after `Parse`, if the tracker implements `WithMetadata`,
+  call it with a short `context.WithTimeout` (best-effort). On success seed
+  `DisplayName` (unless the user supplied one) and `ImageURL`. On failure keep the
+  Parse placeholder — never block topic creation.
+- **Scheduler self-heal:** persist `check.DisplayName` back to the topic when it
+  differs (fixes the existing latent bug where the real title is parsed but never
+  saved). Image is resolved once at add-time; not re-fetched per check.
+- **New endpoint `GET /api/v1/trackers/preview?url=`:** runs `ResolveMetadata`
+  (no creds), returns `{title, image_url}` for the add-form preview. Trackers
+  without the capability return an empty body / 204.
+
+### Frontend
+- **`lib/api.ts`:** add `ImageURL: string` to `Topic`; add `previewTracker(url)`
+  → `{title, image_url}`.
+- **Topic row (`Topics.tsx`):** render an `<img>` poster thumbnail with
+  `onError` → hide; show the real `DisplayName` (no source prefix); the existing
+  tracker badge already conveys source (#5 satisfied).
+- **Add form:** debounced (`useDebouncedValue`) call to `previewTracker` after a
+  valid URL; show poster + resolved title as a preview card; prefill the display
+  name field when empty.
+- **i18n:** `topics.preview.*`, image alt text.
+
+### Success check
+Adding a RuTracker URL shows the real torrent title + image immediately; a
+LostFilm series shows show title + poster; existing placeholder topics upgrade to
+real titles after one scheduled check; broken image URLs disappear cleanly;
+frontend `npm run typecheck && npm test && npm run build` green.
+
+---
+
+## Stage PR-C — Delivery tracking + live progress (#1)
+
+### Backend
+- **DB `0006`:** `topic_deliveries (id, topic_id FK CASCADE, infohash TEXT,
+  label TEXT, client_id UUID, delivered_at TIMESTAMPTZ)`, index on `topic_id`.
+- **Scheduler:** on each successful `Add`, capture the pushed torrent's infohash
+  (from the `Payload`/`check.Hash`) and a human label — for episodic, decode the
+  packed episode id into `S{season:02}E{episode:02}`; for single-torrent, the
+  release/display name — and insert a `topic_deliveries` row. This is **Tier 1**
+  and is never blocked.
+- **Registry `WithStatus` (clients):**
+  ```go
+  type TorrentStatus struct { Hash string; PercentDone float64; State string }
+  type WithStatus interface {
+      Status(ctx context.Context, rawConfig []byte, hashes []string) ([]TorrentStatus, error)
+  }
+  ```
+  Implement for **Transmission** (`torrent-get` with `fields:[hashString,
+  percentDone, status]`, request `ids` by hash) and **qBittorrent**
+  (`/api/v2/torrents/info?hashes=<joined>`). Other clients omit it.
+- **New endpoint `GET /api/v1/topics/{id}/status`:** loads the topic's
+  deliveries, and if its client implements `WithStatus`, queries live status by
+  infohash; returns per-item `{label, percent_done, state, delivered_at}`.
+  Clients without the capability → items with `state:"delivered"` only. On-demand;
+  no background poller.
+
+### Frontend
+- **Topic row:** delivered count + decoded `S01E05` chips (Tier 1, always). When
+  the topic's client supports status, a React Query with `refetchInterval` polls
+  `GET /topics/{id}/status` while the page is open and renders a live percent /
+  "finished" badge. Degrades to "delivered" labels otherwise.
+- **i18n:** `topics.delivery.*` (delivered, downloading, finished, count).
+
+### Caveat (verify during implementation)
+Per-episode **live** status needs each episode's infohash captured from its
+`Payload` at delivery. If an episodic `Payload` doesn't expose a derivable
+infohash, that topic degrades to Tier 1 chips while single-torrent topics get full
+live percent. Tier 1 is never blocked by this.
+
+### Success check
+A RuTracker topic shows live download percent from Transmission that advances on
+poll and reads "finished" at 100%; a LostFilm topic shows decoded delivered
+episodes (live percent if infohash available); a client without `WithStatus`
+shows delivered labels with no error; backend + frontend test suites green.
+
+---
+
+## Cross-cutting
+
+- **Conventions:** PascalCase-read / snake_case-write asymmetry preserved
+  (`Topic` fields untagged; request structs json-tagged). React Query keys from
+  `QK`. `interface` over `type` for TS object shapes. 4-space Go is gofmt-managed.
+- **No synthetic data:** images and titles come only from real tracker pages;
+  empty/uncertain → placeholder or hidden, never fabricated.
+- **Docs:** update `CLAUDE.md` (domain row: `ImageURL`; new `WithMetadata` /
+  `WithStatus` capabilities; deliveries table; category-as-subfolder) in the same
+  commits as the structural changes.
+- **Each stage is its own PR** and must be green on CI before the next.

--- a/frontend/src/components/topics/TopicForm.tsx
+++ b/frontend/src/components/topics/TopicForm.tsx
@@ -285,6 +285,9 @@ export function TopicForm({
             }
             placeholder="/downloads/tv"
           />
+          <p className="text-xs text-muted-foreground">
+            Full path; overrides the client folder and category below.
+          </p>
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="category">Category (optional)</Label>
@@ -294,7 +297,9 @@ export function TopicForm({
             onChange={(e) => setDelivery((d) => ({ ...d, category: e.target.value }))}
             placeholder="tv"
           />
-          <p className="text-xs text-muted-foreground">Applies to qBittorrent.</p>
+          <p className="text-xs text-muted-foreground">
+            Nested under the client's base download folder.
+          </p>
         </div>
       </div>
 

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -332,6 +332,17 @@ type Field = {
   helpText?: string;
 };
 
+// Shared across every client that honours a base save folder. A topic's
+// category nests under it and a topic's own download folder overrides it —
+// see registry.EffectiveDownloadDir on the backend.
+const DOWNLOAD_DIR_FIELD: Field = {
+  key: "download_dir",
+  label: "Base download folder (optional)",
+  placeholder: "/downloads",
+  helpText:
+    "Torrents save here. A topic's category nests under this folder (e.g. /downloads/Movies); a topic's own download folder overrides it.",
+};
+
 // Hard-coded field hints. The backend ConfigSchema is the source of truth;
 // this is just a UX shortcut so the form renders without a JSON-Schema
 // renderer. v0.5 will switch to schema-driven rendering.
@@ -348,7 +359,7 @@ function fieldsForPlugin(name: string): Field[] {
         },
         { key: "username", label: "Username", placeholder: "admin" },
         { key: "password", label: "Password", password: true },
-        { key: "category", label: "Category (optional)" },
+        DOWNLOAD_DIR_FIELD,
       ];
     case "downloadfolder":
       return [
@@ -357,7 +368,7 @@ function fieldsForPlugin(name: string): Field[] {
           label: "Folder path",
           placeholder: "/downloads",
           helpText:
-            "Filesystem path the backend can write to. SABnzbd / NZBGet watch folders work here too.",
+            "Base filesystem path the backend can write to. A topic's category nests under it (e.g. /downloads/Movies). SABnzbd / NZBGet watch folders work here too.",
         },
       ];
     case "transmission":
@@ -371,6 +382,7 @@ function fieldsForPlugin(name: string): Field[] {
         },
         { key: "username", label: "Username (optional)" },
         { key: "password", label: "Password (optional)", password: true },
+        DOWNLOAD_DIR_FIELD,
       ];
     case "deluge":
       return [
@@ -382,6 +394,7 @@ function fieldsForPlugin(name: string): Field[] {
             "Host and port of the Deluge Web UI. Default port is 8112. The plugin appends /json automatically.",
         },
         { key: "password", label: "Password", password: true },
+        DOWNLOAD_DIR_FIELD,
       ];
     case "utorrent":
       return [


### PR DESCRIPTION
## Summary

First of three staged PRs implementing the topic metadata/delivery/folders design (`docs/superpowers/specs/2026-05-30-topic-metadata-delivery-folders-design.md`).

Makes a topic's **category** a uniform path segment instead of a client-native label:

- Every client config gains an optional base `download_dir`.
- The effective save path is resolved once via the new shared helper `registry.EffectiveDownloadDir(base, override, category)`:
  - a topic's explicit `DownloadDir` (full path) overrides everything;
  - otherwise the category nests under the client base: `path.Join(base, category)`;
  - category is traversal-confined (`../../etc` → `etc`) so it can never escape the base.
- Works identically across qBittorrent, Transmission, Deluge and downloadfolder. **Transmission now honours categories** (as a subfolder) for the first time — it has no native category concept. µTorrent still can't set a per-add path (documented).
- qBittorrent's old native-`category` config field is **removed** in favour of this model — the only behaviour change to existing client configs.
- `downloadfolder`'s `Path` becomes the base folder; categories nest under it.

Frontend: shared "Base download folder" field added to the qBittorrent/Transmission/Deluge client forms; topic category hint relabelled to "nested under the client's base download folder".

## Test Plan

- [x] `registry.EffectiveDownloadDir` table-driven unit test (12 cases incl. traversal, override precedence)
- [x] Transmission: new tests asserting `download-dir` = `<base>/<category>` and explicit-dir override
- [x] downloadfolder: new test asserting the file lands under `<base>/<category>`
- [x] `go build/vet/test ./...` green (race + plain, 0 failures)
- [x] Frontend `typecheck` + 31 tests + `build` green