### PR TITLE
fix(kinozal): resolve infohash from get_srv_details, add metadata, mark validated (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Kinozal metadata resolution** (`WithMetadata`): the AddTopic form now
+  resolves a real title + poster from a Kinozal topic URL (cp1251-decoded
+  `<title>` + `og:image`), matching the RuTracker/LostFilm experience.
+
+### Changed
+
+- **Kinozal is now validated end-to-end** and promoted from `alpha` to
+  `validated` on marauder.cc. Verified against a live account: login,
+  infohash resolution, metadata, and download → torrent-client delivery.
+
+### Fixed
+
+- **Kinozal checks reported `no infohash found in topic page`** (#48): the
+  plugin scraped the details page, which doesn't carry the hash. It now reads
+  the infohash from the authenticated `get_srv_details.php?id=<id>&action=2`
+  endpoint and tolerates both `Инфо хеш` / `Инфо хэш` spellings.
+- **AddTopic display name** kept the previous tracker's title when the URL was
+  changed; an auto-filled name now refreshes on URL change while a user-typed
+  name is preserved.
+
 ## [1.0.2] - 2026-06-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,7 +320,7 @@ public `/series/<slug>/seasons` page, reuses the episode parser); the
 AddTopic form uses it to constrain the "start from" season/episode
 selectors to released values.
 
-`WithMetadata` (RuTracker, LostFilm) resolves a real title + poster image
+`WithMetadata` (RuTracker, LostFilm, Kinozal) resolves a real title + poster image
 from a topic URL. It is called best-effort (fail-open, short timeout) at add
 time so a new topic shows a real name + image immediately instead of a
 "RuTracker topic 123" placeholder, and powers `GET /api/v1/trackers/preview?url=`

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ What works **today**:
 - English + Russian UI.
 
 **Validated end-to-end**: the generic magnet and `.torrent`-URL paths,
-the Torznab/Newznab indexer adapters, and the **RuTracker** and
-**LostFilm** plugins (the latter including interactive captcha login),
-each against a live target.
+the Torznab/Newznab indexer adapters, and the **RuTracker**, **LostFilm**
+(including interactive captcha login), and **Kinozal** plugins, each
+against a live target.
 
-What's still **alpha**: the other 10 CIS forum-tracker plugins
-(Kinozal, NNM-Club, Anilibria, Anidub, Rutor, Toloka, Unionpeer,
+What's still **alpha**: the other 9 CIS forum-tracker plugins
+(NNM-Club, Anilibria, Anidub, Rutor, Toloka, Unionpeer,
 Tapochek, Free-Torrents, HD-Club) are structurally complete with
 fixture-based tests but have not been validated against live sites —
 that requires real account credentials and is the first thing

--- a/backend/internal/plugins/trackers/forumcommon/text.go
+++ b/backend/internal/plugins/trackers/forumcommon/text.go
@@ -1,0 +1,34 @@
+package forumcommon
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
+)
+
+// DecodeWindows1251 converts a windows-1251 (Cyrillic) byte string into UTF-8.
+// Several Russian forum trackers (RuTracker, Kinozal) serve cp1251, whose
+// Cyrillic high bytes are invalid UTF-8 — so we only transcode when the input
+// is NOT already valid UTF-8. That keeps ASCII and already-UTF-8 sources
+// untouched while fixing real cp1251 titles. On a decode error the input is
+// returned as-is rather than dropped. This matters because undecoded cp1251
+// Cyrillic is invalid UTF-8 and Postgres rejects it (SQLSTATE 22021) on write.
+func DecodeWindows1251(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	out, err := charmap.Windows1251.NewDecoder().String(s)
+	if err != nil {
+		return s
+	}
+	return out
+}
+
+// CleanTitle decodes a raw <title> match from windows-1251, trims it, and
+// strips the given site suffix (e.g. " :: RuTracker.org"). Shared by the forum
+// trackers' Check and ResolveMetadata so display names stay consistent.
+func CleanTitle(raw, siteSuffix string) string {
+	t := strings.TrimSpace(DecodeWindows1251(raw))
+	return strings.TrimSuffix(t, siteSuffix)
+}

--- a/backend/internal/plugins/trackers/forumcommon/text_test.go
+++ b/backend/internal/plugins/trackers/forumcommon/text_test.go
@@ -1,0 +1,24 @@
+package forumcommon
+
+import (
+	"testing"
+
+	"golang.org/x/text/encoding/charmap"
+)
+
+func TestCleanTitle_DecodesWindows1251AndStripsSuffix(t *testing.T) {
+	cp1251, err := charmap.Windows1251.NewEncoder().String("Голод / Hunger :: RuTracker.org")
+	if err != nil {
+		t.Fatalf("encode cp1251: %v", err)
+	}
+	if got := CleanTitle(cp1251, " :: RuTracker.org"); got != "Голод / Hunger" {
+		t.Errorf("CleanTitle = %q, want %q", got, "Голод / Hunger")
+	}
+}
+
+func TestDecodeWindows1251_AlreadyUTF8_Unchanged(t *testing.T) {
+	in := "Plain ASCII and УТФ-8 текст"
+	if got := DecodeWindows1251(in); got != in {
+		t.Errorf("DecodeWindows1251 = %q, want %q", got, in)
+	}
+}

--- a/backend/internal/plugins/trackers/kinozal/kinozal.go
+++ b/backend/internal/plugins/trackers/kinozal/kinozal.go
@@ -4,10 +4,9 @@
 // RuTracker but the URL pattern is /details.php?id=<topic_id> and the
 // download link is /download.php?id=<topic_id>.
 //
-// **Validation status:** structurally complete with fixture-based unit
-// tests. Live validation requires Kinozal credentials and was not
-// performed in the original implementation session — see CONTRIBUTING.md
-// for the procedure to validate against a real account.
+// **Validation status:** verified end-to-end against a live Kinozal account
+// (2026-06) — login, infohash resolution via get_srv_details.php, metadata
+// (title + poster), and download → torrent-client delivery all confirmed.
 package kinozal
 
 import (
@@ -25,6 +24,9 @@ import (
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
+
+// siteSuffix is the " :: Кинозал.ТВ" tail Kinozal appends to every <title>.
+const siteSuffix = " :: Кинозал.ТВ"
 
 const (
 	pluginName    = "kinozal"
@@ -120,7 +122,7 @@ func (p *plugin) Verify(ctx context.Context, creds *domain.TrackerCredential) (b
 	req.Header.Set("User-Agent", userAgent)
 	resp, err := sess.Client.Do(req)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("kinozal verify: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
@@ -134,11 +136,55 @@ func (p *plugin) Verify(ctx context.Context, creds *domain.TrackerCredential) (b
 // --- Check / Download --------------------------------------------------
 
 var (
-	titleRe   = regexp.MustCompile(`(?s)<title>([^<]+)</title>`)
-	hashRe    = regexp.MustCompile(`(?i)Инфо хэш[^A-Z0-9]+([A-Fa-f0-9]{40})`)
-	hashAltRe = regexp.MustCompile(`(?i)Info[\s_-]?hash[^A-Z0-9]+([A-Fa-f0-9]{40})`)
+	titleRe = regexp.MustCompile(`(?s)<title>([^<]+)</title>`)
+	// hashRe matches the live label "Инфо хеш" (хеш, Cyrillic е) and tolerates
+	// the older "Инфо хэш" (э) spelling + variable spacing before the hash.
+	hashRe    = regexp.MustCompile(`(?i)Инфо\s*х[эе]ш[^A-Za-z0-9]+([A-Fa-f0-9]{40})`)
+	hashAltRe = regexp.MustCompile(`(?i)Info[\s_-]?hash[^A-Za-z0-9]+([A-Fa-f0-9]{40})`)
+
+	// ogImageRe matches <meta property="og:image" content="..."> — the poster
+	// source Kinozal emits in the page head (commonly a relative /i/poster/... URL).
+	ogImageRe = regexp.MustCompile(`(?i)<meta[^>]+property="og:image"[^>]+content="([^"]+)"`)
 )
 
+// cleanTitle decodes a raw <title> match from cp1251 and strips the site
+// suffix. Thin wrapper over the shared forumcommon helper so Check and
+// ResolveMetadata stay consistent. Decoding is mandatory: undecoded cp1251
+// Cyrillic is invalid UTF-8 and Postgres rejects it (SQLSTATE 22021) on write.
+func cleanTitle(raw string) string {
+	return forumcommon.CleanTitle(raw, siteSuffix)
+}
+
+// extractImageURL returns the og:image poster from a topic page body, made
+// absolute against the trusted host (Kinozal emits relative /i/poster/...
+// paths). Returns "" when the page exposes no poster — never fabricated.
+func extractImageURL(body []byte, host string) string {
+	m := ogImageRe.FindSubmatch(body)
+	if m == nil {
+		return ""
+	}
+	raw := strings.TrimSpace(string(m[1]))
+	switch {
+	case raw == "":
+		return ""
+	case strings.HasPrefix(raw, "http://"), strings.HasPrefix(raw, "https://"):
+		return raw
+	case strings.HasPrefix(raw, "//"):
+		return "https:" + raw
+	case strings.HasPrefix(raw, "/"):
+		return "https://" + host + raw
+	default:
+		return "https://" + host + "/" + raw
+	}
+}
+
+// Check makes TWO requests per tick: the details page for the display title,
+// then get_srv_details.php for the infohash (Kinozal exposes the hash only
+// there, not on the details page). Both run under the scheduler's single
+// checkCtx, so they share one TrackerHTTPTimeout budget. The hash is the
+// load-bearing field, so a hash-fetch failure fails the whole Check and the
+// already-fetched title is intentionally discarded — title self-heal simply
+// retries next tick rather than persisting a title with no matching hash.
 func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.TrackerCredential) (*domain.Check, error) {
 	body, err := p.fetch(ctx, topic.URL, creds)
 	if err != nil {
@@ -146,17 +192,76 @@ func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.T
 	}
 	check := &domain.Check{}
 	if m := titleRe.FindSubmatch(body); m != nil {
-		check.DisplayName = strings.TrimSpace(string(m[1]))
-		check.DisplayName = strings.TrimSuffix(check.DisplayName, " / Кинозал.ТВ")
+		check.DisplayName = cleanTitle(string(m[1]))
+	}
+	hash, err := p.fetchInfohash(ctx, topic.URL, creds)
+	if err != nil {
+		return nil, err
+	}
+	check.Hash = hash
+	return check, nil
+}
+
+// fetchInfohash pulls the torrent infohash from get_srv_details.php?id=...&action=2.
+// Kinozal does NOT render the hash on the details page — it lives only in this
+// authenticated AJAX endpoint's response ("Инфо хеш: <40 hex>"). The URL is
+// rebuilt from the trusted domain + numeric id (never the raw user URL) to
+// avoid request forgery (CodeQL go/request-forgery), mirroring Download.
+func (p *plugin) fetchInfohash(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", fmt.Errorf("kinozal: parse url: %w", err)
+	}
+	id, err := strconv.Atoi(u.Query().Get("id"))
+	if err != nil {
+		return "", fmt.Errorf("kinozal: topic id: %w", err)
+	}
+	srvURL := fmt.Sprintf("https://%s/get_srv_details.php?id=%d&action=2", p.domain, id)
+	body, err := p.fetch(ctx, srvURL, creds)
+	if err != nil {
+		return "", fmt.Errorf("kinozal: get_srv_details: %w", err)
 	}
 	if m := hashRe.FindSubmatch(body); m != nil {
-		check.Hash = strings.ToLower(string(m[1]))
-	} else if m := hashAltRe.FindSubmatch(body); m != nil {
-		check.Hash = strings.ToLower(string(m[1]))
-	} else {
-		return nil, errors.New("kinozal: no infohash found in topic page")
+		return strings.ToLower(string(m[1])), nil
 	}
-	return check, nil
+	if m := hashAltRe.FindSubmatch(body); m != nil {
+		return strings.ToLower(string(m[1])), nil
+	}
+	return "", errors.New("kinozal: no infohash found in topic page")
+}
+
+// --- WithMetadata ------------------------------------------------------
+
+var _ registry.WithMetadata = (*plugin)(nil)
+
+// ResolveMetadata fetches the public details page and extracts a human-readable
+// title (the <title> tag, cp1251-decoded, minus the " :: Кинозал.ТВ" suffix)
+// and the og:image poster (made absolute). creds may be nil — the details page
+// is publicly viewable, so a session isn't required. Image URL is "" when the
+// page exposes no poster; the caller treats errors as fail-open.
+func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (*registry.Metadata, error) {
+	m := urlPattern.FindStringSubmatch(strings.TrimSpace(rawURL))
+	if m == nil {
+		return nil, errors.New("resolve metadata: not a kinozal details URL")
+	}
+	id, err := strconv.Atoi(m[1])
+	if err != nil {
+		return nil, fmt.Errorf("resolve metadata: topic id: %w", err)
+	}
+	// Rebuild the URL from the trusted host (p.domain) + the numeric id, never
+	// the raw user-supplied URL, so a crafted URL cannot redirect the request
+	// to an arbitrary host (CodeQL go/request-forgery). Mirrors Download.
+	canonical := fmt.Sprintf("https://%s/details.php?id=%d", p.domain, id)
+	body, err := p.fetch(ctx, canonical, creds)
+	if err != nil {
+		return nil, fmt.Errorf("resolve metadata: %w", err)
+	}
+	meta := &registry.Metadata{}
+	if mt := titleRe.FindSubmatch(body); mt != nil {
+		meta.Title = cleanTitle(string(mt[1]))
+	}
+	meta.ImageURL = extractImageURL(body, p.domain)
+	return meta, nil
 }
 
 func (p *plugin) Download(ctx context.Context, topic *domain.Topic, _ *domain.Check, creds *domain.TrackerCredential) (*domain.Payload, error) {
@@ -199,7 +304,7 @@ func (p *plugin) fetch(ctx context.Context, target string, creds *domain.Tracker
 	req.Header.Set("User-Agent", userAgent)
 	resp, err := sess.Client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("kinozal GET: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {

--- a/backend/internal/plugins/trackers/kinozal/kinozal_e2e_test.go
+++ b/backend/internal/plugins/trackers/kinozal/kinozal_e2e_test.go
@@ -14,11 +14,14 @@ import (
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
 
-const e2eDetailsHTML = `<html><head><title>The Movie / Кино (2026) [BDRip] [1080p] / Кинозал.ТВ</title></head>
+const e2eDetailsHTML = `<html><head><title>The Movie / Кино (2026) [BDRip] [1080p] :: Кинозал.ТВ</title></head>
 <body>
 <a href="/logout.php">Выход</a>
-<div>Инфо хэш: 0123456789ABCDEF0123456789ABCDEF01234567</div>
 </body></html>`
+
+// e2eSrvDetailsHTML mirrors the real get_srv_details.php?id=...&action=2 body —
+// the only place Kinozal exposes the infohash ("Инфо хеш: <40 hex>").
+const e2eSrvDetailsHTML = `<ul><li>Инфо хеш: 6FADE7192D2257460B7793C9096A79FE6D5012A9</li><li>Размер части торрента: 8 МБ</li></ul>`
 
 func TestE2E(t *testing.T) {
 	e2etest.RunFullPipeline(t, e2etest.Case{
@@ -30,6 +33,9 @@ func TestE2E(t *testing.T) {
 					http.SetCookie(w, &http.Cookie{Name: "uid", Value: "42"})
 					w.WriteHeader(200)
 					_, _ = w.Write([]byte(`<a href="/logout.php">Выход</a>`))
+				case strings.HasPrefix(r.URL.Path, "/get_srv_details.php"):
+					w.WriteHeader(200)
+					_, _ = w.Write([]byte(e2eSrvDetailsHTML))
 				case strings.HasPrefix(r.URL.Path, "/details.php"):
 					w.WriteHeader(200)
 					_, _ = w.Write([]byte(e2eDetailsHTML))
@@ -63,7 +69,7 @@ func TestE2E(t *testing.T) {
 			Username:  "alice",
 			SecretEnc: []byte("password123"),
 		},
-		ExpectedHash:         "0123456789abcdef0123456789abcdef01234567",
+		ExpectedHash:         "6fade7192d2257460b7793c9096a79fe6d5012a9",
 		ExpectedNameContains: "The Movie",
 	})
 }

--- a/backend/internal/plugins/trackers/kinozal/kinozal_test.go
+++ b/backend/internal/plugins/trackers/kinozal/kinozal_test.go
@@ -7,15 +7,22 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/text/encoding/charmap"
+
 	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
 
-const fixtureDetailsHTML = `<html><head><title>The Movie / Кино (2026) [BDRip] [1080p] / Кинозал.ТВ</title></head>
+const fixtureDetailsHTML = `<html><head><title>The Movie / Кино (2026) [BDRip] [1080p] :: Кинозал.ТВ</title></head>
 <body>
 <a href="/logout.php">Выход</a>
-<div>Инфо хэш: 0123456789ABCDEF0123456789ABCDEF01234567</div>
 </body></html>`
+
+// fixtureSrvDetailsHTML is the real response body of
+// get_srv_details.php?id=...&action=2 captured from a live logged-in session
+// (kinozal.tv id=2136770). The infohash lives here, NOT on the details page,
+// and the label is "Инфо хеш" (хеш), not "Инфо хэш".
+const fixtureSrvDetailsHTML = `<ul><li>Инфо хеш: 6FADE7192D2257460B7793C9096A79FE6D5012A9</li><li>Размер части торрента: 8 МБ</li></ul>`
 
 func newTestPlugin(t *testing.T) *plugin {
 	t.Helper()
@@ -24,17 +31,20 @@ func newTestPlugin(t *testing.T) *plugin {
 		case strings.HasPrefix(r.URL.Path, "/takelogin.php"):
 			http.SetCookie(w, &http.Cookie{Name: "uid", Value: "42"})
 			w.WriteHeader(200)
-			w.Write([]byte(`<a href="/logout.php">Выход</a>`))
+			_, _ = w.Write([]byte(`<a href="/logout.php">Выход</a>`))
+		case strings.HasPrefix(r.URL.Path, "/get_srv_details.php"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(fixtureSrvDetailsHTML))
 		case strings.HasPrefix(r.URL.Path, "/details.php"):
 			w.WriteHeader(200)
-			w.Write([]byte(fixtureDetailsHTML))
+			_, _ = w.Write([]byte(fixtureDetailsHTML))
 		case strings.HasPrefix(r.URL.Path, "/download.php"):
 			w.Header().Set("Content-Type", "application/x-bittorrent")
 			w.WriteHeader(200)
-			w.Write([]byte("d8:announce..."))
+			_, _ = w.Write([]byte("d8:announce..."))
 		case r.URL.Path == "/":
 			w.WriteHeader(200)
-			w.Write([]byte(`<a href="/logout.php">Выход</a>`))
+			_, _ = w.Write([]byte(`<a href="/logout.php">Выход</a>`))
 		default:
 			w.WriteHeader(404)
 		}
@@ -60,7 +70,7 @@ func (s *schemeRewrite) RoundTrip(req *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(req)
 }
 
-func TestCanParse(t *testing.T) {
+func TestCanParse_KnownURLs_MatchExpected(t *testing.T) {
 	p := &plugin{}
 	cases := map[string]bool{
 		"https://kinozal.tv/details.php?id=12345":     true,
@@ -76,7 +86,7 @@ func TestCanParse(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
+func TestParse_DetailsURL_ExtractsTopicID(t *testing.T) {
 	p := &plugin{}
 	topic, err := p.Parse(context.Background(), "https://kinozal.tv/details.php?id=99999")
 	if err != nil {
@@ -87,14 +97,15 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestCheck(t *testing.T) {
+func TestCheck_ServerDetails_ResolvesHashAndTitle(t *testing.T) {
 	p := newTestPlugin(t)
 	topic := &domain.Topic{URL: "https://" + p.domain + "/details.php?id=99999"}
 	check, err := p.Check(context.Background(), topic, nil)
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
-	if check.Hash != "0123456789abcdef0123456789abcdef01234567" {
+	// Hash comes from get_srv_details.php (the details page has no hash).
+	if check.Hash != "6fade7192d2257460b7793c9096a79fe6d5012a9" {
 		t.Errorf("hash: %q", check.Hash)
 	}
 	if !strings.Contains(check.DisplayName, "The Movie") {
@@ -102,7 +113,200 @@ func TestCheck(t *testing.T) {
 	}
 }
 
-func TestDownload(t *testing.T) {
+// TestCleanTitle_DecodesWindows1251 feeds real cp1251-encoded bytes (the
+// encoding Kinozal actually serves) through cleanTitle and asserts they come
+// back as correct UTF-8 with the site suffix stripped. Guards the SQLSTATE
+// 22021 bug where undecoded cp1251 Cyrillic is rejected by Postgres on write.
+func TestCleanTitle_DecodesWindows1251(t *testing.T) {
+	cp1251, err := charmap.Windows1251.NewEncoder().String("Извне (4 сезон) / From :: Кинозал.ТВ")
+	if err != nil {
+		t.Fatalf("encode cp1251: %v", err)
+	}
+	if got := cleanTitle(cp1251); got != "Извне (4 сезон) / From" {
+		t.Errorf("cleanTitle(cp1251) = %q, want %q", got, "Извне (4 сезон) / From")
+	}
+}
+
+// TestResolveMetadata_TitleAndAbsoluteImage serves a cp1251 details page with a
+// relative og:image (exactly how kinozal.tv emits posters) and asserts the
+// title is decoded + de-suffixed and the image URL is made absolute against the
+// trusted domain.
+func TestResolveMetadata_TitleAndAbsoluteImage(t *testing.T) {
+	title, err := charmap.Windows1251.NewEncoder().String("Извне (4 сезон) / From / 2026 :: Кинозал.ТВ")
+	if err != nil {
+		t.Fatalf("encode cp1251: %v", err)
+	}
+	body := "<html><head><title>" + title + "</title>" +
+		`<meta property="og:image" content="/i/poster/2/7/2136727.jpg"></head><body></body></html>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{
+		sessions:  forumcommon.New(),
+		domain:    host,
+		transport: &schemeRewrite{},
+	}
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://kinozal.tv/details.php?id=2136770", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if meta.Title != "Извне (4 сезон) / From / 2026" {
+		t.Errorf("title = %q", meta.Title)
+	}
+	wantImg := "https://" + host + "/i/poster/2/7/2136727.jpg"
+	if meta.ImageURL != wantImg {
+		t.Errorf("image URL = %q, want %q", meta.ImageURL, wantImg)
+	}
+}
+
+// TestResolveMetadata_NoImageReturnsEmpty asserts ImageURL is "" (never
+// fabricated) when the page exposes no og:image.
+func TestResolveMetadata_NoImageReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`<html><head><title>Plain :: Кинозал.ТВ</title></head><body></body></html>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{
+		sessions:  forumcommon.New(),
+		domain:    host,
+		transport: &schemeRewrite{},
+	}
+
+	meta, err := p.ResolveMetadata(context.Background(), "https://kinozal.tv/details.php?id=1", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if meta.Title != "Plain" {
+		t.Errorf("title = %q, want %q", meta.Title, "Plain")
+	}
+	if meta.ImageURL != "" {
+		t.Errorf("image URL = %q, want empty", meta.ImageURL)
+	}
+}
+
+// TestExtractImageURL_AllArms covers every branch of the og:image
+// absolutization switch: absolute passthrough, protocol-relative, root-relative,
+// bare-relative, and the no-poster empty case (never fabricated).
+func TestExtractImageURL_AllArms(t *testing.T) {
+	const host = "kinozal.tv"
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"absolute https passthrough",
+			`<meta property="og:image" content="https://cdn.example.com/p.jpg">`,
+			"https://cdn.example.com/p.jpg",
+		},
+		{
+			"protocol-relative gets https",
+			`<meta property="og:image" content="//cdn.example.com/p.jpg">`,
+			"https://cdn.example.com/p.jpg",
+		},
+		{
+			"root-relative against host",
+			`<meta property="og:image" content="/i/poster/2/7/2136727.jpg">`,
+			"https://kinozal.tv/i/poster/2/7/2136727.jpg",
+		},
+		{
+			"bare-relative gets slash + host",
+			`<meta property="og:image" content="i/poster/x.jpg">`,
+			"https://kinozal.tv/i/poster/x.jpg",
+		},
+		{
+			"no og:image returns empty",
+			`<html><head><title>No poster</title></head></html>`,
+			"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractImageURL([]byte(tc.body), host); got != tc.want {
+				t.Errorf("extractImageURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFetchInfohash_LabelSpellings pins the regex tolerance: the live "Инфо хеш"
+// (хеш), the legacy "Инфо хэш" (хэш), the English fallback, and the
+// no-hash-present case which must return the "no infohash found" error #48 fixed.
+func TestFetchInfohash_LabelSpellings(t *testing.T) {
+	const wantHash = "6fade7192d2257460b7793c9096a79fe6d5012a9"
+	cases := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{"cyrillic хеш (live)", `<li>Инфо хеш: 6FADE7192D2257460B7793C9096A79FE6D5012A9</li>`, wantHash, false},
+		{"cyrillic хэш (legacy)", `<li>Инфо хэш: 6FADE7192D2257460B7793C9096A79FE6D5012A9</li>`, wantHash, false},
+		{"english Info hash fallback", `<div>Info hash: 6FADE7192D2257460B7793C9096A79FE6D5012A9</div>`, wantHash, false},
+		{"no hash present", `<ul><li>Размер части торрента: 8 МБ</li></ul>`, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.body
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(body))
+			}))
+			t.Cleanup(srv.Close)
+			host := strings.TrimPrefix(srv.URL, "http://")
+			p := &plugin{sessions: forumcommon.New(), domain: host, transport: &schemeRewrite{}}
+
+			hash, err := p.fetchInfohash(context.Background(), "https://kinozal.tv/details.php?id=99999", nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got hash %q", hash)
+				}
+				if !strings.Contains(err.Error(), "no infohash found") {
+					t.Errorf("error = %v, want it to contain 'no infohash found'", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fetchInfohash: %v", err)
+			}
+			if hash != tc.want {
+				t.Errorf("hash = %q, want %q", hash, tc.want)
+			}
+		})
+	}
+}
+
+// TestCheck_NoInfohash_PropagatesError asserts the #48 failure mode surfaces:
+// a get_srv_details response without a hash makes Check return the
+// "no infohash found" error rather than a hash-less success.
+func TestCheck_NoInfohash_PropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/get_srv_details.php") {
+			_, _ = w.Write([]byte(`<ul><li>Размер части торрента: 8 МБ</li></ul>`)) // no hash
+			return
+		}
+		_, _ = w.Write([]byte(fixtureDetailsHTML))
+	}))
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{sessions: forumcommon.New(), domain: host, transport: &schemeRewrite{}}
+
+	topic := &domain.Topic{URL: "https://" + p.domain + "/details.php?id=99999"}
+	_, err := p.Check(context.Background(), topic, nil)
+	if err == nil || !strings.Contains(err.Error(), "no infohash found") {
+		t.Fatalf("Check error = %v, want it to contain 'no infohash found'", err)
+	}
+}
+
+func TestDownload_ValidTopic_ReturnsTorrentBytes(t *testing.T) {
 	p := newTestPlugin(t)
 	topic := &domain.Topic{
 		URL:   "https://" + p.domain + "/details.php?id=99999",

--- a/backend/internal/plugins/trackers/rutracker/rutracker.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker.go
@@ -28,9 +28,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"unicode/utf8"
-
-	"golang.org/x/text/encoding/charmap"
 
 	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
@@ -171,30 +168,12 @@ var (
 	postImgSrcRe = regexp.MustCompile(`(?i)<img[^>]+class="[^"]*postImg[^"]*"[^>]+src="([^"]+)"`)
 )
 
-// cleanTitle decodes a raw <title> match from windows-1251 (the encoding
-// RuTracker serves its pages in), trims it, and strips the site suffix.
-// Shared by Check and ResolveMetadata so both stay consistent. Without the
-// decode the Cyrillic bytes are invalid UTF-8 — they render as mojibake and
-// Postgres rejects them (SQLSTATE 22021) on write.
+// cleanTitle decodes a raw <title> match from cp1251 and strips the site
+// suffix. Thin wrapper over the shared forumcommon helper so Check and
+// ResolveMetadata stay consistent. Decoding is mandatory: undecoded cp1251
+// Cyrillic is invalid UTF-8 and Postgres rejects it (SQLSTATE 22021) on write.
 func cleanTitle(raw string) string {
-	t := strings.TrimSpace(decodeWindows1251(raw))
-	return strings.TrimSuffix(t, " :: RuTracker.org")
-}
-
-// decodeWindows1251 converts a windows-1251 (Cyrillic) byte string into UTF-8.
-// RuTracker serves cp1251, whose Cyrillic high bytes are invalid UTF-8 — so we
-// only transcode when the input is NOT already valid UTF-8. That keeps ASCII
-// and any already-UTF-8 source untouched while fixing real cp1251 titles. On a
-// decode error the input is returned as-is rather than dropped.
-func decodeWindows1251(s string) string {
-	if utf8.ValidString(s) {
-		return s
-	}
-	out, err := charmap.Windows1251.NewDecoder().String(s)
-	if err != nil {
-		return s
-	}
-	return out
+	return forumcommon.CleanTitle(raw, " :: RuTracker.org")
 }
 
 // extractImageURL returns the first poster image URL from a topic page body,

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -160,7 +160,14 @@ on the next check.
 | **URL format** | `https://kinozal.tv/details.php?id=<id>` |
 
 Russian movie / TV tracker. Same one-thread-one-topic model as
-RuTracker. Hash is the modification timestamp on the page.
+RuTracker. The infohash is read from the authenticated
+`get_srv_details.php?id=<id>&action=2` endpoint (the details page itself
+doesn't expose it); the display title + poster come from the details
+page `<title>` (cp1251-decoded) and `og:image`.
+
+**Validation status:** verified end-to-end against a live Kinozal account
+(2026-06) — login, infohash resolution, metadata, and download → client
+delivery all confirmed.
 
 ### NNM-Club
 

--- a/frontend/src/components/topics/TopicForm.tsx
+++ b/frontend/src/components/topics/TopicForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 
@@ -72,6 +72,11 @@ export function TopicForm({
   const isEdit = mode === "edit";
   const [url] = useState(initial.url);
   const [displayName, setDisplayName] = useState(initial.displayName);
+  // Tracks whether the current display name came from auto-fill (vs typed by
+  // the user). A ref, not state, so it never triggers a re-render — it only
+  // gates whether a new preview may replace the name. Flipped false the moment
+  // the user edits the field, so a typed name is never clobbered.
+  const nameAutoFilled = useRef(false);
   const [quality, setQuality] = useState(initial.quality);
   const [startSeason, setStartSeason] = useState(initial.startSeason);
   const [startEpisode, setStartEpisode] = useState(initial.startEpisode);
@@ -149,21 +154,31 @@ export function TopicForm({
     }
   }, [match, quality]);
 
-  // Prefill the display name from the resolved preview title, but never
-  // overwrite a name the user typed or one prefilled from an existing topic.
+  // Prefill the display name from the resolved preview title. Fills when the
+  // field is empty OR still holds a previously auto-filled value (so switching
+  // the URL to a different tracker repopulates it), but never overwrites a name
+  // the user typed or one prefilled from an existing topic.
   useEffect(() => {
-    if (!isEdit && preview?.title && !displayName) {
+    if (isEdit || !preview?.title) return;
+    if (!displayName || nameAutoFilled.current) {
       setDisplayName(preview.title);
+      nameAutoFilled.current = true;
     }
   }, [preview, isEdit, displayName]);
 
-  // Reset the season/episode selection whenever the URL changes in the add
-  // flow. Skipped in edit mode where the URL is fixed and the initial
-  // season/episode must survive (otherwise prefill would be wiped).
+  // Reset URL-derived fields whenever the URL changes in the add flow: the
+  // season/episode selection, and any auto-filled display name (so a stale
+  // title doesn't linger before the new preview arrives). A user-typed name is
+  // preserved. Skipped in edit mode where the URL is fixed and the prefilled
+  // values must survive.
   useEffect(() => {
     if (isEdit) return;
     setStartSeason("");
     setStartEpisode("");
+    if (nameAutoFilled.current) {
+      setDisplayName("");
+      nameAutoFilled.current = false;
+    }
   }, [debouncedUrl, isEdit]);
 
   // Delivery field (client/dir/category) state lives in a single object to
@@ -232,7 +247,10 @@ export function TopicForm({
         <Input
           id="display"
           value={displayName}
-          onChange={(e) => setDisplayName(e.target.value)}
+          onChange={(e) => {
+            setDisplayName(e.target.value);
+            nameAutoFilled.current = false;
+          }}
           placeholder="Leave blank to auto-detect"
         />
       </div>

--- a/frontend/src/pages/Topics.test.tsx
+++ b/frontend/src/pages/Topics.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type ReactNode } from "react";
@@ -21,6 +21,7 @@ vi.mock("@/lib/api", async () => {
       put: vi.fn(),
       del: vi.fn(),
       updateTopic: vi.fn(),
+      previewTracker: vi.fn(),
     },
   };
 });
@@ -31,6 +32,7 @@ const mockApi = api as unknown as {
   get: ReturnType<typeof vi.fn>;
   post: ReturnType<typeof vi.fn>;
   updateTopic: ReturnType<typeof vi.fn>;
+  previewTracker: ReturnType<typeof vi.fn>;
 };
 
 const LOSTFILM_URL = "https://www.lostfilm.tv/series/Some_Show/seasons";
@@ -171,6 +173,85 @@ describe("AddTopicCard — season/episode catalog dropdowns", () => {
     const episodeInput = screen.getByLabelText(/start from episode/i);
     expect(episodeInput.tagName).toBe("INPUT");
     expect(episodeInput).toHaveAttribute("type", "number");
+  });
+});
+
+describe("AddTopicCard — display name auto-fill on URL change", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Routes /trackers/match and /trackers/preview to tracker-specific values
+  // keyed off the URL, so switching the URL changes both responses.
+  function routeMatchAndPreviewByUrl() {
+    mockApi.get.mockImplementation((path: string) => {
+      if (path.startsWith("/trackers/match")) {
+        const tracker = path.includes("kinozal") ? "kinozal" : "rutracker";
+        return Promise.resolve({
+          tracker_name: tracker,
+          display_name: tracker,
+          supports_episode_filter: false,
+          supports_season_catalog: false,
+          requires_credentials: false,
+          uses_cloudflare: false,
+        });
+      }
+      if (path.startsWith("/clients")) return Promise.resolve(clientsList);
+      return Promise.resolve({ credentials: [] });
+    });
+    mockApi.previewTracker.mockImplementation((url: string) =>
+      Promise.resolve(
+        url.includes("kinozal")
+          ? { title: "Kinozal Show", image_url: "" }
+          : { title: "RuTracker Show", image_url: "" },
+      ),
+    );
+  }
+
+  const RUTRACKER_URL = "https://rutracker.org/forum/viewtopic.php?t=1";
+  const KINOZAL_URL = "https://kinozal.tv/details.php?id=2136770";
+
+  it("replaces an auto-filled name when the URL changes to a different tracker", async () => {
+    const user = userEvent.setup();
+    routeMatchAndPreviewByUrl();
+
+    renderCard();
+    const urlInput = screen.getByLabelText(/url or magnet link/i);
+    await user.type(urlInput, RUTRACKER_URL);
+
+    const displayInput = (await screen.findByLabelText(
+      /display name/i,
+    )) as HTMLInputElement;
+    await waitFor(() => expect(displayInput.value).toBe("RuTracker Show"));
+
+    await user.clear(urlInput);
+    await user.type(urlInput, KINOZAL_URL);
+
+    await waitFor(() => expect(displayInput.value).toBe("Kinozal Show"));
+  });
+
+  it("keeps a user-typed name even when the URL changes", async () => {
+    const user = userEvent.setup();
+    routeMatchAndPreviewByUrl();
+
+    renderCard();
+    const urlInput = screen.getByLabelText(/url or magnet link/i);
+    await user.type(urlInput, RUTRACKER_URL);
+
+    const displayInput = (await screen.findByLabelText(
+      /display name/i,
+    )) as HTMLInputElement;
+    await user.clear(displayInput);
+    await user.type(displayInput, "My Custom Name");
+
+    await user.clear(urlInput);
+    await user.type(urlInput, KINOZAL_URL);
+
+    // User intent wins: the auto-fill must not clobber a typed name.
+    await waitFor(() =>
+      expect(mockApi.previewTracker).toHaveBeenCalledWith(KINOZAL_URL),
+    );
+    expect(displayInput.value).toBe("My Custom Name");
   });
 });
 

--- a/site/src/data/trackerPages.ts
+++ b/site/src/data/trackerPages.ts
@@ -122,9 +122,9 @@ export const trackerPages: TrackerPageContent[] = [
     ],
     faq: [
       {
-        question: "What does the 'alpha' label on Kinozal mean?",
+        question: "Is the Kinozal integration ready to use?",
         answer:
-          "The Kinozal plugin is structurally complete and unit-tested against fixture HTML, but hasn't yet been validated end-to-end against a live account. It will work if the live page matches the fixtures; it may need a selector tweak if the site changed. Community validation is welcome.",
+          "Yes. The Kinozal plugin is verified end-to-end against a live account — login, infohash detection (read from Kinozal's get_srv_details endpoint), metadata (title + poster), and download to your torrent client are all confirmed working as of June 2026.",
       },
     ],
   },

--- a/site/src/data/trackers.ts
+++ b/site/src/data/trackers.ts
@@ -52,7 +52,7 @@ export const trackers: Tracker[] = [
     category: "forum-cis",
     region: "RU",
     auth: "account",
-    status: "alpha",
+    status: "validated",
   },
   {
     slug: "nnmclub",


### PR DESCRIPTION
## Summary

- **Fixes #48** — Kinozal topic checks failed with `kinozal: no infohash found in topic page`. The plugin scraped the details page, which doesn't carry the hash. It now reads the infohash from the authenticated `get_srv_details.php?id=<id>&action=2` endpoint and tolerates both `Инфо хеш` / `Инфо хэш` spellings.
- **Kinozal metadata** (`WithMetadata`) — resolves a real cp1251-decoded title + `og:image` poster from the topic URL, so a new topic shows its real name and poster at add time (matching RuTracker/LostFilm).
- **Frontend fix** — the AddTopic form kept the previous tracker's auto-filled title when the URL changed; an auto-filled name now refreshes on URL change while a user-typed name is preserved.
- **Refactor** — shared cp1251 decode + title cleanup extracted to `forumcommon` (`DecodeWindows1251`, `CleanTitle`); RuTracker and Kinozal delegate.
- **Docs** — Kinozal promoted from `alpha` to `validated` on marauder.cc, README, and CHANGELOG; corrected the `trackers.md` hash note.

## Verification

Verified **end-to-end against a live Kinozal account**: login, infohash resolution, metadata, and download → Transmission delivery all confirmed (real topic check resolved hash `657e573b…`, delivery recorded with the decoded Russian title).

## Test Plan

- Backend: `go build ./... && go vet ./... && go test -race ./...` — full suite green (kinozal, rutracker, forumcommon included).
- Frontend: `npm run typecheck && npm test` — 37 tests pass, including the new display-name auto-fill cases.
- Site: `npm run build` — 0 errors/warnings, 16 pages.
- New coverage: `get_srv_details` хеш/хэш/English/no-hash branches, the `no infohash found` error path (#48's own failure mode), and all `extractImageURL` arms.

## Commits

1. `refactor(forumcommon): share cp1251 decode and title cleanup`
2. `fix(kinozal): resolve infohash and metadata from correct endpoints`
3. `fix(topics): refresh auto-filled display name when URL changes`
4. `docs: mark Kinozal integration as validated`
