### PR TITLE
fix(qbittorrent): accept JSON add-response; verify E2E via Marauder API

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,24 +109,37 @@ jobs:
           test -n "$CLIENT_ID"
 
           echo "[3] add magnet topic"
-          MAG='magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=marauder-e2e'
-          curl -sS -X POST http://localhost:34080/api/v1/topics \
+          INFOHASH=0123456789abcdef0123456789abcdef01234567
+          MAG="magnet:?xt=urn:btih:${INFOHASH}&dn=marauder-e2e"
+          TOPIC_JSON=$(curl -sS -X POST http://localhost:34080/api/v1/topics \
             -H "Authorization: Bearer $TOK" \
             -H "Content-Type: application/json" \
-            -d "{\"url\":\"$MAG\",\"client_id\":\"$CLIENT_ID\"}"
+            -d "{\"url\":\"$MAG\",\"client_id\":\"$CLIENT_ID\"}")
+          echo "$TOPIC_JSON"
+          TOPIC_ID=$(echo "$TOPIC_JSON" | awk -F'"ID":"' '{print $2}' | awk -F'"' '{print $1}')
+          test -n "$TOPIC_ID"
 
-          echo "[4] wait for one scheduler tick (75s)"
+          echo "[4] wait for the scheduler to push the torrent (up to ~135s)"
+          # Verify through Marauder's own API, which exercises the real
+          # backend -> qBittorrent delivery path and records topic_deliveries.
+          # We deliberately do NOT poke the qBittorrent WebUI directly:
+          # qBittorrent 5.x rejects requests whose Host-header port differs
+          # from its WebUI port, which the published host port (34611 -> 6611)
+          # does, so a host-side login returns 401.
           sleep 75
-
-          echo "[5] verify in qBittorrent"
-          COOKIE=$(curl -sS -i -X POST "http://localhost:34611/api/v2/auth/login" \
-            -H "Referer: http://localhost:34611" \
-            --data-urlencode "username=admin" \
-            --data-urlencode "password=${QBIT_PASSWORD}" | \
-            grep -i "^set-cookie:" | sed 's/Set-Cookie: //i' | cut -d';' -f1)
-          BODY=$(curl -sS -H "Cookie: $COOKIE" "http://localhost:34611/api/v2/torrents/info")
-          echo "$BODY"
-          echo "$BODY" | grep -q "0123456789abcdef0123456789abcdef01234567"
+          echo "[5] verify delivery via Marauder topic status API"
+          for _ in $(seq 1 6); do
+            STATUS=$(curl -sS -H "Authorization: Bearer $TOK" \
+              "http://localhost:34080/api/v1/topics/$TOPIC_ID/status")
+            echo "$STATUS"
+            if echo "$STATUS" | grep -q "$INFOHASH"; then
+              echo "delivery recorded for $INFOHASH"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "torrent $INFOHASH never appeared in topic status"
+          exit 1
 
       - name: Print stack logs on failure
         if: failure()

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
@@ -145,11 +145,32 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(b))
 	}
-	// qBittorrent returns 200 "Ok." on success, 200 "Fails." on invalid
-	// torrent (yes really). Check the body.
+	// qBittorrent's /torrents/add success contract varies by version:
+	//   - legacy: 200 with body "Ok." (and "Fails." on a rejected torrent).
+	//   - newer:  200 with a JSON summary, e.g.
+	//     {"added_torrent_ids":[..],"failure_count":0,"pending_count":0,"success_count":1}
+	// Detect failure precisely. A naive substring check for "fail" trips on
+	// the JSON field name "failure_count" and turns a success into a false
+	// rejection (observed against linuxserver/qbittorrent on the multipart
+	// add path).
 	b, _ := io.ReadAll(resp.Body)
-	if strings.Contains(strings.ToLower(string(b)), "fail") {
-		return fmt.Errorf("qbittorrent rejected torrent: %s", string(b))
+	respBody := strings.TrimSpace(string(b))
+	if strings.HasPrefix(respBody, "{") {
+		var summary struct {
+			SuccessCount int `json:"success_count"`
+			FailureCount int `json:"failure_count"`
+			PendingCount int `json:"pending_count"`
+		}
+		if err := json.Unmarshal([]byte(respBody), &summary); err == nil {
+			if summary.FailureCount > 0 || (summary.SuccessCount == 0 && summary.PendingCount == 0) {
+				return fmt.Errorf("qbittorrent rejected torrent: %s", respBody)
+			}
+			return nil
+		}
+		// Unparseable JSON falls through to the legacy string check below.
+	}
+	if strings.Contains(strings.ToLower(respBody), "fails") {
+		return fmt.Errorf("qbittorrent rejected torrent: %s", respBody)
 	}
 	return nil
 }

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent_test.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent_test.go
@@ -21,7 +21,12 @@ type fakeQBit struct {
 	// login204 mimics qBittorrent >=5.2.x, which answers a successful login
 	// with 204 No Content and an empty body instead of 200 "Ok.".
 	login204 bool
-	mu       sync.Mutex
+	// addJSON mimics qBittorrent's newer /torrents/add, which answers with a
+	// JSON summary ({"success_count":1,"failure_count":0,...}) instead of the
+	// legacy "Ok." string. The JSON contains the substring "fail" in
+	// "failure_count", which must NOT be read as a rejection.
+	addJSON bool
+	mu      sync.Mutex
 }
 
 func (f *fakeQBit) handler() http.Handler {
@@ -78,7 +83,14 @@ func (f *fakeQBit) handler() http.Handler {
 				}
 			}
 		}
+		// f.mu is already held for the duration of this handler (deferred
+		// unlock at the top), so read addJSON directly — do not re-lock.
+		useJSON := f.addJSON
 		w.WriteHeader(http.StatusOK)
+		if useJSON {
+			w.Write([]byte(`{"added_torrent_ids":["abc"],"failure_count":0,"pending_count":0,"success_count":1}`))
+			return
+		}
 		w.Write([]byte("Ok."))
 	})
 	return mux
@@ -162,6 +174,23 @@ func TestAdd_MagnetURI_SubmitsURLField(t *testing.T) {
 	}
 	if fake.lastBody != payload.MagnetURI {
 		t.Errorf("urls form field = %q", fake.lastBody)
+	}
+}
+
+// TestAdd_JSONSuccessResponse_NotRejected guards against a regression where
+// newer qBittorrent answers /torrents/add with a JSON summary whose
+// "failure_count" field contains the substring "fail". A naive substring
+// check turned that success into a false "qbittorrent rejected torrent"
+// error, so deliveries were never recorded and the scheduler retried forever.
+func TestAdd_JSONSuccessResponse_NotRejected(t *testing.T) {
+	srv, fake := newServer(t)
+	fake.addJSON = true
+	p := &plugin{sessions: map[string]*session{}}
+
+	cfg, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
+	payload := &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:abc"}
+	if err := p.Add(context.Background(), cfg, payload, domain.AddOptions{}); err != nil {
+		t.Fatalf("Add against a JSON-summary server: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes the two qBittorrent issues that surfaced once the nightly E2E got past the database (after the PGDATA fix #41). Both stem from qBittorrent version drift.

## 1. Plugin: successful add misread as a rejection (production bug)
Newer qBittorrent answers `POST /torrents/add` (multipart) with a JSON summary instead of `Ok.`:
```json
{"added_torrent_ids":["…"],"failure_count":0,"pending_count":0,"success_count":1}
```
The old check — `strings.Contains(toLower(body), "fail")` — matches the **`failure_count`** field name, so every successful push became `"qbittorrent rejected torrent"`. Effect in production: deliveries are never recorded and the scheduler retries the same torrent every tick, even though qBit added it.

**Fix:** parse the JSON summary (`success`/`failure`/`pending` counts); fall back to the legacy `"Fails."` string contract for older servers. Added `TestAdd_JSONSuccessResponse_NotRejected`.

## 2. E2E: verification hit a path qBittorrent rejects
Step [5] logged into the qBittorrent WebUI on the **published host port** (`34611 → 6611`). qBittorrent 5.x **Host-header validation** returns `401` when the Host port differs from its WebUI port — which the mapped port does. (The backend is unaffected: it reaches qBit at `qbittorrent:6611`.)

**Fix:** verify through Marauder's own `GET /api/v1/topics/{id}/status` (via the gateway), which exercises the real backend→qBittorrent delivery path and records `topic_deliveries`. Capture the topic id from the add response and poll status for the infohash. No more direct WebUI poking.

## Root cause confirmed by reproduction
- Reproduced the `401` against `linuxserver/qbittorrent` v5.1.4: login succeeds only when the Host header port matches `6611`.
- The CI log shows the backend receiving the JSON add-response that tripped the substring check.

## Test plan
- `go build/vet` + `go test -race ./...` (full backend) green locally.
- New unit test covers the JSON add-response.
- After merge, run E2E via `workflow_dispatch` to confirm the full walkthrough goes green.

Depends only on #41 (already merged). Independent of #42/#43.