### PR TITLE
ci(release): auto-bump dev stack version to the latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,3 +172,44 @@ jobs:
           files: sboms/**/*.cdx.json
           draft: false
           prerelease: ${{ contains(steps.changelog.outputs.tag, '-rc') || contains(steps.changelog.outputs.tag, '-alpha') || contains(steps.changelog.outputs.tag, '-beta') }}
+
+  # ----------------------------------------------- bump source-build version
+  # Keep the source-build (dev) stack's stamped version in sync with the
+  # latest release, so a local `docker compose up --build` reports the real
+  # released version instead of a hand-maintained marker. Commits the bump
+  # back to main with [skip ci] so it doesn't re-trigger CI.
+  bump-dev-version:
+    name: Bump dev stack version
+    needs: [release]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set dev stack version to the released version
+        run: |
+          set -euo pipefail
+          VER="${GITHUB_REF_NAME#v}"
+
+          # Update the source-build VERSION build arg and the marauder-* image
+          # tags in the base compose file. Other images (postgres, nginx) are
+          # left untouched by the marauder- prefix anchor.
+          sed -i -E "s|(VERSION: \")[^\"]+(\")|\1${VER}\2|" deploy/docker-compose.yml
+          sed -i -E "s#(image: marauder-(backend|frontend|cfsolver):).*#\1${VER}#" deploy/docker-compose.yml
+
+          if git diff --quiet -- deploy/docker-compose.yml; then
+            echo "deploy/docker-compose.yml already at ${VER}, nothing to do"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add deploy/docker-compose.yml
+          git commit -m "chore: set dev stack version to ${VER} [skip ci]"
+          git push origin main

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -41,8 +41,8 @@ services:
       context: ../backend
       dockerfile: Dockerfile
       args:
-        VERSION: "1.1.0-dev"
-    image: marauder-backend:1.1.0-dev
+        VERSION: "1.0.2"
+    image: marauder-backend:1.0.2
     restart: unless-stopped
     depends_on:
       db:
@@ -85,7 +85,7 @@ services:
     build:
       context: ../frontend
       dockerfile: Dockerfile
-    image: marauder-frontend:1.1.0-dev
+    image: marauder-frontend:1.0.2
     restart: unless-stopped
     depends_on:
       - backend
@@ -107,7 +107,7 @@ services:
     build:
       context: ../cfsolver
       dockerfile: Dockerfile
-    image: marauder-cfsolver:1.1.0-dev
+    image: marauder-cfsolver:1.0.2
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9244/health"]


### PR DESCRIPTION
## Summary

The source-build (dev) stack stamped a hand-maintained `VERSION` (`1.1.0-dev`)
that drifted from the actual latest release (`1.0.2`). This makes the release
pipeline keep it in sync automatically, so the version is never edited by hand.

- **One-time sync:** `deploy/docker-compose.yml` `VERSION` build arg + the
  `marauder-{backend,frontend,cfsolver}` image tags set to `1.0.2` (the current
  release).
- **Automation:** a `bump-dev-version` job in `release.yml` runs after a
  successful release (tag push only) and rewrites those four lines to the
  released version, committing back to `main` with `[skip ci]`. Other images
  (postgres, nginx) are left untouched by the `marauder-` prefix anchor.

Going forward, cutting `vX.Y.Z` automatically sets the dev stack to `X.Y.Z`.

## Test plan

- `actionlint` passes on the updated `release.yml`.
- Dry-ran the two `sed` rewrites with a fake version: exactly the 4 intended
  lines change (`VERSION` + 3 `marauder-*` image tags); `postgres`/`nginx`
  lines are unchanged. Caught and fixed a delimiter bug (the image `sed` used
  `|`, which collides with the `backend|frontend|cfsolver` alternation) before
  it could fail the CI step under `set -e`.

## Note

The dev label now shows the last release exactly (e.g. `1.0.2`), so a local
build with newer-but-unreleased code reads `1.0.2` with no `-dev` suffix — the
intended "current release version" behaviour.