### PR TITLE
fix(qbittorrent): handle 5.2.x 204 login + add client canary (#38)

### DIFF
--- a/.github/workflows/client-acceptance.yml
+++ b/.github/workflows/client-acceptance.yml
@@ -33,3 +33,51 @@ jobs:
         uses: actions/checkout@v6
       - name: Acceptance (pinned baseline)
         run: bash deploy/acceptance/acceptance.sh ${{ matrix.client }} pinned
+
+  latest:
+    name: latest-canary / ${{ matrix.client }}
+    # Canary only — never gate releases, so skip on tag pushes.
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        client: [qbittorrent, transmission, deluge]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Acceptance (latest image)
+        id: acc
+        continue-on-error: true
+        run: bash deploy/acceptance/acceptance.sh ${{ matrix.client }} latest
+      - name: File deduped canary issue on failure
+        if: steps.acc.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLIENT: ${{ matrix.client }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create client-canary --color FBCA04 \
+            --description "An upstream client latest release broke acceptance" \
+            2>/dev/null || true
+          TITLE="[client-canary] ${CLIENT} latest acceptance failing"
+          NUM=$(gh issue list --label client-canary --state open \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" | head -1)
+          if [ -n "${NUM}" ]; then
+            gh issue comment "${NUM}" \
+              --body "Still failing on the latest image. Run: ${RUN_URL}"
+          else
+            gh issue create --title "${TITLE}" --label client-canary --body \
+          "The acceptance test for \`${CLIENT}\` against its **latest** image failed while the pinned baseline is expected green. A new upstream release likely changed the client's API contract. Investigate and, if confirmed, adapt the plugin and bump the pinned baseline. Run: ${RUN_URL}"
+          fi
+      - name: Surface canary failure as a red (non-blocking) check
+        if: steps.acc.outcome == 'failure'
+        run: |
+          echo "::warning::${{ matrix.client }} latest canary failed — issue filed"
+          exit 1

--- a/.github/workflows/client-acceptance.yml
+++ b/.github/workflows/client-acceptance.yml
@@ -1,0 +1,35 @@
+name: Client acceptance (pinned + latest canary)
+
+# Broad, shallow matrix: every supported client is created through the
+# Marauder API against a REAL container, on a pinned baseline and (nightly)
+# on the client's latest image. Complements the deep qBittorrent pipeline in
+# e2e.yml. Not run per-PR — too slow; PRs rely on unit tests.
+
+on:
+  schedule:
+    - cron: '0 5 * * *'   # 05:00 UTC nightly (after e2e at 04:00)
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+concurrency:
+  group: client-acceptance-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pinned:
+    name: pinned / ${{ matrix.client }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        client: [qbittorrent, transmission, deluge, utorrent]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Acceptance (pinned baseline)
+        run: bash deploy/acceptance/acceptance.sh ${{ matrix.client }} pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   base stack so the backend reaches each client by Docker service DNS. All
   five client plugins were verified end-to-end against their real containers
   via the Marauder API (create-client → plugin `Test()` login/connect).
+- Client acceptance CI (`.github/workflows/client-acceptance.yml` +
+  `deploy/acceptance/acceptance.sh`): nightly matrix that creates every
+  supported client through the Marauder API against a real container, on a
+  pinned baseline (blocking, also runs on tags to gate releases) and on each
+  client's latest image (non-blocking canary that auto-files a deduped issue
+  when an upstream release breaks a client — the early warning that issue #38
+  lacked).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `deploy/docker-compose.test-clients.yml`: a client-only integration test
+  matrix that spins up every supported download client across versions —
+  qBittorrent `5.2.1` and `5.1.4`, Transmission `4.1.2` and `4.0.6`, Deluge
+  `2.2.0`, and a profile-gated µTorrent `v2.1.0` — each with a healthcheck and
+  a pinned image tag, host ports bound to `127.0.0.1` in the 34xxx range. It
+  composes standalone (poke clients on their host ports) or layered onto the
+  base stack so the backend reaches each client by Docker service DNS. All
+  five client plugins were verified end-to-end against their real containers
+  via the Marauder API (create-client → plugin `Test()` login/connect).
+
+### Fixed
+
+- qBittorrent client setup failing against qBittorrent 5.2.x with
+  `client test failed: login failed: status=204 body=""` (#38). qBittorrent
+  5.2.0 changed the WebUI `/api/v2/auth/login` success response from
+  `200 "Ok."` to `204 No Content`; the plugin previously accepted only the
+  legacy form and rejected valid logins. Login success is now decided by a
+  `loginSucceeded` helper that accepts both contracts while still rejecting
+  failures — including a `204` carrying an unexpected body. Verified
+  empirically against linuxserver/qbittorrent `5.1.4` (200 `Ok.`) and `5.2.1`
+  (204, empty).
+
 ## [1.0.1] - 2026-06-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,15 @@ were verified end-to-end against these real containers via the Marauder API
 (create-client → plugin `Test()`). The non-networked `downloadfolder` client
 is not part of this matrix.
 
+`.github/workflows/client-acceptance.yml` drives `deploy/acceptance/acceptance.sh
+<client> <pinned|latest>` as a nightly matrix (also on tag push for the pinned
+baseline). The runner brings up the base stack plus one client under the
+isolated `marauder-acceptance` Compose project (so it never touches a running
+`deploy` dev stack or `deploy/.env`) and asserts `POST /api/v1/clients`
+succeeds — i.e. the plugin `Test()` passed. The `latest` channel overrides the
+client image tag via `MARAUDER_TEST_*_TAG=latest`; on failure the workflow files
+a deduped `client-canary` GitHub issue.
+
 ## Ports (per `~/.claude/rules/local-port-ranges.md` — host ports must be 30000-49999)
 
 Host-facing ports — all in the 34xxx range, overrideable via env vars:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ backend/        Go services (main backend + cfsolver sidecar)
 frontend/       React 19.2 + Vite + Tailwind 4 + shadcn admin UI
 cfsolver/       Standalone Go service: chromedp-based Cloudflare solver
 deploy/         docker-compose stacks (source-build base + prebuilt-image
-                ghcr stack + dev + sso overlays)
+                ghcr stack + dev + sso overlays + test-clients matrix)
 docs/           ROADMAP, PRD, VISION, COMPETITORS, per-feature guides
 site/           Astro 5 marketing site published to marauder.cc
 techdebt/       Debt-tracking files (one per issue, see global rule)
@@ -186,6 +186,10 @@ docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dev.yml up 
 
 # Run prebuilt GHCR images (no clone/build; pin tag via MARAUDER_VERSION in .env)
 docker compose -f deploy/docker-compose.ghcr.yml --env-file deploy/.env up -d
+
+# Torrent-client test matrix (multi-version qBit + transmission/deluge/µTorrent)
+# Standalone (host ports); or stack on base so the backend reaches clients by DNS.
+docker compose -f deploy/docker-compose.test-clients.yml up -d
 ```
 
 `deploy/docker-compose.ghcr.yml` is the end-user "pull prebuilt" stack:
@@ -195,6 +199,23 @@ ships the gateway nginx config **inline** via Compose top-level `configs:`
 The inline block is a copy of `deploy/nginx/gateway.conf` with nginx's `$`
 escaped as `$$`; **keep the two in sync**. The source-build `docker-compose.yml`
 (+ dev/sso overlays) is unchanged and still bind-mounts `gateway.conf`.
+
+`deploy/docker-compose.test-clients.yml` is a **client-only** matrix (no
+db/backend/frontend) for exercising the client plugins against real clients
+across versions — born out of issue #38 (qBittorrent 5.2.x switched login from
+`200 "Ok."` to `204 No Content`). It ships two qBittorrent versions
+(`5.2.1`→204, `5.1.4`→200), two Transmission (`4.1.2`/`4.0.6`), Deluge `2.2.0`,
+and a profile-gated legacy µTorrent (`ekho/utorrent:v2.1.0`, amd64-only, opt-in
+via `--profile utorrent`). Every service has a `curl`-based healthcheck (so
+`up -d --wait` gates on real readiness); host ports bind to `127.0.0.1` in the
+34xxx range (34621/34622 qbit, 34121/34122 transmission, 34112 deluge, 34608
+µTorrent); image tags are all pinned and registry-verified — no `latest`.
+Distinct service names let it compose either standalone or layered onto the
+base stack for service-DNS access. All four networked client plugins
+(qBittorrent, Transmission, Deluge, and µTorrent — default creds `admin`/empty)
+were verified end-to-end against these real containers via the Marauder API
+(create-client → plugin `Test()`). The non-networked `downloadfolder` client
+is not part of this matrix.
 
 ## Ports (per `~/.claude/rules/local-port-ranges.md` — host ports must be 30000-49999)
 

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
@@ -90,7 +90,7 @@ func (p *plugin) Test(ctx context.Context, rawConfig []byte) error {
 		return fmt.Errorf("ping qbit: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %d from version endpoint", resp.StatusCode)
 	}
 	return nil
@@ -141,7 +141,7 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 		return fmt.Errorf("add torrent: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(b))
 	}
@@ -180,7 +180,7 @@ func (p *plugin) Status(ctx context.Context, rawConfig []byte, hashes []string) 
 		return nil, fmt.Errorf("qbit status: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("qbit status %d: %s", resp.StatusCode, string(b))
 	}
@@ -253,13 +253,32 @@ func (p *plugin) session(ctx context.Context, cfg Config) (*session, error) {
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != 200 || !strings.EqualFold(strings.TrimSpace(string(body)), "ok.") {
+	if !loginSucceeded(resp.StatusCode, body) {
 		return nil, fmt.Errorf("login failed: status=%d body=%q", resp.StatusCode, string(body))
 	}
 	s.loggedIn = true
 	s.expiresAt = time.Now().Add(10 * time.Minute)
 	p.sessions[cfg.URL] = s
 	return s, nil
+}
+
+// loginSucceeded reports whether a /api/v2/auth/login response indicates a
+// successful authentication. qBittorrent changed its contract across versions:
+//   - <=5.1.x: 200 OK with body "Ok." (and "Fails." on bad credentials)
+//   - >=5.2.x: 204 No Content with an empty body
+//
+// Both are accepted; everything else (including a 204 carrying an unexpected
+// body) is treated as a failure. See issue #38.
+func loginSucceeded(status int, body []byte) bool {
+	trimmed := strings.TrimSpace(string(body))
+	switch status {
+	case http.StatusNoContent:
+		return trimmed == ""
+	case http.StatusOK:
+		return strings.EqualFold(trimmed, "ok.")
+	default:
+		return false
+	}
 }
 
 func nonEmpty(s, fallback string) string {

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent_test.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 
@@ -20,7 +18,10 @@ type fakeQBit struct {
 	loginCalls int
 	addCalls   int
 	lastBody   string
-	mu         sync.Mutex
+	// login204 mimics qBittorrent >=5.2.x, which answers a successful login
+	// with 204 No Content and an empty body instead of 200 "Ok.".
+	login204 bool
+	mu       sync.Mutex
 }
 
 func (f *fakeQBit) handler() http.Handler {
@@ -28,25 +29,32 @@ func (f *fakeQBit) handler() http.Handler {
 	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		f.loginCalls++
+		use204 := f.login204
 		f.mu.Unlock()
 		_ = r.ParseForm()
 		if r.Form.Get("username") == "admin" && r.Form.Get("password") == "secret" {
-			w.WriteHeader(200)
+			if use204 {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("Ok."))
 			return
 		}
-		w.WriteHeader(200)
+		// Bad credentials are rejected the same way in both contracts:
+		// 200 with a "Fails." body. The login204 flag only governs success.
+		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("Fails."))
 	})
 	mux.HandleFunc("/api/v2/app/version", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("v4.6.0"))
 	})
 	mux.HandleFunc("/api/v2/torrents/info", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		f.lastBody = r.URL.Query().Get("hashes")
 		f.mu.Unlock()
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		// One downloading, one finished-seeding torrent.
 		w.Write([]byte(`[` +
 			`{"hash":"ABC123","progress":0.42,"state":"downloading"},` +
@@ -70,7 +78,7 @@ func (f *fakeQBit) handler() http.Handler {
 				}
 			}
 		}
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("Ok."))
 	})
 	return mux
@@ -84,7 +92,7 @@ func newServer(t *testing.T) (*httptest.Server, *fakeQBit) {
 	return srv, f
 }
 
-func TestTestSucceedsOnGoodCreds(t *testing.T) {
+func TestTest_ValidCredentials_Succeeds(t *testing.T) {
 	srv, _ := newServer(t)
 	p := &plugin{sessions: map[string]*session{}}
 
@@ -96,7 +104,7 @@ func TestTestSucceedsOnGoodCreds(t *testing.T) {
 	}
 }
 
-func TestTestFailsOnBadCreds(t *testing.T) {
+func TestTest_InvalidCredentials_ReturnsError(t *testing.T) {
 	srv, _ := newServer(t)
 	p := &plugin{sessions: map[string]*session{}}
 
@@ -108,7 +116,39 @@ func TestTestFailsOnBadCreds(t *testing.T) {
 	}
 }
 
-func TestAddMagnet(t *testing.T) {
+// TestTest_204LoginResponse_Succeeds is the regression test for issue #38:
+// qBittorrent 5.2.x answers a successful login with 204 No Content (empty
+// body). The whole Test() flow — which goes through session() — must accept it.
+func TestTest_204LoginResponse_Succeeds(t *testing.T) {
+	srv, fake := newServer(t)
+	fake.login204 = true
+	p := &plugin{sessions: map[string]*session{}}
+
+	cfg, _ := json.Marshal(Config{
+		URL: srv.URL, Username: "admin", Password: "secret",
+	})
+	if err := p.Test(context.Background(), cfg); err != nil {
+		t.Fatalf("Test against a 204-login server: %v", err)
+	}
+}
+
+// TestTest_InvalidCredentialsOn204Server_ReturnsError guards that the 204
+// success contract does not turn a rejected login into a false success: a
+// 5.2.x-style server still answers bad credentials with 200 "Fails.".
+func TestTest_InvalidCredentialsOn204Server_ReturnsError(t *testing.T) {
+	srv, fake := newServer(t)
+	fake.login204 = true
+	p := &plugin{sessions: map[string]*session{}}
+
+	cfg, _ := json.Marshal(Config{
+		URL: srv.URL, Username: "admin", Password: "wrong",
+	})
+	if err := p.Test(context.Background(), cfg); err == nil {
+		t.Fatal("expected login failure on a 204-mode server with bad creds")
+	}
+}
+
+func TestAdd_MagnetURI_SubmitsURLField(t *testing.T) {
 	srv, fake := newServer(t)
 	p := &plugin{sessions: map[string]*session{}}
 
@@ -125,7 +165,7 @@ func TestAddMagnet(t *testing.T) {
 	}
 }
 
-func TestAddTorrentFile(t *testing.T) {
+func TestAdd_TorrentFile_Succeeds(t *testing.T) {
 	srv, fake := newServer(t)
 	p := &plugin{sessions: map[string]*session{}}
 
@@ -142,7 +182,7 @@ func TestAddTorrentFile(t *testing.T) {
 	}
 }
 
-func TestSessionReuseAcrossCalls(t *testing.T) {
+func TestSession_RepeatedCalls_LogsInOnce(t *testing.T) {
 	srv, fake := newServer(t)
 	p := &plugin{sessions: map[string]*session{}}
 
@@ -163,7 +203,7 @@ func TestSessionReuseAcrossCalls(t *testing.T) {
 	}
 }
 
-func TestStatusMapsHashesAndStates(t *testing.T) {
+func TestStatus_MultipleHashes_MapsStatesAndProgress(t *testing.T) {
 	srv, fake := newServer(t)
 	p := &plugin{sessions: map[string]*session{}}
 	cfg, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
@@ -191,7 +231,35 @@ func TestStatusMapsHashesAndStates(t *testing.T) {
 	}
 }
 
-// nonUsedDeclarations stops the linter complaining about unused imports
-// when this file is the entry point.
-var _ = strings.Builder{}
-var _ = multipart.NewWriter
+// TestLoginSucceeded covers both qBittorrent WebUI login response contracts:
+//   - legacy (<=5.1.x): 200 OK with body "Ok." on success, "Fails." on bad creds
+//   - current (>=5.2.x): 204 No Content with an empty body on success
+//
+// Verified empirically against linuxserver/qbittorrent 5.1.4 (200 "Ok.") and
+// 5.2.1 (204, empty) — see issue #38.
+func TestLoginSucceeded(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"legacy 200 Ok.", 200, "Ok.", true},
+		{"legacy 200 Ok. with trailing newline", 200, "Ok.\n", true},
+		{"legacy 200 case-insensitive ok.", 200, "OK.", true},
+		{"current 204 empty body", 204, "", true},
+		{"current 204 with whitespace body", 204, "  \n", true},
+		{"bad creds 200 Fails.", 200, "Fails.", false},
+		{"200 empty body", 200, "", false},
+		{"204 with unexpected non-empty body", 204, "nope", false},
+		{"403 banned empty body", 403, "", false},
+		{"500 server error", 500, "Ok.", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := loginSucceeded(tt.status, []byte(tt.body)); got != tt.want {
+				t.Errorf("loginSucceeded(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/acceptance/acceptance.sh
+++ b/deploy/acceptance/acceptance.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Acceptance test for one Marauder download-client plugin against a REAL client
+# container. Brings up the base stack + a single client (isolated Compose
+# project), creates the client through the Marauder API — which runs the
+# plugin's Test() login/handshake — and asserts the call returns 2xx.
+#
+# Usage: acceptance.sh <client> <channel>
+#   client  : qbittorrent | transmission | deluge | utorrent
+#   channel : pinned | latest
+set -euo pipefail
+
+CLIENT="${1:?usage: acceptance.sh <client> <pinned|latest>}"
+CHANNEL="${2:?usage: acceptance.sh <client> <pinned|latest>}"
+
+# Run from the deploy/ directory (this script lives in deploy/acceptance/).
+DEPLOY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$DEPLOY_DIR"
+
+# Isolated project + non-default API port so a running dev stack is untouched.
+export MARAUDER_HOST_PORT="${MARAUDER_HOST_PORT:-34085}"
+API="http://localhost:${MARAUDER_HOST_PORT}"
+COMPOSE=(docker compose -p marauder-acceptance
+  -f docker-compose.yml -f docker-compose.test-clients.yml)
+
+# Map client -> service, plugin name, internal URL, image-tag env var.
+case "$CLIENT" in
+  qbittorrent)
+    SERVICE=qbittorrent-521; PLUGIN=qbittorrent
+    CLIENT_URL="http://qbittorrent-521:6611"; TAG_VAR=MARAUDER_TEST_QBIT_TAG ;;
+  transmission)
+    SERVICE=transmission-412; PLUGIN=transmission
+    CLIENT_URL="http://transmission-412:9091/transmission/rpc"
+    TAG_VAR=MARAUDER_TEST_TRANSMISSION_TAG ;;
+  deluge)
+    SERVICE=deluge-220; PLUGIN=deluge
+    CLIENT_URL="http://deluge-220:8112"; TAG_VAR=MARAUDER_TEST_DELUGE_TAG ;;
+  utorrent)
+    SERVICE=utorrent; PLUGIN=utorrent
+    CLIENT_URL="http://utorrent:8080"; TAG_VAR=MARAUDER_TEST_UTORRENT_TAG
+    COMPOSE+=(--profile utorrent) ;;
+  *) echo "unknown client: $CLIENT" >&2; exit 2 ;;
+esac
+
+[ "$CHANNEL" = latest ] && export "${TAG_VAR}=latest"
+[ "$CHANNEL" = pinned ] || [ "$CHANNEL" = latest ] || {
+  echo "unknown channel: $CHANNEL" >&2; exit 2; }
+
+# Fresh, throwaway env (never touch the developer's deploy/.env).
+ENV_FILE="$(mktemp)"
+cp .env.example "$ENV_FILE"
+MASTER=$(openssl rand -base64 32)
+METRICS=$(openssl rand -hex 32)
+sed -i "s|MARAUDER_MASTER_KEY=.*|MARAUDER_MASTER_KEY=${MASTER}|" "$ENV_FILE"
+sed -i "s|MARAUDER_METRICS_TOKEN=.*|MARAUDER_METRICS_TOKEN=${METRICS}|" "$ENV_FILE"
+COMPOSE+=(--env-file "$ENV_FILE")
+
+cleanup() {
+  "${COMPOSE[@]}" down -v >/dev/null 2>&1 || true
+  rm -f "$ENV_FILE"
+}
+trap cleanup EXIT
+
+echo "==> $CLIENT/$CHANNEL: bringing up base stack + $SERVICE"
+"${COMPOSE[@]}" up -d --wait --wait-timeout 180 \
+  db backend frontend gateway "$SERVICE"
+
+# Resolve per-client credentials.
+USERNAME=admin; PASSWORD=""
+case "$CLIENT" in
+  qbittorrent)
+    CID="$(${COMPOSE[@]} ps -q "$SERVICE")"
+    for _ in $(seq 1 30); do
+      PASSWORD=$(docker logs "$CID" 2>&1 \
+        | grep "temporary password" | awk '{print $NF}' | tail -1 || true)
+      [ -n "$PASSWORD" ] && break; sleep 2
+    done
+    [ -n "$PASSWORD" ] || { echo "no qBittorrent temp password" >&2; exit 1; } ;;
+  transmission) USERNAME=""; PASSWORD="" ;;  # rpc-authentication-required: false
+  deluge)       PASSWORD="deluge" ;;          # linuxserver default web password
+  utorrent)     USERNAME=admin; PASSWORD="" ;;  # image default admin / empty
+esac
+
+# Build the plugin config (Deluge takes no username).
+if [ "$PLUGIN" = deluge ]; then
+  CONFIG=$(printf '{"url":"%s","password":"%s"}' "$CLIENT_URL" "$PASSWORD")
+else
+  CONFIG=$(printf '{"url":"%s","username":"%s","password":"%s"}' \
+    "$CLIENT_URL" "$USERNAME" "$PASSWORD")
+fi
+
+echo "==> logging in to Marauder at $API"
+TOK=$(curl -fsS -X POST "$API/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"pleasechangeme"}' \
+  | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+[ -n "$TOK" ] || { echo "Marauder login failed" >&2; exit 1; }
+
+echo "==> creating $PLUGIN client (runs plugin Test())"
+REQ=$(printf '{"client_name":"%s","display_name":"acceptance-%s","is_default":false,"config":%s}' \
+  "$PLUGIN" "$CLIENT" "$CONFIG")
+CODE=$(curl -s -o /tmp/acceptance_resp.json -w '%{http_code}' \
+  -X POST "$API/api/v1/clients" \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d "$REQ")
+
+if [ "$CODE" -ge 200 ] && [ "$CODE" -lt 300 ]; then
+  echo "PASS: $CLIENT/$CHANNEL create-client -> HTTP $CODE"
+  exit 0
+fi
+
+echo "FAIL: $CLIENT/$CHANNEL create-client -> HTTP $CODE" >&2
+cat /tmp/acceptance_resp.json >&2; echo >&2
+echo "--- client logs ---" >&2; docker logs "$(${COMPOSE[@]} ps -q "$SERVICE")" 2>&1 | tail -40 >&2
+echo "--- backend logs ---" >&2; "${COMPOSE[@]}" logs backend 2>&1 | tail -40 >&2
+exit 1

--- a/deploy/docker-compose.test-clients.yml
+++ b/deploy/docker-compose.test-clients.yml
@@ -1,0 +1,186 @@
+# Torrent-client test matrix for Marauder.
+#
+# Spins up every download client Marauder supports, across multiple
+# versions, so the client plugins can be exercised against REAL clients —
+# not just the in-process httptest fakes. Born out of issue #38, where
+# qBittorrent 5.2.x changed its login response from `200 "Ok."` to
+# `204 No Content` and the legacy-only check rejected a valid login.
+#
+# This file defines ONLY client services (no db/backend/frontend), so it
+# composes two ways:
+#
+#   1. Standalone — bring the matrix up and poke each client on its host
+#      port directly (curl, browser, plugin e2e tests):
+#
+#        docker compose -f deploy/docker-compose.test-clients.yml up -d
+#
+#   2. Stacked on the full stack — the backend then reaches each client by
+#      Docker service DNS (the URLs in the table below), so you can add
+#      them as clients inside a running Marauder and test end-to-end:
+#
+#        docker compose -f deploy/docker-compose.yml \
+#                       -f deploy/docker-compose.test-clients.yml up -d
+#
+# Every service declares a healthcheck, so `docker compose up -d --wait`
+# blocks until each client's WebUI/RPC is actually serving — handy for
+# gating an e2e script.
+#
+# Tear down + wipe all client state:
+#   docker compose -f deploy/docker-compose.test-clients.yml down -v
+#
+# Host ports stay in the 34xxx range (local-port-ranges rule); they don't
+# overlap the dev overlay's 34611/34091, and they bind to 127.0.0.1 only
+# so the (auth-less) test clients are never exposed on the LAN. Container-
+# internal ports keep their conventional values. Every image tag below was
+# verified to resolve before being pinned (no `latest`, no guesses).
+#
+# | Service           | Host port (127.0.0.1) | Internal | URL to enter in Marauder (stacked) |
+# |-------------------|-----------------------|----------|------------------------------------|
+# | qbittorrent-521   | 34621                 | 6611     | http://qbittorrent-521:6611                    |
+# | qbittorrent-514   | 34622                 | 6611     | http://qbittorrent-514:6611                    |
+# | transmission-412  | 34121                 | 9091     | http://transmission-412:9091/transmission/rpc  |
+# | transmission-406  | 34122                 | 9091     | http://transmission-406:9091/transmission/rpc  |
+# | deluge-220        | 34112                 | 8112     | http://deluge-220:8112                         |
+# | utorrent          | 34608                 | 8080     | http://utorrent:8080                           |
+#
+# qBittorrent has no fixed password — the linuxserver image mints a random
+# temporary one on each start until you set your own in the WebUI. Read it
+# with, e.g.:
+#   docker logs deploy-qbittorrent-521-1 2>&1 | grep "temporary password"
+
+x-health: &health
+  interval: 15s
+  timeout: 5s
+  retries: 5
+  start_period: 40s
+
+x-qbit-common: &qbit-common
+  restart: unless-stopped
+  environment: &qbit-env
+    PUID: "1000"
+    PGID: "1000"
+    TZ: "Etc/UTC"
+    WEBUI_PORT: "6611"
+  logging: &log-opts
+    driver: json-file
+    options:
+      max-size: "5m"
+      max-file: "2"
+  # `curl -s` (no -f) exits 0 for any HTTP response, so the probe tolerates
+  # the WebUI's unauthenticated 401 — it only fails on connection refused.
+  healthcheck:
+    <<: *health
+    test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:6611/ || exit 1"]
+
+services:
+  # --- qBittorrent: the two sides of the issue #38 login contract --------
+  # 5.2.1 answers a successful login with 204 No Content (empty body).
+  qbittorrent-521:
+    <<: *qbit-common
+    image: lscr.io/linuxserver/qbittorrent:5.2.1
+    environment: *qbit-env
+    volumes:
+      - qbit_521_config:/config
+      - qbit_521_downloads:/downloads
+    ports:
+      - "127.0.0.1:${MARAUDER_TEST_QBIT_521_PORT:-34621}:6611"
+
+  # 5.1.4 answers a successful login the legacy way: 200 OK, body "Ok.".
+  qbittorrent-514:
+    <<: *qbit-common
+    image: lscr.io/linuxserver/qbittorrent:5.1.4
+    environment: *qbit-env
+    volumes:
+      - qbit_514_config:/config
+      - qbit_514_downloads:/downloads
+    ports:
+      - "127.0.0.1:${MARAUDER_TEST_QBIT_514_PORT:-34622}:6611"
+
+  # --- Transmission: current + previous major ---------------------------
+  # RPC at /transmission/rpc on 9091. No auth by default in this image.
+  transmission-412:
+    image: lscr.io/linuxserver/transmission:4.1.2
+    restart: unless-stopped
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: "Etc/UTC"
+    volumes:
+      - transmission_412_config:/config
+      - transmission_412_downloads:/downloads
+    ports:
+      - "127.0.0.1:${MARAUDER_TEST_TRANSMISSION_412_PORT:-34121}:9091"
+    logging: *log-opts
+    healthcheck:
+      <<: *health
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:9091/transmission/rpc || exit 1"]
+
+  transmission-406:
+    image: lscr.io/linuxserver/transmission:4.0.6
+    restart: unless-stopped
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: "Etc/UTC"
+    volumes:
+      - transmission_406_config:/config
+      - transmission_406_downloads:/downloads
+    ports:
+      - "127.0.0.1:${MARAUDER_TEST_TRANSMISSION_406_PORT:-34122}:9091"
+    logging: *log-opts
+    healthcheck:
+      <<: *health
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:9091/transmission/rpc || exit 1"]
+
+  # --- Deluge: web UI JSON-RPC at /json on 8112 -------------------------
+  # The plugin talks to the web daemon, not the classic daemon RPC (58846).
+  # Default web UI password is "deluge".
+  deluge-220:
+    image: lscr.io/linuxserver/deluge:2.2.0
+    restart: unless-stopped
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: "Etc/UTC"
+    volumes:
+      - deluge_220_config:/config
+      - deluge_220_downloads:/downloads
+    ports:
+      - "127.0.0.1:${MARAUDER_TEST_DELUGE_220_PORT:-34112}:8112"
+    logging: *log-opts
+    healthcheck:
+      <<: *health
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8112/ || exit 1"]
+
+  # --- µTorrent: WebUI at /gui on 8080 (HTTP basic auth) ----------------
+  # No maintained official image exists; ekho/utorrent wraps the legacy
+  # Linux utserver. It is amd64-only, so it is kept behind the "utorrent"
+  # profile and a default `up` skips it on arm64 hosts. Enable with:
+  #   docker compose --profile utorrent ... up -d
+  # Pinned to v2.1.0 (last tagged release); credentials are the image's
+  # defaults — check its logs/README; this file does not assert them.
+  utorrent:
+    image: ekho/utorrent:v2.1.0
+    profiles: ["utorrent"]
+    restart: unless-stopped
+    volumes:
+      - utorrent_data:/utorrent/settings
+    ports:
+      - "127.0.0.1:${MARAUDER_TEST_UTORRENT_PORT:-34608}:8080"
+    logging: *log-opts
+    healthcheck:
+      <<: *health
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8080/gui/ || exit 1"]
+
+volumes:
+  qbit_521_config:
+  qbit_521_downloads:
+  qbit_514_config:
+  qbit_514_downloads:
+  transmission_412_config:
+  transmission_412_downloads:
+  transmission_406_config:
+  transmission_406_downloads:
+  deluge_220_config:
+  deluge_220_downloads:
+  utorrent_data:

--- a/deploy/docker-compose.test-clients.yml
+++ b/deploy/docker-compose.test-clients.yml
@@ -77,7 +77,7 @@ services:
   # 5.2.1 answers a successful login with 204 No Content (empty body).
   qbittorrent-521:
     <<: *qbit-common
-    image: lscr.io/linuxserver/qbittorrent:5.2.1
+    image: lscr.io/linuxserver/qbittorrent:${MARAUDER_TEST_QBIT_TAG:-5.2.1}
     environment: *qbit-env
     volumes:
       - qbit_521_config:/config
@@ -99,7 +99,7 @@ services:
   # --- Transmission: current + previous major ---------------------------
   # RPC at /transmission/rpc on 9091. No auth by default in this image.
   transmission-412:
-    image: lscr.io/linuxserver/transmission:4.1.2
+    image: lscr.io/linuxserver/transmission:${MARAUDER_TEST_TRANSMISSION_TAG:-4.1.2}
     restart: unless-stopped
     environment:
       PUID: "1000"
@@ -136,7 +136,7 @@ services:
   # The plugin talks to the web daemon, not the classic daemon RPC (58846).
   # Default web UI password is "deluge".
   deluge-220:
-    image: lscr.io/linuxserver/deluge:2.2.0
+    image: lscr.io/linuxserver/deluge:${MARAUDER_TEST_DELUGE_TAG:-2.2.0}
     restart: unless-stopped
     environment:
       PUID: "1000"
@@ -160,7 +160,7 @@ services:
   # Pinned to v2.1.0 (last tagged release); credentials are the image's
   # defaults — check its logs/README; this file does not assert them.
   utorrent:
-    image: ekho/utorrent:v2.1.0
+    image: ekho/utorrent:${MARAUDER_TEST_UTORRENT_TAG:-v2.1.0}
     profiles: ["utorrent"]
     restart: unless-stopped
     volumes:

--- a/docs/superpowers/specs/2026-06-18-client-acceptance-and-upstream-canary-design.md
+++ b/docs/superpowers/specs/2026-06-18-client-acceptance-and-upstream-canary-design.md
@@ -1,0 +1,199 @@
+# Design: Client Acceptance Tests + Upstream Version Canary
+
+| Field | Value |
+|---|---|
+| Date | 2026-06-18 |
+| Status | Approved — ready for implementation planning |
+| Related | Issue #38 (qBittorrent 5.2.x `204` login break); `deploy/docker-compose.test-clients.yml`; `.github/workflows/e2e.yml` |
+
+## 1. Problem
+
+Marauder pushes torrents into four download clients (qBittorrent,
+Transmission, Deluge, µTorrent) through version-sensitive HTTP/RPC contracts.
+Issue #38 showed how fragile this is: qBittorrent 5.2.0 changed its login
+success response from `200 "Ok."` to `204 No Content`, silently breaking
+client setup for everyone on the new version. A **user** reported it before we
+did.
+
+Two gaps let that happen:
+
+1. **No coverage breadth.** The nightly `e2e.yml` exercises a real client
+   end-to-end, but **only qBittorrent**. Transmission, Deluge, and µTorrent
+   have unit tests against in-process fakes only — nothing proves the real
+   protocol still works.
+2. **No baseline/canary separation.** `e2e.yml` runs the dev overlay, which
+   pins `qbittorrent:latest`. So it *was* effectively a "test against latest"
+   probe — but with nothing pinned as a known-good baseline. When `latest`
+   breaks, the single nightly signal goes red and cannot distinguish *"we
+   regressed"* from *"upstream changed under us."*
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- Automated **acceptance test for every supported client** that proves the
+  plugin can authenticate/connect against a **real** client container.
+- Run that against a **pinned, verified version** (the known-good baseline)
+  **and** against the client's **latest** version (an upstream canary).
+- When `latest` breaks, surface it as an **early, actionable notification**
+  (red CI check + an auto-filed GitHub issue) without blocking releases.
+- Keep PR CI fast — no per-PR container spin-up.
+
+**Non-goals (this iteration)**
+
+- Deeper pipeline assertions (push a magnet → scheduler tick → confirm the
+  torrent is present in the client). The existing `e2e.yml` already does this
+  for qBittorrent; extending it to all clients is future work (§9).
+- Testing every historical version — only `pinned` and `latest` per client.
+- µTorrent `latest` canary (its `ekho/utorrent` image is unmaintained;
+  "latest" ≈ pinned, so there is no meaningful upstream drift to catch).
+
+## 3. Acceptance level (decided)
+
+Each test performs the **connectivity/auth** check, no torrent push:
+
+> Bring up `db + backend + <one client>` → log into the Marauder API →
+> `POST /api/v1/clients` → assert `2xx`.
+
+A successful create means the backend ran the plugin's `Test()` —
+login/handshake — against the live client. This is the exact path that #38
+broke, it is uniform across all four clients, and it runs in seconds (no
+75-second scheduler tick).
+
+## 4. Architecture — a 2-axis matrix
+
+- **Axis A — client:** `qbittorrent`, `transmission`, `deluge`, `utorrent`
+- **Axis B — channel:** `pinned` | `latest`
+
+µTorrent is `pinned`-only. Result: **4 pinned + 3 latest = 7 isolated cells**.
+Each cell brings up its own single client, so a failure attributes cleanly to
+one `(client, channel)` pair.
+
+## 5. Components
+
+Three units, each independently understandable and testable.
+
+### 5.1 Client definitions — `deploy/docker-compose.test-clients.yml` (extend)
+
+Already the single source of truth for each client's image, internal port,
+healthcheck, and volumes. Extension: make the **image tag of each primary
+service env-overridable with the pinned value as default**, so the canary can
+swap in `latest` at runtime without committing a `latest` tag:
+
+| Service (primary) | Image tag expression |
+|---|---|
+| `qbittorrent-521` | `lscr.io/linuxserver/qbittorrent:${MARAUDER_TEST_QBIT_TAG:-5.2.1}` |
+| `transmission-412` | `lscr.io/linuxserver/transmission:${MARAUDER_TEST_TRANSMISSION_TAG:-4.1.2}` |
+| `deluge-220` | `lscr.io/linuxserver/deluge:${MARAUDER_TEST_DELUGE_TAG:-2.2.0}` |
+| `utorrent` | `ekho/utorrent:${MARAUDER_TEST_UTORRENT_TAG:-v2.1.0}` |
+
+`qbittorrent-514` (the legacy 5.1.4 manual-regression service) keeps its hard
+pin. Defaults remain pinned, so the file stays rule-compliant (no committed
+`latest`); only the canary job exports `MARAUDER_TEST_*_TAG=latest`.
+
+### 5.2 Acceptance runner — `deploy/acceptance/acceptance.sh <client> <channel>`
+
+A self-contained, **locally runnable** script — the "function" under test:
+
+- **Inputs:** `client ∈ {qbittorrent,transmission,deluge,utorrent}`,
+  `channel ∈ {pinned,latest}`.
+- **Behavior:**
+  1. For `channel=latest`, export the matching `MARAUDER_TEST_*_TAG=latest`.
+  2. `docker compose -f docker-compose.yml -f docker-compose.test-clients.yml
+     up -d --wait <client-service>` plus the base stack so the Marauder API is
+     reachable at the gateway (`http://localhost:34080`, as `e2e.yml` does).
+     Relies on the healthchecks already on each client so `--wait` gates on
+     real readiness; the `.env` (master key, metrics token) is generated the
+     same way as in `e2e.yml`.
+  3. Resolve that client's credentials (§6).
+  4. Log into the Marauder API, `POST /clients`, assert `2xx`; on non-2xx,
+     print the response body + `docker logs` for the client and backend, exit
+     non-zero.
+  5. Always `down -v` (teardown + volume wipe).
+- **Output:** process exit code (0 = acceptance passed).
+- **Local use:** `./deploy/acceptance/acceptance.sh deluge pinned`.
+
+Encapsulating per-client credential/URL knowledge here (not in the workflow)
+keeps the CI YAML thin and lets a developer reproduce any cell locally.
+
+### 5.3 CI workflow — `.github/workflows/client-acceptance.yml` (new)
+
+A dedicated workflow, kept separate from `e2e.yml` (that file owns the *deep*
+qBittorrent pipeline; this owns the *broad shallow* matrix).
+
+- **Triggers:** `schedule` (nightly cron), `push: tags: ['v*']`,
+  `workflow_dispatch`. No per-PR trigger — matches the existing e2e philosophy.
+- **Job `pinned`** — `strategy.matrix.client: [qbittorrent, transmission,
+  deluge, utorrent]`, each calling `acceptance.sh <client> pinned`.
+  **Blocking.** A red here means *our* regression. Because it runs on
+  `tags: v*`, it gates releases.
+- **Job `latest`** — `strategy.matrix.client: [qbittorrent, transmission,
+  deluge]`, each calling `acceptance.sh <client> latest`. Runs nightly +
+  dispatch **only** (not on tag — releases must not hinge on upstream's
+  latest). The acceptance step uses `continue-on-error: true` so the cell
+  shows **red but does not fail the run or block anything**, followed by an
+  `if: failure()` step that files the canary alert (§7).
+
+## 6. Per-client credential resolution
+
+| Client | Marauder `client_name` | Config sent to `POST /clients` | Credential source |
+|---|---|---|---|
+| qBittorrent | `qbittorrent` | `{url: http://qbittorrent-521:6611, username: admin, password: <temp>}` | temp password scraped from `docker logs <container>` ("temporary password") |
+| Transmission | `transmission` | `{url: http://transmission-412:9091/transmission/rpc, username: "", password: ""}` | none — image runs `rpc-authentication-required: false` |
+| Deluge | `deluge` | `{url: http://deluge-220:8112, password: deluge}` | linuxserver default web password `deluge` |
+| µTorrent | `utorrent` | `{url: http://utorrent:8080, username: admin, password: ""}` | image default `admin` / empty (verified against the token endpoint) |
+
+The backend reaches each client by **Docker service DNS** because the runner
+stacks the base compose and the matrix file on the same network.
+
+## 7. Canary alert (latest-channel failure)
+
+On a `latest` cell failure, an `if: failure()` step opens-or-updates a deduped
+GitHub issue using the `gh` CLI (`GITHUB_TOKEN`, `issues: write`):
+
+- Title marker: `[client-canary] <client> latest acceptance failing`.
+- Label: `client-canary`.
+- Dedup: `gh issue list --label client-canary --state open` filtered by the
+  title marker → if found, add a comment with the run link; else
+  `gh issue create`.
+
+This reproduces how #38 reached us (a tracked issue) but days earlier and
+self-reported, while the red-but-non-blocking check keeps it visible in the
+Actions tab.
+
+## 8. Data flow & error handling
+
+```
+matrix cell (client, channel)
+  → acceptance.sh
+    → [latest only] export MARAUDER_TEST_<X>_TAG=latest
+    → docker compose up -d --wait <client-service> + base stack (API @ :34080)
+    → resolve creds → POST /api/v1/clients → assert 2xx
+    → down -v (always)
+  → exit code
+    → pinned fail  : job red → blocks tag/release
+    → latest fail  : continue-on-error red annotation + deduped gh issue
+```
+
+- **Teardown** is `if: always()` (`down -v`) so no leaked containers/volumes.
+- **Diagnostics on failure:** dump the client + backend `docker logs` before
+  teardown.
+- **Flake guard:** `--wait` plus the existing per-client healthchecks ensure
+  the client is actually serving before the API call; the backend's own
+  healthcheck gates readiness.
+
+## 9. Out of scope / future
+
+- Promote the canary from connectivity to full pipeline (magnet → scheduler
+  tick → confirm in client) per client — reuses the `e2e.yml` pattern.
+- Auto-bump the pinned baseline to a new version once its canary has been
+  green for N nights (turn a passing canary into a pin PR).
+- Live `Status` (`WithStatus`) assertions for qBittorrent/Transmission.
+
+## 10. Validation
+
+The `pinned` half of this matrix was already executed manually during the #38
+work: `create-client → Test()` succeeded against real `qbittorrent` 5.2.1 +
+5.1.4, `transmission` 4.1.2, `deluge` 2.2.0, and `utorrent` v2.1.0. The first
+automated `pinned` run is therefore expected green; this design automates and
+schedules that, and layers the `latest` canary on top.

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -118,11 +118,12 @@ const sections = [
   {
     title: "CI / CD that takes itself seriously",
     intro:
-      "Five GitHub Actions workflows, golangci-lint with 12 rules, Trivy scans, cosign signing, CycloneDX SBOMs, Dependabot.",
+      "Six GitHub Actions workflows, golangci-lint with 12 rules, Trivy scans, cosign signing, CycloneDX SBOMs, Dependabot.",
     bullets: [
       "ci.yml: backend race-tests + golangci-lint + govulncheck, frontend tsc + build, cfsolver build/vet — under 3 minutes per PR",
       "docker.yml: builds all 3 images on push to main, Trivy scan with HIGH/CRITICAL fail",
       "e2e.yml: nightly + on-tag full compose-stack walkthrough (magnet → qBittorrent end-to-end)",
+      "client-acceptance.yml: nightly matrix creating every supported client against a real container — pinned baseline + a latest-version canary that auto-files an issue when an upstream release breaks a client",
       "release.yml: tag-pushed multi-arch (amd64 + arm64) build, cosign keyless signing via OIDC, CycloneDX SBOM per image, GitHub Release with auto-extracted CHANGELOG",
       "codeql.yml: GitHub CodeQL SAST for Go and TypeScript with the security-extended query pack",
       "dependabot.yml: weekly grouped updates for gomod, npm, github-actions, docker base images",


### PR DESCRIPTION
## Summary

- **Fix #38** — qBittorrent client setup failed against qBittorrent 5.2.x with `client test failed: login failed: status=204 body=""`. qBittorrent 5.2.0 changed the WebUI `/api/v2/auth/login` success response from `200 "Ok."` to `204 No Content`; the plugin accepted only the legacy form and rejected valid logins. A new `loginSucceeded(status, body)` helper accepts both contracts while still rejecting failures (including a `204` carrying an unexpected body).
- **Test matrix** — `deploy/docker-compose.test-clients.yml`: every supported client across versions (qBittorrent 5.2.1/5.1.4, Transmission 4.1.2/4.0.6, Deluge 2.2.0, profile-gated µTorrent v2.1.0), each pinned, healthchecked, and bound to `127.0.0.1`.
- **Acceptance + canary** — `deploy/acceptance/acceptance.sh` + `.github/workflows/client-acceptance.yml`: a nightly matrix that creates every client through the API against a real container, on a pinned baseline (gates releases on tag) and a latest-version canary that auto-files a deduped issue when an upstream release breaks a client — the early warning #38 lacked.

## Test plan

- `go build ./... && go vet ./... && go test -race ./...` — all green, including a new `loginSucceeded` table test (200/204/failure cases) and a 204 integration test through `Test()`.
- Reproduced #38 end-to-end against real containers: qBittorrent **5.2.1** returns `204` → unpatched backend rejected (`422`), patched backend accepts (`201`); **5.1.4** (`200 "Ok."`) still works.
- Ran `acceptance.sh <client> pinned` for all four clients plus `qbittorrent latest` → every cell **PASS (201)** against real containers; runner uses an isolated Compose project so a dev stack is untouched.
- Marketing site rebuilt (16 pages) after listing the new workflow.

Closes #38