### PR TITLE
ci: auto-release on PR merge with semver bump and issue notify

### DIFF
--- a/.github/scripts/release-helpers.sh
+++ b/.github/scripts/release-helpers.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# release-helpers.sh — pure-function helpers for the auto-release pipeline.
+#
+# Extracted from workflow YAML so the risky parsing (Conventional Commit ->
+# semver bump, next-version arithmetic, issue-number extraction) is unit
+# testable. See release-helpers_test.sh.
+#
+# Subcommands:
+#   bump-level   "<pr-title>" "<pr-body>"   -> major|minor|patch|none
+#   next-version <latest-tag>  <level>      -> X.Y.Z
+#   issue-refs   "<pr-body>"   "<branch>"   -> newline-separated issue numbers
+#   unreleased-body                         -> CHANGELOG [Unreleased] body (stdin)
+#   roll-changelog <ver> <date> [h] [bul]   -> rolled CHANGELOG (stdin -> stdout)
+#
+# All output goes to stdout; the script is side-effect free (roll-changelog and
+# unreleased-body read CHANGELOG from stdin and never touch the filesystem).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------- bump-level
+#
+# Maps a merged PR's Conventional Commit title (the squash subject) to a semver
+# bump level. Only version-bumping types produce a release:
+#   feat!  / BREAKING CHANGE  -> major
+#   feat                      -> minor
+#   fix / perf                -> patch
+#   everything else           -> none   (chore/docs/ci/test/refactor/build/...)
+bump_level() {
+  local title="$1" body="${2:-}"
+
+  # Breaking change wins regardless of type:
+  #   - a "!" before the colon in the title  (feat!: / fix(scope)!: ...)
+  #   - a "BREAKING CHANGE:" / "BREAKING-CHANGE:" line anywhere in the body
+  if [[ "$title" =~ ^[a-zA-Z]+(\([^\)]*\))?! ]]; then
+    echo "major"; return
+  fi
+  if printf '%s' "$body" | grep -qiE '(^|[[:space:]])BREAKING[ -]CHANGE:'; then
+    echo "major"; return
+  fi
+
+  # Extract the leading type token (letters before an optional "(scope)" / "!"
+  # / ":"). Lowercased for a case-insensitive match.
+  local type
+  type=$(printf '%s' "$title" | sed -E 's/^([a-zA-Z]+).*/\1/' | tr '[:upper:]' '[:lower:]')
+
+  case "$type" in
+    feat)       echo "minor" ;;
+    fix|perf)   echo "patch" ;;
+    *)          echo "none"  ;;
+  esac
+}
+
+# -------------------------------------------------------------- next-version
+#
+# Given the latest "vX.Y.Z" tag (or empty for a first release) and a bump
+# level, prints the next version WITHOUT the leading "v". A higher bump zeroes
+# the lower components. Any pre-release suffix on the latest tag is ignored.
+next_version() {
+  local latest="$1" level="$2"
+
+  # Strip leading "v" and any "-prerelease"/"+build" suffix, then default
+  # missing components to 0.
+  local core="${latest#v}"
+  core="${core%%-*}"
+  core="${core%%+*}"
+  [[ -z "$core" ]] && core="0.0.0"
+
+  local major minor patch
+  major="${core%%.*}";              major="${major:-0}"
+  local rest="${core#*.}"
+  minor="${rest%%.*}";              minor="${minor:-0}"
+  patch="${rest#*.}";               patch="${patch:-0}"
+  # Guard against malformed tags leaving non-numerics.
+  [[ "$major" =~ ^[0-9]+$ ]] || major=0
+  [[ "$minor" =~ ^[0-9]+$ ]] || minor=0
+  [[ "$patch" =~ ^[0-9]+$ ]] || patch=0
+
+  case "$level" in
+    major) major=$((major + 1)); minor=0; patch=0 ;;
+    minor) minor=$((minor + 1)); patch=0 ;;
+    patch) patch=$((patch + 1)) ;;
+    *) echo "next-version: unknown level '$level'" >&2; return 1 ;;
+  esac
+
+  echo "${major}.${minor}.${patch}"
+}
+
+# ---------------------------------------------------------------- issue-refs
+#
+# Extracts GitHub issue numbers a merged PR should notify, from two sources:
+#   1. Closing keywords in the PR body: Close(s|d) / Fix(es|ed) / Resolve(s|d)
+#      followed by "#<n>" (case-insensitive, GitHub's own keyword set).
+#   2. A leading issue-number branch prefix, e.g. "48-kinozal-...".
+# Output is newline-separated, numerically sorted, de-duplicated.
+issue_refs() {
+  local body="${1:-}" branch="${2:-}"
+  {
+    # Closing keywords -> #<n>. grep -o the whole match, then keep digits.
+    printf '%s' "$body" \
+      | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+      | grep -oE '[0-9]+' || true
+
+    # Leading numeric branch prefix.
+    if [[ "$branch" =~ ^([0-9]+) ]]; then
+      echo "${BASH_REMATCH[1]}"
+    fi
+  } | sort -n -u
+}
+
+# ----------------------------------------------------------- unreleased-body
+#
+# Prints the body lines of the "## [Unreleased]" section (everything between
+# that heading and the next "## " heading), read from CHANGELOG on stdin. Used
+# to decide whether the developer forgot to fill in the changelog.
+unreleased_body() {
+  awk '
+    $0 == "## [Unreleased]" {flag=1; next}
+    /^## / && flag {flag=0}
+    flag {print}
+  '
+}
+
+# ----------------------------------------------------------- roll-changelog
+#
+# Reads CHANGELOG.md on stdin and prints a rolled copy on stdout:
+#   - "## [Unreleased]"  becomes  "## [<ver>] - <date>"  (its content moves
+#     under the released version), and a fresh empty "## [Unreleased]" block is
+#     inserted above it.
+#   - If a heading + bullet are given (passed by the caller only when the
+#     Unreleased body was empty), they are injected under the new version
+#     heading so the release notes are never blank.
+roll_changelog() {
+  local ver="$1" date="$2" heading="${3:-}" bullet="${4:-}"
+  awk -v ver="$ver" -v date="$date" -v heading="$heading" -v bullet="$bullet" '
+    $0 == "## [Unreleased]" && !done {
+      print "## [Unreleased]"
+      print ""
+      print "## [" ver "] - " date
+      if (heading != "") {
+        print ""
+        print "### " heading
+        print ""
+        print "- " bullet
+      }
+      done=1
+      next
+    }
+    { print }
+  '
+}
+
+# ---------------------------------------------------------------- dispatch
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    bump-level)     bump_level     "${1:-}" "${2:-}" ;;
+    next-version)   next_version   "${1:-}" "${2:-}" ;;
+    issue-refs)     issue_refs     "${1:-}" "${2:-}" ;;
+    unreleased-body) unreleased_body ;;
+    roll-changelog) roll_changelog "${1:-}" "${2:-}" "${3:-}" "${4:-}" ;;
+    *)
+      echo "usage: $0 {bump-level|next-version|issue-refs|unreleased-body|roll-changelog} ..." >&2
+      return 2
+      ;;
+  esac
+}
+
+# Only run main when executed directly (so the test can source the functions).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.github/scripts/release-helpers_test.sh
+++ b/.github/scripts/release-helpers_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Table-driven tests for release-helpers.sh. Runnable locally and in CI:
+#   bash .github/scripts/release-helpers_test.sh
+# Exits non-zero on the first failing assertion's tally.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=release-helpers.sh
+source "$DIR/release-helpers.sh"
+
+pass=0
+fail=0
+
+check() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: %s\n  expected: %q\n  actual:   %q\n' "$desc" "$expected" "$actual"
+  fi
+}
+
+# --------------------------------------------------------------- bump-level
+check "feat -> minor"            "minor" "$(bump_level 'feat: add seasons catalog' '')"
+check "feat(scope) -> minor"     "minor" "$(bump_level 'feat(topics): per-topic dir' '')"
+check "fix -> patch"             "patch" "$(bump_level 'fix(kinozal): resolve infohash' '')"
+check "perf -> patch"            "patch" "$(bump_level 'perf: cache decode' '')"
+check "feat! -> major"           "major" "$(bump_level 'feat!: drop legacy config' '')"
+check "fix(scope)! -> major"     "major" "$(bump_level 'fix(api)!: change payload' '')"
+check "body BREAKING -> major"   "major" "$(bump_level 'fix: tweak' 'line
+
+BREAKING CHANGE: removed field')"
+check "body BREAKING- -> major"  "major" "$(bump_level 'fix: tweak' 'BREAKING-CHANGE: removed field')"
+check "chore -> none"            "none"  "$(bump_level 'chore(deps): bump' '')"
+check "chore(deps,fe) -> none"   "none"  "$(bump_level 'chore(deps,frontend)(deps): bump group (#46)' '')"
+check "docs -> none"             "none"  "$(bump_level 'docs: update README' '')"
+check "ci -> none"               "none"  "$(bump_level 'ci: tweak workflow' '')"
+check "refactor -> none"         "none"  "$(bump_level 'refactor(forumcommon): share decode' '')"
+check "unknown -> none"          "none"  "$(bump_level 'wip random subject' '')"
+
+# ------------------------------------------------------------- next-version
+check "v1.0.2 patch -> 1.0.3"    "1.0.3" "$(next_version 'v1.0.2' 'patch')"
+check "v1.0.2 minor -> 1.1.0"    "1.1.0" "$(next_version 'v1.0.2' 'minor')"
+check "v1.0.2 major -> 2.0.0"    "2.0.0" "$(next_version 'v1.0.2' 'major')"
+check "1.2.3 minor -> 1.3.0"     "1.3.0" "$(next_version '1.2.3' 'minor')"
+check "v2.5.9 major -> 3.0.0"    "3.0.0" "$(next_version 'v2.5.9' 'major')"
+check "prerelease ignored"       "1.1.0" "$(next_version 'v1.0.2-rc1' 'minor')"
+check "empty tag patch -> 0.0.1" "0.0.1" "$(next_version '' 'patch')"
+check "empty tag minor -> 0.1.0" "0.1.0" "$(next_version '' 'minor')"
+
+# --------------------------------------------------------------- issue-refs
+check "closes keyword"           "12"    "$(issue_refs 'Closes #12' '')"
+check "fixes keyword"            "7"     "$(issue_refs 'this fixes #7 nicely' '')"
+check "resolved keyword"         "9"     "$(issue_refs 'Resolved #9' '')"
+check "branch prefix only"       "48"    "$(issue_refs 'no refs here' '48-kinozal-check-fails')"
+check "body + branch deduped"    "$(printf '13\n48')" "$(issue_refs 'Fixes #13' '48-foo')"
+check "same number deduped"      "5"     "$(issue_refs 'Closes #5' '5-foo-bar')"
+check "no refs -> empty"         ""      "$(issue_refs 'nothing to see' 'feature/no-issue')"
+check "multiple in body sorted"  "$(printf '3\n21')" "$(issue_refs 'Closes #21 and fixes #3' '')"
+
+# ------------------------------------------------------- changelog rolling
+SAMPLE_CL='# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- something broke
+
+## [1.0.2] - 2026-06-18
+
+### Added
+
+- a thing'
+
+# Roll renames [Unreleased] to the version and inserts a fresh empty one.
+ROLLED="$(printf '%s\n' "$SAMPLE_CL" | roll_changelog '1.1.0' '2026-06-21')"
+check "roll keeps fresh Unreleased" "1" "$(printf '%s' "$ROLLED" | grep -c '^## \[Unreleased\]$')"
+check "roll adds version heading"   "1" "$(printf '%s' "$ROLLED" | grep -c '^## \[1.1.0\] - 2026-06-21$')"
+check "roll preserves old version"  "1" "$(printf '%s' "$ROLLED" | grep -c '^## \[1.0.2\] - 2026-06-18$')"
+check "roll keeps existing entry"   "1" "$(printf '%s' "$ROLLED" | grep -c '^- something broke$')"
+# The new version heading must come AFTER the fresh Unreleased one.
+check "Unreleased before version" "ok" "$(printf '%s' "$ROLLED" | awk '/^## \[Unreleased\]$/{u=NR} /^## \[1.1.0\]/{v=NR} END{print (u<v && u>0)?"ok":"bad"}')"
+
+# unreleased-body extracts only the section content.
+check "unreleased body content" "1" "$(printf '%s\n' "$SAMPLE_CL" | unreleased_body | grep -c '^- something broke$')"
+check "unreleased body excludes old" "0" "$(printf '%s\n' "$SAMPLE_CL" | unreleased_body | grep -c '^- a thing$')"
+
+# Empty Unreleased -> body is whitespace-only.
+EMPTY_CL='# Changelog
+
+## [Unreleased]
+
+## [1.0.2] - 2026-06-18
+
+- old'
+check "empty unreleased detected" "" "$(printf '%s\n' "$EMPTY_CL" | unreleased_body | tr -d '[:space:]')"
+
+# Roll with fallback heading+bullet injects under the version heading.
+ROLLED_FB="$(printf '%s\n' "$EMPTY_CL" | roll_changelog '1.0.3' '2026-06-21' 'Fixed' 'fix(x): the real PR title')"
+check "fallback bullet injected" "1" "$(printf '%s' "$ROLLED_FB" | grep -c '^- fix(x): the real PR title$')"
+check "fallback heading injected" "1" "$(printf '%s' "$ROLLED_FB" | grep -c '^### Fixed$')"
+
+# ------------------------------------------------------------------- tally
+echo "-----------------------------------------"
+echo "release-helpers: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,165 @@
+name: Auto release on merge
+
+# Cuts a release automatically when a PR is squash-merged to main.
+#
+# It does NOT build anything itself — it derives the next semantic version from
+# the merged PR's Conventional Commit title, rolls CHANGELOG.md, and pushes an
+# annotated tag. The existing release.yml fires on that v* tag and does the
+# heavy lifting (multi-arch build, cosign, SBOM, GitHub Release, issue notify).
+#
+# The PR description and the linked issue numbers travel forward to release.yml
+# inside the annotated tag message (read there via `git tag -l --format`), so
+# the release notes can include the PR body and the linked issues can be
+# notified only AFTER the artifacts actually exist.
+#
+# Version policy (only version-bumping Conventional Commit types release):
+#   feat!/BREAKING CHANGE -> major   feat -> minor   fix/perf -> patch
+#   chore/docs/ci/test/refactor/build (incl. dependabot) -> no release.
+#
+# ONE-TIME SETUP — required for the tag push to trigger release.yml:
+#   GitHub suppresses workflow re-triggering for events raised by the built-in
+#   GITHUB_TOKEN, so a tag pushed with it would NOT start release.yml. Create a
+#   repo (or org) secret `RELEASE_PAT` — a fine-grained PAT with `contents:
+#   write` on this repo — and the tag push below uses it so release.yml fires.
+#   Without the secret the workflow still rolls the CHANGELOG and creates the
+#   tag (using GITHUB_TOKEN), but release.yml must then be started manually via
+#   its workflow_dispatch. A startup step warns when the secret is absent.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+# Serialize merges so two PRs landing back-to-back can't compute the same next
+# version off the same latest tag. Never cancel — every merge must be processed.
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # commit the CHANGELOG roll + push the tag to main
+
+jobs:
+  tag:
+    name: Compute version and tag
+    # Only real merges, never a closed-without-merge.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (full history + tags)
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          # Persist a PAT (if configured) so the `git push` of the tag below
+          # triggers release.yml. Falls back to GITHUB_TOKEN (tag created, but
+          # release.yml won't auto-start — see the header setup note).
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Warn if RELEASE_PAT is missing
+        # secrets can't be used in a step `if:`, so map presence to env and
+        # branch inside the script.
+        env:
+          HAS_PAT: ${{ secrets.RELEASE_PAT != '' }}
+        run: |
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::RELEASE_PAT secret is not set. The tag will be created with GITHUB_TOKEN, which will NOT trigger release.yml. Start release.yml manually via workflow_dispatch, or add the RELEASE_PAT secret (see auto-release.yml header)."
+          fi
+
+      - name: Determine bump and next version
+        id: ver
+        # PR title/body are attacker-controllable; pass them through env (never
+        # inline ${{ }} in run:) to avoid shell injection.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          chmod +x .github/scripts/release-helpers.sh
+          H=.github/scripts/release-helpers.sh
+
+          LEVEL="$("$H" bump-level "$PR_TITLE" "${PR_BODY:-}")"
+          echo "Bump level for '$PR_TITLE': $LEVEL"
+          if [ "$LEVEL" = "none" ]; then
+            echo "Non-version-bumping PR — no release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LATEST="$(git tag --sort=-v:refname | head -1)"
+          echo "Latest tag: ${LATEST:-<none>}"
+          VER="$("$H" next-version "${LATEST:-}" "$LEVEL")"
+          echo "Next version: $VER"
+
+          if git rev-parse -q --verify "refs/tags/v$VER" >/dev/null; then
+            echo "Tag v$VER already exists — skipping (idempotent re-run)."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
+
+      - name: Roll CHANGELOG.md
+        if: steps.ver.outputs.release == 'true'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          H=.github/scripts/release-helpers.sh
+          VER="${{ steps.ver.outputs.version }}"
+          LEVEL="${{ steps.ver.outputs.level }}"
+          DATE="$(date -u +'%Y-%m-%d')"
+
+          # If the developer forgot to fill in [Unreleased], synthesize a single
+          # bullet from the real PR title so the release notes are never blank.
+          BODY="$("$H" unreleased-body < CHANGELOG.md | tr -d '[:space:]')"
+          if [ -z "$BODY" ]; then
+            case "$LEVEL" in
+              major|minor) HEADING="Added" ;;
+              *)           HEADING="Fixed" ;;
+            esac
+            echo "::warning::[Unreleased] was empty — synthesizing a bullet from the PR title."
+            "$H" roll-changelog "$VER" "$DATE" "$HEADING" "$PR_TITLE" < CHANGELOG.md > CHANGELOG.new
+          else
+            "$H" roll-changelog "$VER" "$DATE" < CHANGELOG.md > CHANGELOG.new
+          fi
+          mv CHANGELOG.new CHANGELOG.md
+
+      - name: Commit, tag and push
+        if: steps.ver.outputs.release == 'true'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          H=.github/scripts/release-helpers.sh
+          VER="${{ steps.ver.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Commit the CHANGELOG roll to main (skip ci so it doesn't re-trigger).
+          git add CHANGELOG.md
+          git commit -m "chore(release): cut v$VER [skip ci]"
+
+          # Build the annotated-tag message: PR title + body, plus machine
+          # readable trailers release.yml parses (issue numbers + PR number).
+          ISSUES="$("$H" issue-refs "${PR_BODY:-}" "${PR_HEAD:-}" | sed 's/^/#/' | paste -sd' ' -)"
+          {
+            printf '%s\n\n' "$PR_TITLE"
+            printf '%s\n\n' "${PR_BODY:-}"
+            printf 'Issues: %s\n' "$ISSUES"
+            printf 'PR: #%s\n' "$PR_NUMBER"
+          } > .tagmsg
+
+          git tag -a "v$VER" -F .tagmsg
+          git push origin main
+          git push origin "v$VER"
+
+          echo "### :rocket: Tagged v$VER" >> "$GITHUB_STEP_SUMMARY"
+          echo "release.yml will build artifacts and publish the GitHub Release." >> "$GITHUB_STEP_SUMMARY"
+          [ -n "$ISSUES" ] && echo "Linked issues: $ISSUES" >> "$GITHUB_STEP_SUMMARY" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,20 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+  # ------------------------------------------------------- release scripts
+  # Unit-test the pure helper logic behind the auto-release pipeline
+  # (Conventional Commit -> semver bump, next-version arithmetic, issue-ref
+  # extraction, CHANGELOG rolling). Pure bash, no toolchain needed.
+  release-scripts:
+    name: Release helper tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run release-helpers tests
+        run: bash .github/scripts/release-helpers_test.sh
+
   # ---------------------------------------------------------------- frontend
   frontend:
     name: Frontend (Node ${{ matrix.node }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history + tags so the annotated tag object (carrying the PR
+          # description from auto-release.yml) is available to read locally.
+          fetch-depth: 0
 
       - name: Download SBOMs
         uses: actions/download-artifact@v8
@@ -163,6 +167,24 @@ jobs:
             echo "Marauder $TAG. See CHANGELOG.md for details." > release-notes.md
           fi
 
+          # Append the merged PR's description, carried in the annotated tag
+          # message by auto-release.yml. Everything except the machine-readable
+          # "Issues:"/"PR:" trailer lines is the PR title + body. A manually
+          # pushed tag or a workflow_dispatch run has no annotation, so this
+          # adds nothing and the behavior is unchanged.
+          PRDESC="$(git tag -l --format='%(contents)' "$TAG" 2>/dev/null \
+            | sed -E '/^(Issues|PR):[[:space:]]/d')"
+          if [ -n "$(printf '%s' "$PRDESC" | tr -d '[:space:]')" ]; then
+            {
+              echo ""
+              echo "---"
+              echo ""
+              echo "## Pull Request"
+              echo ""
+              printf '%s\n' "$PRDESC"
+            } >> release-notes.md
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -172,6 +194,69 @@ jobs:
           files: sboms/**/*.cdx.json
           draft: false
           prerelease: ${{ contains(steps.changelog.outputs.tag, '-rc') || contains(steps.changelog.outputs.tag, '-alpha') || contains(steps.changelog.outputs.tag, '-beta') }}
+
+  # --------------------------------------------------- notify linked issues
+  # Comment on every issue the released PR was linked to (closing keywords in
+  # the PR body and/or an issue-number branch prefix), telling the reporter the
+  # fix/feature shipped and how to test it. Issue numbers are read from the
+  # "Issues:" trailer in the annotated tag message that auto-release.yml wrote.
+  # Runs only AFTER the release is published, so the linked tag/images exist.
+  notify-issues:
+    name: Notify linked issues
+    needs: [release]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout (tags)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Comment on linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          VER="${TAG#v}"
+
+          # Parse "Issues: #a #b" from the annotated tag message.
+          ISSUES="$(git tag -l --format='%(contents)' "$TAG" \
+            | sed -nE 's/^Issues:[[:space:]]*//p' \
+            | grep -oE '[0-9]+' || true)"
+
+          if [ -z "$ISSUES" ]; then
+            echo "No linked issues in tag $TAG — nothing to notify."
+            exit 0
+          fi
+
+          REL_URL="https://github.com/${REPO}/releases/tag/${TAG}"
+
+          # Build the comment body in a file (avoids flush-left heredocs that
+          # would break the YAML block scalar). printf keeps every line indented
+          # as run-block content while emitting unindented markdown.
+          {
+            printf ':rocket: **Released in [%s](%s).**\n\n' "$TAG" "$REL_URL"
+            printf 'This shipped in Marauder %s. Test it by pulling the prebuilt images:\n\n' "$TAG"
+            printf '```\n'
+            printf 'ghcr.io/%s/marauder-backend:%s\n'  "$OWNER" "$VER"
+            printf 'ghcr.io/%s/marauder-frontend:%s\n' "$OWNER" "$VER"
+            printf 'ghcr.io/%s/marauder-cfsolver:%s\n' "$OWNER" "$VER"
+            printf '```\n\n'
+            printf 'or set `MARAUDER_VERSION=%s` in your `deploy/.env` and re-pull the GHCR stack.\n\n' "$VER"
+            printf 'Please give it a try and let us know if it resolves the problem — thanks for the report! :pray:\n'
+          } > issue-comment.md
+
+          for n in $ISSUES; do
+            echo "Commenting on issue #$n"
+            gh issue comment "$n" --repo "$REPO" --body-file issue-comment.md \
+              || echo "::warning::Failed to comment on issue #$n (non-fatal)."
+          done
 
   # ----------------------------------------------- bump source-build version
   # Keep the source-build (dev) stack's stamped version in sync with the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ deploy/         docker-compose stacks (source-build base + prebuilt-image
 docs/           ROADMAP, PRD, VISION, COMPETITORS, per-feature guides
 site/           Astro 5 marketing site published to marauder.cc
 techdebt/       Debt-tracking files (one per issue, see global rule)
-.github/        Workflows: ci, docker, e2e, release, codeql
+.github/        Workflows: ci, docker, e2e, release, auto-release, codeql
+                + scripts/ (release-helpers.sh: tested bump/version/issue logic)
 ```
 
 ## Backend (`backend/internal/...`)
@@ -225,6 +226,36 @@ isolated `marauder-acceptance` Compose project (so it never touches a running
 succeeds — i.e. the plugin `Test()` passed. The `latest` channel overrides the
 client image tag via `MARAUDER_TEST_*_TAG=latest`; on failure the workflow files
 a deduped `client-canary` GitHub issue.
+
+### Release automation (no manual version/tag)
+
+Releases are cut automatically on merge — **do not hand-pick versions or push
+`v*` tags manually** (manual `workflow_dispatch` on `release.yml` still works as
+an escape hatch). The flow:
+
+- **One-time setup:** a `RELEASE_PAT` repo secret (fine-grained PAT,
+  `contents: write`) is required — a tag pushed with the default `GITHUB_TOKEN`
+  will **not** trigger `release.yml` (GitHub's recursion guard). Without it the
+  tag is still created but `release.yml` must be dispatched manually.
+- `.github/workflows/auto-release.yml` runs on **PR merge to main**. It derives
+  the next semver from the merged PR's Conventional Commit **title** (squash
+  subject): `feat!`/`BREAKING CHANGE`→major, `feat`→minor, `fix`/`perf`→patch,
+  everything else (`chore`/`docs`/`ci`/`test`/`refactor`/`build`, incl.
+  dependabot)→**no release**. It then rolls `CHANGELOG.md` (`[Unreleased]` →
+  `[X.Y.Z]`, fresh empty `[Unreleased]`), commits `[skip ci]`, and pushes an
+  **annotated tag** whose message carries the PR title+body plus
+  `Issues:`/`PR:` trailers.
+- `release.yml` (unchanged trigger: `v*` tag push) builds/signs/SBOMs the
+  images, and composes the GitHub Release notes from the CHANGELOG section
+  **plus** the PR description read from the tag annotation. A `notify-issues`
+  job then comments on every linked issue (closing keywords in the PR body
+  **and** an issue-number branch prefix like `48-...`) once artifacts exist.
+- The version/bump/issue parsing lives in `.github/scripts/release-helpers.sh`
+  (pure functions, unit-tested by `release-helpers_test.sh`, run as the
+  `release-scripts` CI job). **Edit the script + its test, not inline YAML.**
+- Keep `CHANGELOG.md`'s `[Unreleased]` section filled as you work — it becomes
+  the release notes. If it's empty on a version-bumping merge, a single bullet
+  is synthesized from the PR title as a fallback.
 
 ## Ports (per `~/.claude/rules/local-port-ranges.md` — host ports must be 30000-49999)
 

--- a/docs/superpowers/specs/2026-06-21-auto-release-on-merge-design.md
+++ b/docs/superpowers/specs/2026-06-21-auto-release-on-merge-design.md
@@ -1,0 +1,179 @@
+# Auto-release on PR merge — design
+
+**Date:** 2026-06-21
+**Status:** approved (proceeding to implementation)
+**Branch:** `ci/auto-release-on-merge`
+
+## Problem
+
+Releasing Marauder is manual and error-prone:
+
+1. A human hand-edits `CHANGELOG.md`, moving the `[Unreleased]` block to a
+   `[X.Y.Z]` section.
+2. A human picks the next version and pushes a `vX.Y.Z` tag.
+3. `release.yml` (tag trigger) builds/signs/SBOMs the three images and creates
+   the GitHub Release from the matching `CHANGELOG.md` section.
+4. `bump-dev-version` syncs the version into `deploy/docker-compose.yml`.
+
+Steps 1–2 are the pain: choosing the version by hand is annoying and forgetting
+the changelog roll produces empty release notes.
+
+## Goal
+
+When a PR is squash-merged to `main`, automatically:
+
+- Derive the next semantic version from the merged PR's Conventional Commit
+  title (squash subject), so no human picks a number.
+- Roll `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z]`), create + push the tag, and
+  let the existing `release.yml` build and publish as it does today.
+- Compose the GitHub Release notes from **both** the `CHANGELOG.md` section and
+  the merged PR's description.
+- If the PR is linked to a GitHub issue (closing keyword **or** issue-number
+  branch prefix), comment on that issue that the fix/feature shipped and can be
+  tested with the released image tag.
+
+## Decisions (locked with the user)
+
+| Decision | Choice |
+|---|---|
+| Which merges cut a release | **Only version-bumping Conventional Commit types.** `feat`→minor, `fix`/`perf`→patch, `feat!`/`BREAKING CHANGE`→major. `chore`/`docs`/`ci`/`test`/`refactor`/`build` (incl. dependabot dep bumps) merge silently with **no** release. |
+| Bump source | **PR title** (squash-merge makes it the commit subject); PR body scanned for `BREAKING CHANGE`. |
+| Issue discovery | **Both** PR-body closing keywords (`Closes/Fixes/Resolves #N`) **and** leading issue-number branch prefix (e.g. `48-kinozal-...`). |
+| Empty `[Unreleased]` on a version PR | Synthesize one bullet from the **real PR title** (never fabricated data — it's the actual change description). |
+| `docker-compose.ghcr.yml` default tag | Out of scope. Only the existing `bump-dev-version` (source stack) stays. |
+
+## Architecture — the annotated tag is the carrier
+
+```
+PR merged to main
+      │
+      ▼
+┌──────────────────────────┐   pushes annotated   ┌───────────────────────┐
+│  auto-release.yml (NEW)   │ ───── tag vX.Y.Z ───▶│  release.yml (extend)  │
+│  • parse bump from title  │  (msg = PR title +   │  • build/sign/SBOM     │
+│  • compute next version   │   PR body +          │  • notes = CHANGELOG   │
+│  • roll CHANGELOG.md       │   "Issues:" trailer) │    section + PR body   │
+│  • create + push ann. tag │                      │  • notify-issues job   │
+└──────────────────────────┘                      └───────────────────────┘
+```
+
+### Required one-time setup — `RELEASE_PAT` secret
+
+GitHub suppresses workflow re-triggering for events raised by the built-in
+`GITHUB_TOKEN` (recursion guard), so a tag pushed with it would **not** start
+`release.yml`. `auto-release.yml` therefore pushes the tag with a
+`RELEASE_PAT` secret (a fine-grained PAT with `contents: write`) when present.
+Without it the workflow still rolls the CHANGELOG and creates the tag, but
+`release.yml` must be started manually via its `workflow_dispatch` — a warning
+annotation is emitted in that case. This keeps the proven tag-push path in
+`release.yml` 100% untouched (no reusable-workflow refactor, no changes to the
+image build/tagging logic).
+
+**Why route through an annotated git tag** instead of refactoring `release.yml`
+into a reusable `workflow_call`: `release.yml` already fires on `v*` tag push
+and is the single authority that builds images and creates the GitHub Release.
+Embedding the PR body + issue numbers in the **annotated tag message** lets
+`release.yml` read them with `git tag -l --format='%(contents)' "$TAG"` without
+a second trigger path (which would risk a double release) and — crucially —
+means the issue comment fires **after** artifacts exist, not seconds after the
+tag is created.
+
+## Components
+
+### 1. `.github/scripts/release-helpers.sh` (new, unit-tested)
+
+Pure string logic, extracted from YAML so the risky parsing is testable:
+
+- `bump-level "<pr-title>" "<pr-body>"` → `major|minor|patch|none`
+  - `feat!` / `BREAKING CHANGE:` → `major`
+  - `feat` → `minor`
+  - `fix` / `perf` → `patch`
+  - anything else → `none`
+- `next-version <latest-tag> <level>` → `X.Y.Z`
+  - resets lower components on a higher bump (minor zeroes patch, major zeroes
+    minor+patch).
+- `issue-refs "<pr-body>" "<branch>"` → newline list of issue numbers, deduped,
+  from `Closes/Fixes/Resolves #N` (case-insensitive) and a leading `^[0-9]+`
+  branch prefix.
+
+Companion `release-helpers_test.sh` runs table-driven assertions and exits
+non-zero on any mismatch.
+
+### 2. `.github/workflows/auto-release.yml` (new)
+
+- Trigger: `pull_request: { types: [closed], branches: [main] }`.
+- Guard: `if: github.event.pull_request.merged == true`.
+- `concurrency: { group: auto-release, cancel-in-progress: false }` —
+  serializes near-simultaneous merges so two PRs can't compute the same next
+  version off the same latest tag.
+- `permissions: { contents: write }`.
+- Steps:
+  1. Checkout `main`, full history + tags.
+  2. `LEVEL=$(release-helpers.sh bump-level "$TITLE" "$BODY")`. If `none` →
+     log and exit 0 (no release).
+  3. `LATEST=$(git tag --sort=-v:refname | head -1)`;
+     `VER=$(release-helpers.sh next-version "$LATEST" "$LEVEL")`.
+  4. If tag `v$VER` already exists → log and exit 0 (idempotent re-run).
+  5. Roll `CHANGELOG.md` (see Component 3). Commit to `main` with `[skip ci]`.
+  6. Collect issue refs; build the annotated-tag message:
+     ```
+     <PR title>
+
+     <PR body>
+
+     Issues: #<a> #<b>
+     PR: #<num>
+     ```
+  7. `git tag -a "v$VER" -F <msgfile>` then `git push origin "v$VER"`.
+
+### 3. CHANGELOG roll (inside auto-release.yml)
+
+`awk`/`sed` transform: rename the `## [Unreleased]` heading to
+`## [X.Y.Z] - YYYY-MM-DD` and insert a fresh empty `## [Unreleased]` block
+above it. If the `[Unreleased]` body is empty, insert a single bullet under an
+`### Added` (feat) / `### Fixed` (fix) heading derived from the PR title so the
+release notes are never blank. The build date uses the workflow run date (UTC).
+
+### 4. `release.yml` extensions
+
+- **Release-notes step**: after the existing CHANGELOG extraction, read the tag
+  annotation and append a `## Pull Request` section containing the PR body.
+  Defensive: a manual `workflow_dispatch` run or a hand-pushed tag with no
+  annotation simply skips the PR section — existing behavior preserved.
+- **New `notify-issues` job** (`needs: [release]`,
+  `permissions: { issues: write }`): parse the `Issues:` trailer from the tag
+  annotation and `gh issue comment` each one:
+  > 🚀 Released in **vX.Y.Z**. Pull `ghcr.io/artyomsv/marauder-backend:X.Y.Z`
+  > (and `-frontend` / `-cfsolver`) to test, or update your stack's
+  > `MARAUDER_VERSION`. Please verify and report back here.
+  No annotation / no issues → job no-ops. Comment failure is non-fatal.
+
+## Error handling
+
+| Case | Behavior |
+|---|---|
+| Non-version PR (`chore`, etc.) | Graceful skip, exit 0, no tag. |
+| Empty `[Unreleased]` on a version PR | Synthesize one bullet from the PR title. |
+| Tag already exists (re-run) | Detect and skip. |
+| Concurrent merges | `concurrency` group serializes; second run recomputes off the now-latest tag. |
+| Issue comment fails | Non-fatal — release is already published. |
+| Manual `workflow_dispatch` release | No annotation → no PR section, no issue comments (unchanged). |
+
+## Testing / success criteria
+
+1. **Unit:** `release-helpers_test.sh` passes. Cases include:
+   `feat: x`→minor, `fix(scope): y`→patch, `feat!: z`→major,
+   `fix: a\n\nBREAKING CHANGE: b`→major, `chore(deps): c`→none;
+   `next-version v1.0.2 minor`→`1.1.0`, `v1.0.2 major`→`2.0.0`,
+   `v1.0.2 patch`→`1.0.3`; issue-refs from body + `48-foo` branch → `48`.
+   Wired into a small CI job so regressions are caught pre-merge.
+2. **End-to-end (user acceptance):** merge a `feat:`/`fix:` PR linked to an
+   issue → a `vX.Y.Z` tag appears, the GitHub Release body contains both the
+   CHANGELOG section and the PR description, and the linked issue receives the
+   release comment.
+
+## Out of scope
+
+- Replacing the manual Keep-a-Changelog format with a generator (release-please
+  etc.) — the design intentionally consumes the existing `[Unreleased]` block.
+- Bumping the `docker-compose.ghcr.yml` default `MARAUDER_VERSION` fallback.


### PR DESCRIPTION
## Summary

Automates releases so no human picks a version or pushes a tag. On every squash-merge to `main`, the next semantic version is derived from the PR's Conventional Commit title, `CHANGELOG.md` is rolled, and the existing `release.yml` builds and publishes.

- **`auto-release.yml` (new)** — fires on PR merge to `main`. Derives the bump from the PR title (`feat!`/`BREAKING CHANGE`→major, `feat`→minor, `fix`/`perf`→patch; `chore`/`docs`/`ci`/`test`/`refactor`/`build`, incl. dependabot → **no release**), rolls `CHANGELOG.md` (`[Unreleased]`→`[X.Y.Z]`), and pushes an annotated tag carrying the PR body + `Issues:`/`PR:` trailers.
- **`release.yml` (extended)** — release notes now include the PR description (read from the tag annotation), and a new `notify-issues` job comments on every linked issue (closing keywords **and** issue-number branch prefix like `48-…`) once artifacts exist, telling the reporter how to test the released image tag. The proven tag-push build path is otherwise untouched.
- **`release-helpers.sh` (new)** — pure bump/version/issue/changelog logic, unit-tested by `release-helpers_test.sh` (40 assertions) and run as the `release-scripts` CI job.

## ⚠️ Required one-time setup

Add a repo secret **`RELEASE_PAT`** — a fine-grained PAT with `contents: write`. A tag pushed by the built-in `GITHUB_TOKEN` will **not** trigger `release.yml` (GitHub's recursion guard). Without the secret the workflow still rolls the CHANGELOG and creates the tag, but `release.yml` must be dispatched manually (a warning is emitted).

## Test Plan

1. Add the `RELEASE_PAT` secret.
2. Merge a `feat:`/`fix:` PR linked to an issue (`Closes #N` or an `N-…` branch).
3. Verify: a `vX.Y.Z` tag appears → GitHub Release published with both the CHANGELOG section and the PR description → the linked issue receives a "released, test with `…:X.Y.Z`" comment.

Verified locally before this PR: helper suite `40 passed, 0 failed`; YAML parses; actionlint clean (no errors); dry-run against real repo state produces `v1.0.3` for a `fix`, `v2.0.0` for a `feat!`, and no release for a dependabot `chore`.

Spec: `docs/superpowers/specs/2026-06-21-auto-release-on-merge-design.md`