### PR TITLE
fix(deploy): pin PGDATA so postgres 18 boots with legacy volume mount

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,10 +128,21 @@ jobs:
           echo "$BODY"
           echo "$BODY" | grep -q "0123456789abcdef0123456789abcdef01234567"
 
-      - name: Print backend logs on failure
+      - name: Print stack logs on failure
         if: failure()
         working-directory: deploy
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml logs backend
+        run: |
+          echo "::group::container status"
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml ps -a
+          echo "::endgroup::"
+          # db first: a depends_on:service_healthy failure aborts the
+          # whole `up`, and the db is the usual culprit — but its logs
+          # were never dumped, which hid postgres#1259 for 60 runs.
+          for svc in db backend frontend gateway; do
+            echo "::group::$svc logs"
+            docker compose -f docker-compose.yml -f docker-compose.dev.yml logs "$svc" || true
+            echo "::endgroup::"
+          done
 
       - name: Tear down
         if: always()

--- a/deploy/docker-compose.ghcr.yml
+++ b/deploy/docker-compose.ghcr.yml
@@ -36,6 +36,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-marauder}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-marauder}
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C"
+      # PG18 hard-errors when a volume sits at the legacy
+      # /var/lib/postgresql/data path (docker-library/postgres#1259).
+      # Pin PGDATA there so the layout stays valid and the db boots.
+      PGDATA: /var/lib/postgresql/data
     volumes:
       - marauder_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -14,8 +14,8 @@
 
 services:
   db:
-    # Tracks the 18.x line. Currently resolves to 18.3; will roll forward
-    # to 18.4 automatically when the upstream alpine tag is published.
+    # Tracks the 18.x line. Currently resolves to 18.4; rolls forward
+    # automatically when a newer upstream alpine tag is published.
     image: postgres:18-alpine
     restart: unless-stopped
     environment:
@@ -23,6 +23,12 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-marauder}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-marauder}
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C"
+      # PG18 relocated its default data dir to a major-version subdir and
+      # now HARD-ERRORS when a volume is mounted at the legacy
+      # /var/lib/postgresql/data path (docker-library/postgres#1259).
+      # Pin PGDATA back to that path so the existing on-disk layout stays
+      # valid (zero migration) and the container boots cleanly.
+      PGDATA: /var/lib/postgresql/data
     volumes:
       - marauder_pgdata:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary
- **Fixes the nightly E2E** (failed all 60 runs since 2026-04-08) and the **broken fresh-install path** for end users.
- Root cause: `postgres:18-alpine` is a floating tag; PG18 added a guard that **hard-errors when a volume is mounted at the legacy `/var/lib/postgresql/data`** ([docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)). The db crash-loops → never healthy → `backend`'s `depends_on: service_healthy` aborts `compose up` ~0.5s in (*"container deploy-db-1 is unhealthy"*). No diff in our repo caused it — the image behind the tag changed.
- The **GHCR "pull prebuilt" stack** had the identical bug, so every fresh install today gets a dead database.

## Changes
- Add `PGDATA: /var/lib/postgresql/data` to the db service in `docker-compose.yml` **and** `docker-compose.ghcr.yml`. Explicitly declaring the legacy path satisfies the new guard while keeping the existing on-disk layout valid — **zero migration** for existing v1.0.x deployments.
- `e2e.yml`: on failure, dump `ps -a` + `db`/`backend`/`frontend`/`gateway` logs. The old step only tailed `backend` (a container that never starts when the dependency is unhealthy), which hid this for two months.

## Test plan
- Reproduced the crash-loop locally with the unmodified compose; confirmed the `postgres#1259` error in db logs.
- With the fix, db reaches `healthy` in ~10s, **0 restarts**, and a sentinel row survives a restart (verified against the real edited `docker-compose.yml`).
- Merging will trigger E2E on the next nightly/dispatch; can also kick it via `workflow_dispatch` after merge to confirm green.