### PR TITLE
Auto-resolved topic title + poster image (WithMetadata)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,11 @@ techdebt/       Debt-tracking files (one per issue, see global rule)
 | `crypto` | AES-256-GCM for tracker credentials and client config blobs |
 | `db` / `db/repo` | pgxpool wrapper + repository structs (`Topics`, `Clients`, `Notifiers`, `Users`, `TrackerCredentials`, `Audit`, `Settings`). `TrackerCredentials` carries encrypted `secret_enc` (password) **and** `session_enc`/`session_nonce` (cookie-session blob; migration `0002`), plus a nullable `session_expired_at` marker (migration `0003`) the scheduler uses to dedupe expiry notifications (atomic `MarkSessionExpired`, cleared by `SetSession` on re-auth) |
 | **`notify`** | reusable notification dispatcher — `Send(userID, domain.Message)` fans out to all of a user's configured notifiers (best-effort, metered). First/only consumer: scheduler session-expiry alerts. The single event→notifier fan-out point |
-| `domain` | core types: `Topic` (incl. per-topic `ClientID`, `DownloadDir`, `Category`), `Check`, `Payload`, `TrackerCredential`, `AddOptions` (`DownloadDir` + `Category`) |
+| `domain` | core types: `Topic` (incl. per-topic `ClientID`, `DownloadDir`, `Category`, `ImageURL`), `Check`, `Payload`, `TrackerCredential`, `AddOptions` (`DownloadDir` + `Category`) |
 | **`extra`** | shared `extra.Int / StringSlice / String` helpers for the untyped `map[string]any` blobs in `Topic.Extra` and `Check.Extra` (added 2026-04-07; **use this instead of writing local helpers**) |
 | `logging` | zerolog setup (JSON in prod, pretty in dev) |
 | `metrics` | Prometheus collectors (HTTP, scheduler, tracker, client) |
-| `plugins/registry` | plugin interfaces + global registry + capability interfaces (`WithQuality`, `WithEpisodeFilter`, `WithCredentials`, `WithCloudflare`, `WithInteractiveLogin`, `WithSeasonCatalog`) + typed sentinels **`registry.ErrNoPendingEpisodes`**, `ErrCaptchaRequired`, `ErrSessionExpired` |
+| `plugins/registry` | plugin interfaces + global registry + capability interfaces (`WithQuality`, `WithEpisodeFilter`, `WithCredentials`, `WithCloudflare`, `WithInteractiveLogin`, `WithSeasonCatalog`, `WithMetadata`) + the `registry.EffectiveDownloadDir(base, override, category)` save-path helper + typed sentinels **`registry.ErrNoPendingEpisodes`**, `ErrCaptchaRequired`, `ErrSessionExpired` |
 | **`plugins/captchalogin`** | reusable human-in-the-loop interactive captcha-login engine (`Begin`/`Complete`/`Refresh` + TTL pending-session store). A tracker supplies a `Config` (LoginURL, CaptchaURL, CookieNames, BuildForm, Classify); first consumer is LostFilm. See `WithInteractiveLogin` |
 | `plugins/trackers/<name>` | one package per tracker plugin (16 plugins as of v1.0.0+) |
 | `plugins/clients/<name>` | one package per torrent client (qBittorrent, Transmission, Deluge, µTorrent, downloadfolder) |
@@ -251,7 +251,7 @@ unit test plus an e2e test using `plugins/e2etest.HostRewriteTransport`.
 
 Optional capability interfaces: `WithQuality`, `WithEpisodeFilter`,
 `WithCredentials`, `WithCloudflare`, `WithInteractiveLogin`,
-`WithSeasonCatalog`. The frontend AddTopic form discovers most via
+`WithSeasonCatalog`, `WithMetadata`. The frontend AddTopic form discovers most via
 `GET /api/v1/trackers/match?url=`; `supports_interactive_login` is
 **also** surfaced per-tracker in `GET /api/v1/system/info` because the
 add-credential form selects a tracker by name and has no URL.
@@ -260,6 +260,16 @@ seasons/episodes from `GET /api/v1/trackers/seasons?url=` (fetches the
 public `/series/<slug>/seasons` page, reuses the episode parser); the
 AddTopic form uses it to constrain the "start from" season/episode
 selectors to released values.
+
+`WithMetadata` (RuTracker, LostFilm) resolves a real title + poster image
+from a topic URL. It is called best-effort (fail-open, short timeout) at add
+time so a new topic shows a real name + image immediately instead of a
+"RuTracker topic 123" placeholder, and powers `GET /api/v1/trackers/preview?url=`
+for the AddTopic form's preview card. The scheduler additionally self-heals the
+title on each check (`displayNamePersister` → `Topics.UpdateDisplayName`) when a
+plugin's `Check` reports a `DisplayName` that differs from what's stored. The
+image is stored in `topics.image_url` (migration `0005`) and rendered as a
+graceful `<img>` (hidden on load error — no fake fallback).
 
 For per-episode trackers (currently only LostFilm), `Download` must
 return `fmt.Errorf("...: %w", registry.ErrNoPendingEpisodes)` when the

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.27.0
+	golang.org/x/text v0.37.0
 )
 
 require (
@@ -37,6 +38,5 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/backend/internal/api/handlers/topics.go
+++ b/backend/internal/api/handlers/topics.go
@@ -110,6 +110,25 @@ func (h *Topics) Create(w http.ResponseWriter, r *http.Request) {
 		displayName = parsed.DisplayName
 	}
 
+	// Best-effort metadata resolution: ask the tracker for a real title and a
+	// poster image straight from the page so a freshly-added topic shows them
+	// immediately instead of a "RuTracker topic 123" placeholder. This is
+	// fail-open — metadata is enhancement, not core: any error (timeout, login
+	// wall, parse miss) leaves the placeholder in place and never blocks the
+	// add. The scheduler later self-heals the title on the first check.
+	var imageURL string
+	if wm, ok := tracker.(registry.WithMetadata); ok {
+		mctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+		meta, merr := wm.ResolveMetadata(mctx, req.URL, nil)
+		cancel()
+		if merr == nil && meta != nil {
+			if req.DisplayName == "" && meta.Title != "" {
+				displayName = meta.Title
+			}
+			imageURL = meta.ImageURL
+		}
+	}
+
 	// Overlay any user-supplied capability fields onto the Extra map
 	// the plugin's Parse() returned. The plugin's defaults stay in
 	// place for any field the user didn't specify.
@@ -147,6 +166,7 @@ func (h *Topics) Create(w http.ResponseWriter, r *http.Request) {
 		TrackerName:      tracker.Name(),
 		URL:              req.URL,
 		DisplayName:      displayName,
+		ImageURL:         imageURL,
 		ClientID:         req.ClientID,
 		DownloadDir:      req.DownloadDir,
 		Category:         req.Category,

--- a/backend/internal/api/handlers/trackers.go
+++ b/backend/internal/api/handlers/trackers.go
@@ -76,6 +76,37 @@ func (h *Trackers) Match(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
+// Preview handles GET /api/v1/trackers/preview?url=<encoded> — a real title
+// and poster image resolved from the page, for the AddTopic form preview.
+// Returns 200 with empty fields (not an error) when the tracker can't resolve
+// metadata or doesn't implement the capability, so the form degrades quietly.
+func (h *Trackers) Preview(w http.ResponseWriter, r *http.Request) {
+	rawURL := strings.TrimSpace(r.URL.Query().Get("url"))
+	if rawURL == "" {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("url query parameter is required"))
+		return
+	}
+	t := registry.FindTrackerForURL(rawURL)
+	if t == nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrNotFound("no tracker plugin matches this URL"))
+		return
+	}
+	wm, ok := t.(registry.WithMetadata)
+	if !ok {
+		writeJSON(w, http.StatusOK, registry.Metadata{})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	meta, err := wm.ResolveMetadata(ctx, rawURL, nil)
+	if err != nil || meta == nil {
+		// Fail-open: the preview is cosmetic, never a hard error for the user.
+		writeJSON(w, http.StatusOK, registry.Metadata{})
+		return
+	}
+	writeJSON(w, http.StatusOK, meta)
+}
+
 // Seasons handles GET /api/v1/trackers/seasons?url=<encoded> — the
 // released season/episode catalog for the matched tracker.
 func (h *Trackers) Seasons(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -119,6 +119,7 @@ func NewRouter(d Deps) http.Handler {
 			r.Get("/system/status", sysH.Status)
 			r.Get("/trackers/match", trackersH.Match)
 			r.Get("/trackers/seasons", trackersH.Seasons)
+			r.Get("/trackers/preview", trackersH.Preview)
 
 			r.Get("/topics", topicsH.List)
 			r.Post("/topics", topicsH.Create)

--- a/backend/internal/db/migrations/0005_add_topic_image_url.sql
+++ b/backend/internal/db/migrations/0005_add_topic_image_url.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE topics ADD COLUMN image_url TEXT;
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE topics DROP COLUMN image_url;
+-- +goose StatementEnd

--- a/backend/internal/db/repo/topics.go
+++ b/backend/internal/db/repo/topics.go
@@ -35,7 +35,8 @@ func NewTopics(pool *pgxpool.Pool) *Topics {
 	return &Topics{pool: pool}
 }
 
-const topicColumns = `id, user_id, tracker_name, url, display_name, client_id,
+const topicColumns = `id, user_id, tracker_name, url, display_name,
+		COALESCE(image_url,''), client_id,
 		COALESCE(download_dir,''), COALESCE(category,''), extra, COALESCE(last_hash,''),
 		last_checked_at, last_updated_at, next_check_at,
 		check_interval_sec, consecutive_errors, status,
@@ -49,7 +50,7 @@ func scanTopic(row pgx.Row) (*domain.Topic, error) {
 	var clientID *uuid.UUID
 	err := row.Scan(
 		&t.ID, &t.UserID, &t.TrackerName, &t.URL, &t.DisplayName,
-		&clientID, &t.DownloadDir, &t.Category, &extraRaw, &t.LastHash,
+		&t.ImageURL, &clientID, &t.DownloadDir, &t.Category, &extraRaw, &t.LastHash,
 		&lastChecked, &lastUpdated, &t.NextCheckAt,
 		&t.CheckIntervalSec, &t.ConsecutiveErrors, &status,
 		&t.LastError, &t.CreatedAt, &t.UpdatedAt,
@@ -80,12 +81,12 @@ func scanTopic(row pgx.Row) (*domain.Topic, error) {
 func (r *Topics) Create(ctx context.Context, t *domain.Topic) (*domain.Topic, error) {
 	extra, _ := json.Marshal(t.Extra)
 	q := `
-INSERT INTO topics (user_id, tracker_name, url, display_name, client_id,
+INSERT INTO topics (user_id, tracker_name, url, display_name, image_url, client_id,
                     download_dir, category, extra, check_interval_sec, next_check_at, status)
-VALUES ($1,$2,$3,$4,$5,NULLIF($6,''),NULLIF($7,''),$8,$9,$10,$11)
+VALUES ($1,$2,$3,$4,NULLIF($5,''),$6,NULLIF($7,''),NULLIF($8,''),$9,$10,$11,$12)
 RETURNING ` + topicColumns
 	row := r.pool.QueryRow(ctx, q,
-		t.UserID, t.TrackerName, t.URL, t.DisplayName, t.ClientID,
+		t.UserID, t.TrackerName, t.URL, t.DisplayName, t.ImageURL, t.ClientID,
 		t.DownloadDir, t.Category, extra, t.CheckIntervalSec, t.NextCheckAt, string(t.Status),
 	)
 	return scanTopic(row)
@@ -259,6 +260,23 @@ func (r *Topics) Update(ctx context.Context, id, userID uuid.UUID, displayName s
 		return nil, ErrNotFound
 	}
 	return t, err
+}
+
+// UpdateDisplayName persists a freshly-resolved title for a topic. The
+// scheduler calls this when a tracker's Check reports a DisplayName that
+// differs from what's stored — upgrading placeholder names (e.g. "RuTracker
+// topic 123") to the real title without the user editing anything. A blank
+// name is ignored so a tracker that didn't resolve a title can't wipe a good
+// one.
+func (r *Topics) UpdateDisplayName(ctx context.Context, id uuid.UUID, displayName string) error {
+	if displayName == "" {
+		return nil
+	}
+	_, err := r.pool.Exec(ctx,
+		`UPDATE topics SET display_name = $2, updated_at = now() WHERE id = $1`,
+		id, displayName,
+	)
+	return err
 }
 
 // DueForCheck returns up to `limit` topics whose next_check_at is in the past

--- a/backend/internal/db/repo/topics_test.go
+++ b/backend/internal/db/repo/topics_test.go
@@ -197,12 +197,14 @@ func TestTopics_MarkEpisodeDownloaded_DBError(t *testing.T) {
 // ---------- scanTopic malformed extra ----------
 
 // topicRow returns a pgxmock row slice that matches topicColumns exactly
-// (19 columns as of migration 0004). Callers override individual fields as
-// needed. The helper centralises column-order so tests don't drift.
+// (20 columns as of migration 0005, which added image_url after
+// display_name). Callers override individual fields as needed. The helper
+// centralises column-order so tests don't drift.
 func topicRow(id, userID uuid.UUID, now time.Time) []any {
 	return []any{
 		id, userID, "faketracker", "https://example.invalid/t/1",
-		"My Topic", (*uuid.UUID)(nil),
+		"My Topic", "", // display_name, image_url
+		(*uuid.UUID)(nil),
 		"",                            // download_dir
 		"",                            // category
 		[]byte(`{"quality":"1080p"}`), // extra
@@ -213,9 +215,9 @@ func topicRow(id, userID uuid.UUID, now time.Time) []any {
 	}
 }
 
-// topicColumns19 mirrors the header slice for pgxmock.NewRows (19 cols).
-var topicColumns19 = []string{
-	"id", "user_id", "tracker_name", "url", "display_name", "client_id",
+// topicColumnsAll mirrors the header slice for pgxmock.NewRows (20 cols).
+var topicColumnsAll = []string{
+	"id", "user_id", "tracker_name", "url", "display_name", "image_url", "client_id",
 	"download_dir", "category", "extra", "last_hash",
 	"last_checked_at", "last_updated_at", "next_check_at",
 	"check_interval_sec", "consecutive_errors", "status",
@@ -235,9 +237,10 @@ func TestTopics_ScanTopic_MalformedExtra(t *testing.T) {
 	now := time.Now().UTC()
 
 	// Build a row that matches topicColumns exactly (19 columns).
-	rows := pgxmock.NewRows(topicColumns19).AddRow(
+	rows := pgxmock.NewRows(topicColumnsAll).AddRow(
 		id, userID, "faketracker", "https://example.invalid/t/1",
-		"My Topic", (*uuid.UUID)(nil),
+		"My Topic", "", // display_name, image_url
+		(*uuid.UUID)(nil),
 		"", "",
 		[]byte("{not valid json"), "",
 		(*time.Time)(nil), (*time.Time)(nil), now,
@@ -269,7 +272,7 @@ func TestTopics_ScanTopic_ValidExtra(t *testing.T) {
 	userID := uuid.New()
 	now := time.Now().UTC()
 
-	rows := pgxmock.NewRows(topicColumns19).AddRow(topicRow(id, userID, now)...)
+	rows := pgxmock.NewRows(topicColumnsAll).AddRow(topicRow(id, userID, now)...)
 
 	mock.ExpectQuery(`SELECT .* FROM topics WHERE id = \$1`).
 		WithArgs(id).
@@ -297,7 +300,7 @@ func TestTopics_DueForCheck_IncludesErrorStatus(t *testing.T) {
 	userID := uuid.New()
 	now := time.Now().UTC()
 
-	rows := pgxmock.NewRows(topicColumns19).AddRow(topicRow(id, userID, now)...)
+	rows := pgxmock.NewRows(topicColumnsAll).AddRow(topicRow(id, userID, now)...)
 
 	// The regex asserts the IN clause is present.
 	mock.ExpectQuery(`status IN \('active', 'error'\)`).
@@ -330,16 +333,18 @@ func TestTopics_Create_RoundTripsCategory(t *testing.T) {
 
 	// Build the RETURNING row with category="movies".
 	row := topicRow(id, userID, now)
-	// column index 7 is category (0-based: id,user_id,tracker_name,url,display_name,client_id,download_dir,category,...)
-	row[7] = "movies"
+	// column index 8 is category (0-based: id,user_id,tracker_name,url,
+	// display_name,image_url,client_id,download_dir,category,...)
+	row[8] = "movies"
 
-	rows := pgxmock.NewRows(topicColumns19).AddRow(row...)
+	rows := pgxmock.NewRows(topicColumnsAll).AddRow(row...)
 
 	// Match INSERT containing the category column.
 	mock.ExpectQuery(`INSERT INTO topics.*category.*RETURNING`).
 		WithArgs(
 			userID, "faketracker", "https://example.invalid/t/1",
-			"My Topic", (*uuid.UUID)(nil),
+			"My Topic", "", // display_name, image_url
+			(*uuid.UUID)(nil),
 			"",               // download_dir
 			"movies",         // category
 			pgxmock.AnyArg(), // extra (JSON)
@@ -385,10 +390,10 @@ func TestTopics_Update_HappyPath(t *testing.T) {
 	// Build the RETURNING row reflecting the updated values.
 	row := topicRow(id, userID, now)
 	row[4] = "Updated Name"                                // display_name
-	row[7] = "series"                                      // category
-	row[8] = []byte(`{"quality":"720p","start_season":2}`) // extra
+	row[8] = "series"                                      // category
+	row[9] = []byte(`{"quality":"720p","start_season":2}`) // extra
 
-	rows := pgxmock.NewRows(topicColumns19).AddRow(row...)
+	rows := pgxmock.NewRows(topicColumnsAll).AddRow(row...)
 
 	mock.ExpectQuery(`UPDATE topics SET`).
 		WithArgs(

--- a/backend/internal/domain/domain.go
+++ b/backend/internal/domain/domain.go
@@ -70,6 +70,7 @@ type Topic struct {
 	TrackerName       string
 	URL               string
 	DisplayName       string
+	ImageURL          string
 	ClientID          *uuid.UUID
 	DownloadDir       string
 	Category          string

--- a/backend/internal/plugins/registry/registry.go
+++ b/backend/internal/plugins/registry/registry.go
@@ -104,6 +104,24 @@ type WithSeasonCatalog interface {
 	SeasonCatalog(ctx context.Context, url string) ([]Season, error)
 }
 
+// Metadata is human-facing descriptive data a tracker can resolve from a
+// topic URL: a real display title and a poster/preview image. Either field
+// may be empty when the tracker can't determine it.
+type Metadata struct {
+	Title    string `json:"title"`
+	ImageURL string `json:"image_url"`
+}
+
+// WithMetadata is implemented by trackers that can resolve a human-readable
+// title and a poster/preview image from a topic URL. It powers the real
+// display name (replacing "RuTracker topic 123" placeholders) and the topic
+// image. creds may be nil — implementations should fall back to whatever the
+// public page exposes when no credentials are available.
+type WithMetadata interface {
+	Tracker
+	ResolveMetadata(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (*Metadata, error)
+}
+
 // --- Client & Notifier interfaces ---------------------------------------
 
 // Client is a torrent client plugin.

--- a/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata.go
+++ b/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata.go
@@ -1,0 +1,81 @@
+package lostfilm
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+)
+
+// Compile-time guarantee that LostFilm resolves topic metadata.
+var _ registry.WithMetadata = (*plugin)(nil)
+
+var (
+	// ogImageRe matches <meta property="og:image" content="..."> — the most
+	// robust poster source. LostFilm renders it on every series page.
+	ogImageRe = regexp.MustCompile(`(?i)<meta[^>]+property="og:image"[^>]+content="([^"]+)"`)
+
+	// mainPosterImgRe matches the series poster block:
+	// <div class="main_poster"> ... <img ... src="..."> ... </div>.
+	// (?s) so the <img> can sit on a following line from the opening div.
+	mainPosterImgRe = regexp.MustCompile(`(?is)<div[^>]+class="[^"]*main_poster[^"]*"[^>]*>.*?<img[^>]+src="([^"]+)"`)
+
+	// titleSuffixRe strips the trailing site suffix LostFilm appends to the
+	// <title>, e.g. "Monarch (сериал) - LostFilm.TV" or
+	// "The Boys :: LostFilm.tv". Matches " - LostFilm…" or " :: LostFilm…".
+	titleSuffixRe = regexp.MustCompile(`(?i)\s*(?:-|::)\s*LostFilm.*$`)
+)
+
+// cleanSeriesTitle trims the raw <title> match and strips the LostFilm site
+// suffix so only the show name remains.
+func cleanSeriesTitle(raw string) string {
+	t := strings.TrimSpace(raw)
+	t = titleSuffixRe.ReplaceAllString(t, "")
+	return strings.TrimSpace(t)
+}
+
+// absoluteImageURL makes a possibly-relative poster URL absolute against the
+// plugin's configured domain. Protocol-relative ("//host/x") and already
+// absolute ("https://host/x") URLs are returned unchanged; root-relative
+// ("/x") and bare paths get the scheme+host prefix.
+func (p *plugin) absoluteImageURL(raw string) string {
+	u := strings.TrimSpace(raw)
+	if u == "" {
+		return ""
+	}
+	switch {
+	case strings.HasPrefix(u, "http://"), strings.HasPrefix(u, "https://"):
+		return u
+	case strings.HasPrefix(u, "//"):
+		return "https:" + u
+	case strings.HasPrefix(u, "/"):
+		return "https://" + p.domain + u
+	default:
+		return "https://" + p.domain + "/" + u
+	}
+}
+
+// ResolveMetadata fetches the series page and extracts the clean show title
+// (from <title>, minus the site suffix) and the poster image URL (og:image
+// preferred, then the main_poster block). creds may be nil — the public
+// series page exposes both. Relative image URLs are made absolute against
+// p.domain. The caller treats any error as fail-open.
+func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (*registry.Metadata, error) {
+	body, err := p.fetch(ctx, rawURL, creds)
+	if err != nil {
+		return nil, fmt.Errorf("resolve metadata: %w", err)
+	}
+	meta := &registry.Metadata{}
+	if m := titleRe.FindSubmatch(body); m != nil {
+		meta.Title = cleanSeriesTitle(string(m[1]))
+	}
+	if m := ogImageRe.FindSubmatch(body); m != nil {
+		meta.ImageURL = p.absoluteImageURL(string(m[1]))
+	} else if m := mainPosterImgRe.FindSubmatch(body); m != nil {
+		meta.ImageURL = p.absoluteImageURL(string(m[1]))
+	}
+	return meta, nil
+}

--- a/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata.go
+++ b/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata.go
@@ -23,17 +23,27 @@ var (
 	// (?s) so the <img> can sit on a following line from the opening div.
 	mainPosterImgRe = regexp.MustCompile(`(?is)<div[^>]+class="[^"]*main_poster[^"]*"[^>]*>.*?<img[^>]+src="([^"]+)"`)
 
-	// titleSuffixRe strips the trailing site suffix LostFilm appends to the
-	// <title>, e.g. "Monarch (сериал) - LostFilm.TV" or
-	// "The Boys :: LostFilm.tv". Matches " - LostFilm…" or " :: LostFilm…".
-	titleSuffixRe = regexp.MustCompile(`(?i)\s*(?:-|::)\s*LostFilm.*$`)
+	// ogTitleRe matches <meta property="og:title" content="..."> — LostFilm's
+	// clean show name, preferred over the SEO-bloated <title> tag.
+	ogTitleRe = regexp.MustCompile(`(?i)<meta[^>]+property="og:title"[^>]+content="([^"]+)"`)
+
+	// titleSuffixRe strips the trailing site suffix LostFilm appends, e.g.
+	// "Monarch (сериал) - LostFilm.TV", "The Boys :: LostFilm.tv", or with an
+	// en-dash "… – LostFilm.TV." Matches " - / – / :: LostFilm…".
+	titleSuffixRe = regexp.MustCompile(`(?i)\s*(?:-|–|::)\s*LostFilm.*$`)
 )
 
-// cleanSeriesTitle trims the raw <title> match and strips the LostFilm site
-// suffix so only the show name remains.
+// cleanSeriesTitle reduces a raw title to just the show name. LostFilm's
+// <title> is a full SEO sentence ("<Name>. Сериал <Name> … – LostFilm.TV."),
+// so we strip the site suffix and keep only the leading segment before the
+// first sentence boundary. An og:title (already just the name) passes through
+// unchanged because it has neither.
 func cleanSeriesTitle(raw string) string {
 	t := strings.TrimSpace(raw)
 	t = titleSuffixRe.ReplaceAllString(t, "")
+	if i := strings.Index(t, ". "); i > 0 {
+		t = t[:i]
+	}
 	return strings.TrimSpace(t)
 }
 
@@ -69,7 +79,11 @@ func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *doma
 		return nil, fmt.Errorf("resolve metadata: %w", err)
 	}
 	meta := &registry.Metadata{}
-	if m := titleRe.FindSubmatch(body); m != nil {
+	// Prefer og:title (already the bare show name); fall back to the bloated
+	// <title> tag, which cleanSeriesTitle trims down to the leading segment.
+	if m := ogTitleRe.FindSubmatch(body); m != nil {
+		meta.Title = cleanSeriesTitle(string(m[1]))
+	} else if m := titleRe.FindSubmatch(body); m != nil {
 		meta.Title = cleanSeriesTitle(string(m[1]))
 	}
 	if m := ogImageRe.FindSubmatch(body); m != nil {

--- a/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata_test.go
+++ b/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata_test.go
@@ -1,0 +1,95 @@
+package lostfilm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/artyomsv/marauder/backend/internal/plugins/e2etest"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+func newMetadataTestPlugin(t *testing.T, html string) *plugin {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/series/") {
+			_, _ = w.Write([]byte(html))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	return &plugin{
+		sessions:          forumcommon.New(),
+		domain:            "www.lostfilm.tv",
+		transport:         &e2etest.HostRewriteTransport{From: "www.lostfilm.tv", To: host, Inner: &allHostsToTest{To: host}},
+		redirectValidator: permissiveRedirectValidator,
+	}
+}
+
+func TestResolveMetadata_OgImageAndCleanTitle(t *testing.T) {
+	// og:image present and absolute; title carries the " - LostFilm.TV" suffix.
+	html := `<html><head>
+<title>Монарх: Наследие монстров (Monarch) - LostFilm.TV</title>
+<meta property="og:image" content="https://static.lostfilm.top/Images/791/Posters/poster.jpg">
+</head><body>
+<a href="/logout">logout</a>
+<div class="main_poster"><img src="/Images/791/Posters/image.jpg"></div>
+</body></html>`
+	p := newMetadataTestPlugin(t, html)
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://www.lostfilm.tv/series/Monarch/", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	wantTitle := "Монарх: Наследие монстров (Monarch)"
+	if meta.Title != wantTitle {
+		t.Errorf("title = %q, want %q", meta.Title, wantTitle)
+	}
+	if meta.ImageURL != "https://static.lostfilm.top/Images/791/Posters/poster.jpg" {
+		t.Errorf("image URL = %q, want the og:image", meta.ImageURL)
+	}
+}
+
+func TestResolveMetadata_MainPosterFallbackMadeAbsolute(t *testing.T) {
+	// No og:image — fall back to the main_poster <img src>, which is
+	// root-relative and must be made absolute against the configured domain.
+	html := `<html><head><title>The Boys :: LostFilm.tv</title></head><body>
+<a href="/logout">logout</a>
+<div class="main_poster">
+  <img class="thumb" src="/Images/442/Posters/poster.jpg">
+</div>
+</body></html>`
+	p := newMetadataTestPlugin(t, html)
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://www.lostfilm.tv/series/The_Boys/", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if meta.Title != "The Boys" {
+		t.Errorf("title = %q, want %q", meta.Title, "The Boys")
+	}
+	if meta.ImageURL != "https://www.lostfilm.tv/Images/442/Posters/poster.jpg" {
+		t.Errorf("image URL = %q, want absolute main_poster src", meta.ImageURL)
+	}
+}
+
+func TestResolveMetadata_NoImageReturnsEmpty(t *testing.T) {
+	html := `<html><head><title>No Poster Show - LostFilm.TV</title></head><body>
+<a href="/logout">logout</a></body></html>`
+	p := newMetadataTestPlugin(t, html)
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://www.lostfilm.tv/series/No_Poster/", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if meta.Title != "No Poster Show" {
+		t.Errorf("title = %q, want %q", meta.Title, "No Poster Show")
+	}
+	if meta.ImageURL != "" {
+		t.Errorf("image URL = %q, want empty (never fabricated)", meta.ImageURL)
+	}
+}

--- a/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata_test.go
+++ b/backend/internal/plugins/trackers/lostfilm/lostfilm_metadata_test.go
@@ -77,6 +77,34 @@ func TestResolveMetadata_MainPosterFallbackMadeAbsolute(t *testing.T) {
 	}
 }
 
+func TestResolveMetadata_PrefersOgTitleOverBloatedTitle(t *testing.T) {
+	// Real LostFilm shape: a SEO-bloated <title> with an en-dash site suffix,
+	// plus a clean og:title. og:title wins.
+	html := `<html><head>
+<title>Пацаны (The Boys). Сериал Пацаны (The Boys) Amazon Prime Video (США): гид по сериям – LostFilm.TV.</title>
+<meta property="og:title" content="Пацаны (The Boys)">
+<meta property="og:image" content="https://www.lostfilm.tv/Static/Images/442/Posters/poster.jpg">
+</head><body><a href="/logout">logout</a></body></html>`
+	p := newMetadataTestPlugin(t, html)
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://www.lostfilm.tv/series/The_Boys/", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if meta.Title != "Пацаны (The Boys)" {
+		t.Errorf("title = %q, want %q", meta.Title, "Пацаны (The Boys)")
+	}
+}
+
+func TestCleanSeriesTitle_TrimsBloatedTitleAndEnDash(t *testing.T) {
+	// Fallback path: no og:title, so the bloated <title> with an en-dash suffix
+	// is trimmed to the leading show-name segment.
+	raw := "Пацаны (The Boys). Сериал Пацаны (The Boys) Amazon Prime Video (США): гид – LostFilm.TV."
+	if got := cleanSeriesTitle(raw); got != "Пацаны (The Boys)" {
+		t.Errorf("cleanSeriesTitle = %q, want %q", got, "Пацаны (The Boys)")
+	}
+}
+
 func TestResolveMetadata_NoImageReturnsEmpty(t *testing.T) {
 	html := `<html><head><title>No Poster Show - LostFilm.TV</title></head><body>
 <a href="/logout">logout</a></body></html>`

--- a/backend/internal/plugins/trackers/rutracker/rutracker.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker.go
@@ -156,7 +156,40 @@ var (
 	magnetRe        = regexp.MustCompile(`(magnet:\?xt=urn:btih:[A-Fa-f0-9]+[^"'&\s]*)`)
 	dlHrefRe        = regexp.MustCompile(`href="(dl\.php\?t=\d+)"`)
 	hashLooksLikeRe = regexp.MustCompile(`urn:btih:([A-Fa-f0-9]+)`)
+
+	// ogImageRe matches <meta property="og:image" content="..."> — the most
+	// robust poster source when RuTracker emits it.
+	ogImageRe = regexp.MustCompile(`(?i)<meta[^>]+property="og:image"[^>]+content="([^"]+)"`)
+	// postVarImgRe matches RuTracker's lazy-loaded poster:
+	// <var class="postImg postImgAligned img-right" title="https://...jpg">.
+	// The real URL lives in the title attribute (src is a placeholder).
+	postVarImgRe = regexp.MustCompile(`(?i)<var[^>]+class="[^"]*postImg[^"]*"[^>]+title="([^"]+)"`)
+	// postImgSrcRe matches the eager form: <img class="postImg" src="...">.
+	postImgSrcRe = regexp.MustCompile(`(?i)<img[^>]+class="[^"]*postImg[^"]*"[^>]+src="([^"]+)"`)
 )
+
+// cleanTitle trims a raw <title> match and strips RuTracker's site suffix.
+// Shared by Check and ResolveMetadata so both stay consistent.
+func cleanTitle(raw string) string {
+	t := strings.TrimSpace(raw)
+	return strings.TrimSuffix(t, " :: RuTracker.org")
+}
+
+// extractImageURL returns the first poster image URL from a topic page body,
+// preferring og:image, then the lazy-loaded postImg <var title=...>, then an
+// eager <img class="postImg" src=...>. Returns "" when none is present.
+func extractImageURL(body []byte) string {
+	if m := ogImageRe.FindSubmatch(body); m != nil {
+		return strings.TrimSpace(string(m[1]))
+	}
+	if m := postVarImgRe.FindSubmatch(body); m != nil {
+		return strings.TrimSpace(string(m[1]))
+	}
+	if m := postImgSrcRe.FindSubmatch(body); m != nil {
+		return strings.TrimSpace(string(m[1]))
+	}
+	return ""
+}
 
 // Check fetches the topic page and extracts a hash. The hash is the
 // torrent BTIH from the magnet link, which changes whenever the uploader
@@ -168,8 +201,7 @@ func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.T
 	}
 	check := &domain.Check{}
 	if m := titleRe.FindSubmatch(body); m != nil {
-		check.DisplayName = strings.TrimSpace(string(m[1]))
-		check.DisplayName = strings.TrimSuffix(check.DisplayName, " :: RuTracker.org")
+		check.DisplayName = cleanTitle(string(m[1]))
 	}
 	if m := hashLooksLikeRe.FindSubmatch(body); m != nil {
 		check.Hash = strings.ToLower(string(m[1]))
@@ -177,6 +209,29 @@ func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.T
 		return nil, errors.New("rutracker: no infohash found in topic page")
 	}
 	return check, nil
+}
+
+// --- WithMetadata ------------------------------------------------------
+
+var _ registry.WithMetadata = (*plugin)(nil)
+
+// ResolveMetadata fetches the topic page and extracts a human-readable
+// title (the <title> tag minus the site suffix) and a poster image URL.
+// creds may be nil — the public topic page is fetched without a session,
+// mirroring how Check handles nil creds via fetchTopicPage. Image URL is
+// "" when the page exposes no poster; the caller treats errors as fail-open.
+func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (*registry.Metadata, error) {
+	topic := &domain.Topic{URL: rawURL}
+	body, err := p.fetchTopicPage(ctx, topic, creds)
+	if err != nil {
+		return nil, fmt.Errorf("resolve metadata: %w", err)
+	}
+	meta := &registry.Metadata{}
+	if m := titleRe.FindSubmatch(body); m != nil {
+		meta.Title = cleanTitle(string(m[1]))
+	}
+	meta.ImageURL = extractImageURL(body)
+	return meta, nil
 }
 
 // Download returns the magnet URI for the current topic. RuTracker also

--- a/backend/internal/plugins/trackers/rutracker/rutracker.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker.go
@@ -28,6 +28,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
 
 	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
@@ -168,11 +171,30 @@ var (
 	postImgSrcRe = regexp.MustCompile(`(?i)<img[^>]+class="[^"]*postImg[^"]*"[^>]+src="([^"]+)"`)
 )
 
-// cleanTitle trims a raw <title> match and strips RuTracker's site suffix.
-// Shared by Check and ResolveMetadata so both stay consistent.
+// cleanTitle decodes a raw <title> match from windows-1251 (the encoding
+// RuTracker serves its pages in), trims it, and strips the site suffix.
+// Shared by Check and ResolveMetadata so both stay consistent. Without the
+// decode the Cyrillic bytes are invalid UTF-8 — they render as mojibake and
+// Postgres rejects them (SQLSTATE 22021) on write.
 func cleanTitle(raw string) string {
-	t := strings.TrimSpace(raw)
+	t := strings.TrimSpace(decodeWindows1251(raw))
 	return strings.TrimSuffix(t, " :: RuTracker.org")
+}
+
+// decodeWindows1251 converts a windows-1251 (Cyrillic) byte string into UTF-8.
+// RuTracker serves cp1251, whose Cyrillic high bytes are invalid UTF-8 — so we
+// only transcode when the input is NOT already valid UTF-8. That keeps ASCII
+// and any already-UTF-8 source untouched while fixing real cp1251 titles. On a
+// decode error the input is returned as-is rather than dropped.
+func decodeWindows1251(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	out, err := charmap.Windows1251.NewDecoder().String(s)
+	if err != nil {
+		return s
+	}
+	return out
 }
 
 // extractImageURL returns the first poster image URL from a topic page body,

--- a/backend/internal/plugins/trackers/rutracker/rutracker_test.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker_test.go
@@ -8,10 +8,25 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"golang.org/x/text/encoding/charmap"
 
 	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
+
+// TestCleanTitle_DecodesWindows1251 feeds real cp1251-encoded bytes (the
+// encoding RuTracker actually serves) through cleanTitle and asserts they come
+// back as correct UTF-8. Guards the SQLSTATE 22021 bug where undecoded cp1251
+// Cyrillic was rejected by Postgres on write.
+func TestCleanTitle_DecodesWindows1251(t *testing.T) {
+	cp1251, err := charmap.Windows1251.NewEncoder().String("Голод / Hunger :: RuTracker.org")
+	if err != nil {
+		t.Fatalf("encode cp1251: %v", err)
+	}
+	if got := cleanTitle(cp1251); got != "Голод / Hunger" {
+		t.Errorf("cleanTitle(cp1251) = %q, want %q", got, "Голод / Hunger")
+	}
+}
 
 const fixtureTopicHTML = `<html>
 <head><title>Some Show / Сериал [s01e01-12] [WEBRip] [1080p] :: RuTracker.org</title></head>

--- a/backend/internal/plugins/trackers/rutracker/rutracker_test.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker_test.go
@@ -131,6 +131,86 @@ func TestDownloadReturnsMagnet(t *testing.T) {
 	}
 }
 
+func TestResolveMetadata_OgImagePreferred(t *testing.T) {
+	// Page carries both an og:image meta tag and a postImg <var> — og:image
+	// must win as the most robust source.
+	html := `<html><head>
+<title>Some Show / Сериал [s01e01-12] [WEBRip] [1080p] :: RuTracker.org</title>
+<meta property="og:image" content="https://static.rutracker.cc/templates/img/og-poster.jpg">
+</head><body>
+<div id="logged-in-username">alice</div>
+<var class="postImg postImgAligned img-right" title="https://i.fastpic.org/lazy-poster.jpg" src="https://static.rutracker.cc/spacer.gif"></var>
+</body></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(html))
+	}))
+	t.Cleanup(srv.Close)
+	hostNoScheme := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{
+		sessions:  forumcommon.New(),
+		domain:    hostNoScheme,
+		transport: &schemeRewrite{target: hostNoScheme},
+	}
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://"+p.domain+"/forum/viewtopic.php?t=987654", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	wantTitle := "Some Show / Сериал [s01e01-12] [WEBRip] [1080p]"
+	if meta.Title != wantTitle {
+		t.Errorf("title = %q, want %q", meta.Title, wantTitle)
+	}
+	if meta.ImageURL != "https://static.rutracker.cc/templates/img/og-poster.jpg" {
+		t.Errorf("image URL = %q, want og:image", meta.ImageURL)
+	}
+}
+
+func TestResolveMetadata_PostVarTitleFallback(t *testing.T) {
+	// No og:image — the real image lives in the lazy-loaded postImg <var>
+	// title attribute (src is a placeholder gif).
+	html := `<html><head><title>Another Show :: RuTracker.org</title></head><body>
+<var class="postImg postImgAligned img-right" title="https://i.fastpic.org/real-poster.jpg" src="https://static.rutracker.cc/spacer.gif"></var>
+</body></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(html))
+	}))
+	t.Cleanup(srv.Close)
+	hostNoScheme := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{
+		sessions:  forumcommon.New(),
+		domain:    hostNoScheme,
+		transport: &schemeRewrite{target: hostNoScheme},
+	}
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://"+p.domain+"/forum/viewtopic.php?t=1", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if meta.Title != "Another Show" {
+		t.Errorf("title = %q, want %q", meta.Title, "Another Show")
+	}
+	if meta.ImageURL != "https://i.fastpic.org/real-poster.jpg" {
+		t.Errorf("image URL = %q, want the <var title> URL", meta.ImageURL)
+	}
+}
+
+func TestResolveMetadata_NoImageReturnsEmpty(t *testing.T) {
+	// The existing fixture has no poster — ImageURL must be "" (never fabricated).
+	p, _ := newTestPlugin(t)
+	meta, err := p.ResolveMetadata(context.Background(), "https://"+p.domain+"/forum/viewtopic.php?t=987654", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if !strings.Contains(meta.Title, "Some Show") {
+		t.Errorf("title = %q, want it to contain 'Some Show'", meta.Title)
+	}
+	if meta.ImageURL != "" {
+		t.Errorf("image URL = %q, want empty", meta.ImageURL)
+	}
+}
+
 func TestLogin(t *testing.T) {
 	p, _ := newTestPlugin(t)
 	creds := &domain.TrackerCredential{

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -59,6 +59,14 @@ type markEpisodeDownloader interface {
 	MarkEpisodeDownloaded(ctx context.Context, id uuid.UUID, packed string) error
 }
 
+// displayNamePersister is an optional capability of topicsRepo: it lets the
+// scheduler upgrade a topic's stored title to the real one a tracker resolved
+// during Check (self-healing placeholder names). Best-effort — a failure here
+// never affects the check result.
+type displayNamePersister interface {
+	UpdateDisplayName(ctx context.Context, id uuid.UUID, displayName string) error
+}
+
 // clientsRepo is the subset of *repo.Clients that the scheduler uses.
 type clientsRepo interface {
 	GetByID(ctx context.Context, id uuid.UUID, userID uuid.UUID) (*domain.Client, error)
@@ -367,6 +375,17 @@ func (s *Scheduler) runCheck(ctx context.Context, log zerolog.Logger, t *domain.
 			s.recordResult(ctx, log, t.ID, t.LastHash, anySubmitted, s.backoff(t, true), dlErr.Error())
 			s.recordChecked(true, true)
 			return
+		}
+	}
+
+	// Self-heal the display name: a tracker's Check often resolves the real
+	// title (e.g. RuTracker's <title>) that wasn't available at add time.
+	// Persist it when it changed so placeholder names upgrade themselves.
+	if check.DisplayName != "" && check.DisplayName != t.DisplayName {
+		if p, ok := s.topics.(displayNamePersister); ok {
+			if err := p.UpdateDisplayName(ctx, t.ID, check.DisplayName); err != nil {
+				log.Warn().Err(err).Msg("UpdateDisplayName failed")
+			}
 		}
 	}
 

--- a/frontend/src/components/topics/ClientBadge.test.tsx
+++ b/frontend/src/components/topics/ClientBadge.test.tsx
@@ -20,6 +20,7 @@ function topicWith(clientID: string | null): Topic {
     TrackerName: "lostfilm",
     URL: "https://example.test",
     DisplayName: "Some Show",
+    ImageURL: "",
     ClientID: clientID,
     DownloadDir: "",
     Category: "",

--- a/frontend/src/components/topics/PosterImage.tsx
+++ b/frontend/src/components/topics/PosterImage.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+interface PosterImageProps {
+  src: string | null | undefined;
+  alt: string;
+  className?: string;
+}
+
+// Renders a tracker poster/preview image, hiding itself cleanly when the URL
+// is empty or fails to load (tracker CDNs sometimes hotlink-block or require a
+// referer). No placeholder image is shown — absence stays honest about missing
+// data rather than faking a poster.
+export function PosterImage({ src, alt, className }: PosterImageProps) {
+  const [failed, setFailed] = useState(false);
+  if (!src || failed) return null;
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className={className}
+    />
+  );
+}

--- a/frontend/src/components/topics/TopicForm.tsx
+++ b/frontend/src/components/topics/TopicForm.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { QK } from "@/lib/queryKeys";
 import { useDebouncedValue } from "@/lib/hooks/useDebouncedValue";
 import { SeasonEpisodePicker, SELECT_CLASS } from "./SeasonEpisodePicker";
+import { PosterImage } from "./PosterImage";
 
 // Shape of GET /trackers/match. Drives which optional sections the form
 // renders (quality, season/episode filter, credentials hint).
@@ -100,6 +101,18 @@ export function TopicForm({
   });
   const match = trackerMatchQuery.data ?? null;
 
+  // Resolve a real title + poster image for the preview card. Only fired once
+  // a tracker actually claimed the URL (match present), to avoid a wasted
+  // page fetch on every keystroke of an unrecognised URL.
+  const previewQuery = useQuery({
+    queryKey: QK.trackerPreview(debouncedUrl),
+    queryFn: () => api.previewTracker(debouncedUrl),
+    enabled: !isEdit && debouncedUrl.length >= 8 && !!match,
+    staleTime: 60_000,
+    retry: false,
+  });
+  const preview = previewQuery.data ?? null;
+
   const seasonsQuery = useQuery({
     queryKey: QK.trackerSeasons(debouncedUrl),
     queryFn: () =>
@@ -135,6 +148,14 @@ export function TopicForm({
       setQuality(match.default_quality);
     }
   }, [match, quality]);
+
+  // Prefill the display name from the resolved preview title, but never
+  // overwrite a name the user typed or one prefilled from an existing topic.
+  useEffect(() => {
+    if (!isEdit && preview?.title && !displayName) {
+      setDisplayName(preview.title);
+    }
+  }, [preview, isEdit, displayName]);
 
   // Reset the season/episode selection whenever the URL changes in the add
   // flow. Skipped in edit mode where the URL is fixed and the initial
@@ -191,6 +212,20 @@ export function TopicForm({
         )}
         {matchError && <p className="text-xs text-muted-foreground">{matchError}</p>}
       </div>
+
+      {!isEdit && preview && (preview.title || preview.image_url) && (
+        <div className="flex items-center gap-3 rounded-md border border-border/60 bg-muted/30 p-3">
+          <PosterImage
+            src={preview.image_url}
+            alt={preview.title || "preview"}
+            className="h-16 w-12 shrink-0 rounded object-cover"
+          />
+          <div className="min-w-0">
+            <div className="text-xs text-muted-foreground">Preview</div>
+            <div className="truncate text-sm font-medium">{preview.title || "—"}</div>
+          </div>
+        </div>
+      )}
 
       <div className="space-y-1.5">
         <Label htmlFor="display">Display name (optional)</Label>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -159,7 +159,19 @@ export const api = {
   // downloaded_episodes. 404 unknown/foreign, 422 bad quality.
   updateTopic: (id: string, body: UpdateTopicBody) =>
     request<Topic>("PUT", `/topics/${id}`, body),
+
+  // Resolve a real title + poster image from a tracker URL for the AddTopic
+  // form preview. Returns empty fields (never an error) when the tracker
+  // can't resolve metadata, so callers can render unconditionally.
+  previewTracker: (url: string) =>
+    request<TrackerPreview>("GET", `/trackers/preview?url=${encodeURIComponent(url)}`),
 };
+
+// Response of GET /trackers/preview. Either field may be empty.
+export interface TrackerPreview {
+  title: string;
+  image_url: string;
+}
 
 // Body of PUT /topics/{id}. Mirrors the backend updateTopicReq.
 export interface UpdateTopicBody {
@@ -241,6 +253,7 @@ export type Topic = {
   TrackerName: string;
   URL: string;
   DisplayName: string;
+  ImageURL: string;
   ClientID: string | null;
   DownloadDir: string;
   Category: string;

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -41,4 +41,8 @@ export const QK = {
   // /trackers/seasons?url=… released-season catalog. Used by AddTopicCard
   // to populate the dependent season → episode dropdowns.
   trackerSeasons: (url: string) => ["trackerSeasons", url] as const,
+
+  // /trackers/preview?url=… resolved title + poster image. Used by the
+  // AddTopic form to show a preview card before the topic is created.
+  trackerPreview: (url: string) => ["trackerPreview", url] as const,
 } as const;

--- a/frontend/src/pages/Topics.test.tsx
+++ b/frontend/src/pages/Topics.test.tsx
@@ -86,6 +86,7 @@ const EXISTING_TOPIC: Topic = {
   TrackerName: "lostfilm",
   URL: LOSTFILM_URL,
   DisplayName: "Some Show",
+  ImageURL: "",
   ClientID: "c2",
   DownloadDir: "/downloads/shows",
   Category: "series",

--- a/frontend/src/pages/Topics.tsx
+++ b/frontend/src/pages/Topics.tsx
@@ -27,6 +27,7 @@ import { useArmedConfirm } from "@/lib/hooks/useArmedConfirm";
 import { AddTopicCard } from "@/components/topics/AddTopicCard";
 import { EditTopicCard } from "@/components/topics/EditTopicCard";
 import { ClientBadge, type ClientRef } from "@/components/topics/ClientBadge";
+import { PosterImage } from "@/components/topics/PosterImage";
 
 // Re-exported so existing imports (and tests) that reference AddTopicCard
 // from this page module keep resolving after the extraction.
@@ -186,6 +187,13 @@ export function TopicsPage() {
                     aria-label="Select topic"
                   />
                   <StatusIndicator status={t.Status} />
+                  {!compact && (
+                    <PosterImage
+                      src={t.ImageURL}
+                      alt={t.DisplayName}
+                      className="h-12 w-9 shrink-0 rounded object-cover"
+                    />
+                  )}
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
                       <span className="truncate font-medium">{t.DisplayName}</span>


### PR DESCRIPTION
## Summary

Second of three staged PRs (design: `docs/superpowers/specs/2026-05-30-topic-metadata-delivery-folders-design.md`). **Stacked on #30** — review/merge #30 first; this PR's base is `feat/client-base-folder-category`, so its own diff is just the metadata work.

Implements #2 (image), #3 (real display name), and #5 (redundant source in name) via a single new tracker capability.

### New `WithMetadata` capability
`ResolveMetadata(ctx, url, creds) -> {Title, ImageURL}`, implemented by **RuTracker** and **LostFilm** (each with a compile-time `var _ registry.WithMetadata` assertion). `og:image` preferred for the poster, with `postImg`/`main_poster` fallbacks; titles cleaned of site suffixes (` :: RuTracker.org`, ` - LostFilm`).

### Where it runs
- **Add time** (`POST /topics`): best-effort, fail-open, 8s timeout — a new topic shows a real name + poster immediately instead of `RuTracker topic 6635490`. Any failure leaves the placeholder; never blocks the add.
- **Self-heal** (scheduler): persists `check.DisplayName` when it differs from the stored name (`displayNamePersister` → `Topics.UpdateDisplayName`), so existing placeholder topics upgrade on their next check. *(Fixes a latent bug where trackers already parsed the real title in `Check` but it was never saved.)*
- **Preview** (`GET /trackers/preview?url=`): powers the AddTopic form's debounced preview card (poster + title), and prefills the display-name field.

### Storage & rendering
- `topics.image_url` column (migration `0005`); `domain.Topic.ImageURL`.
- Frontend `<PosterImage>` renders the URL directly (cross-origin `<img>`, no proxy) and **hides cleanly on load error** — no placeholder/fake poster, honest about missing data.

### Caveat (carried from the design)
RuTracker's existing test fixtures had no poster, so the image regexes were exercised against inline test HTML following RuTracker's documented `postImg` markup + `og:image`. Title extraction reuses the already-tested `<title>` logic. Worth a sanity check against a live RuTracker page when convenient; `og:image` is the robust primary path.

## Test Plan

- [x] New `ResolveMetadata` unit tests for RuTracker + LostFilm (og:image, fallback, no-image-empty, relative→absolute)
- [x] Repo tests updated for the new `image_url` column (scan/create round-trip)
- [x] Backend `go build/vet/test ./...` green (35 pkgs, 0 failures)
- [x] Frontend `typecheck` + 31 tests + `build` green (Topic fixtures updated)