### PR TITLE
ci(release): sync marketing-site version on release

### DIFF
--- a/.github/scripts/bump-version-refs.sh
+++ b/.github/scripts/bump-version-refs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# bump-version-refs.sh — stamp a released version into every file that mirrors
+# it. Pure in-place file edits, no git; release.yml's bump-dev-version job calls
+# this and then commits the results (deploy/* with [skip ci]; site/* without, so
+# site.yml redeploys marauder.cc).
+#
+# Usage: bump-version-refs.sh <X.Y.Z> [repo-root]   (repo-root defaults to ".")
+#
+# Deliberately NOT touched:
+#   - seo.ts `releaseDate` — maps to JSON-LD datePublished (original publish
+#     date); must stay stable. Sitemap lastmod uses new Date(), not this.
+#   - install.astro illustrative "commit"/"buildDate" example lines.
+
+set -euo pipefail
+
+VER="${1:-}"
+ROOT="${2:-.}"
+
+if [[ ! "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: $0 <X.Y.Z> [repo-root]  (got version='$VER')" >&2
+  exit 2
+fi
+
+SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
+
+# deploy/docker-compose.yml — source-build VERSION arg + marauder-* image tags.
+sed -i -E "s|(VERSION: \")[^\"]+(\")|\1${VER}\2|"                 "$ROOT/deploy/docker-compose.yml"
+sed -i -E "s#(image: marauder-(backend|frontend|cfsolver):).*#\1${VER}#" "$ROOT/deploy/docker-compose.yml"
+
+# deploy/docker-compose.ghcr.yml — ${MARAUDER_VERSION:-X.Y.Z} fallbacks + the
+# "defaults to X.Y.Z below" comment.
+sed -i -E "s|(:-)${SEMVER}(})|\1${VER}\2|g"                       "$ROOT/deploy/docker-compose.ghcr.yml"
+sed -i -E "s|(defaults to )${SEMVER}|\1${VER}|g"                  "$ROOT/deploy/docker-compose.ghcr.yml"
+
+# deploy/.env.example — the MARAUDER_VERSION pin users copy.
+sed -i -E "s|(MARAUDER_VERSION=)${SEMVER}|\1${VER}|"              "$ROOT/deploy/.env.example"
+
+# site/src/data/seo.ts — SITE.software.version (homepage hero + JSON-LD).
+sed -i -E "s|(version: \")${SEMVER}(\")|\1${VER}\2|"              "$ROOT/site/src/data/seo.ts"
+
+# site/src/pages/install.astro — example /system/info output + ghcr default note.
+sed -i -E "s|(\"version\": \")${SEMVER}(\")|\1${VER}\2|"          "$ROOT/site/src/pages/install.astro"
+sed -i -E "s|(defaults to <code>)${SEMVER}(</code>)|\1${VER}\2|"  "$ROOT/site/src/pages/install.astro"
+
+echo "bump-version-refs: stamped ${VER} into deploy/ and site/ version references"

--- a/.github/scripts/bump-version-refs_test.sh
+++ b/.github/scripts/bump-version-refs_test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Tests for bump-version-refs.sh. Copies the REAL repo files into a temp root
+# (so fixtures never drift from reality), runs the bump, and asserts every
+# mirrored version literal is updated — and that releaseDate is left alone.
+#
+#   bash .github/scripts/bump-version-refs_test.sh
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$DIR/../.." && pwd)"
+SCRIPT="$DIR/bump-version-refs.sh"
+VER="9.9.9"
+
+pass=0
+fail=0
+check() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: %s\n  expected: %q\n  actual:   %q\n' "$desc" "$expected" "$actual"
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Mirror just the files the script edits, preserving relative paths.
+mkdir -p "$TMP/deploy" "$TMP/site/src/data" "$TMP/site/src/pages"
+cp "$REPO/deploy/docker-compose.yml"      "$TMP/deploy/"
+cp "$REPO/deploy/docker-compose.ghcr.yml" "$TMP/deploy/"
+cp "$REPO/deploy/.env.example"            "$TMP/deploy/"
+cp "$REPO/site/src/data/seo.ts"           "$TMP/site/src/data/"
+cp "$REPO/site/src/pages/install.astro"   "$TMP/site/src/pages/"
+
+# Capture releaseDate before the bump (must be unchanged after).
+RELDATE_BEFORE="$(grep -E 'releaseDate:' "$TMP/site/src/data/seo.ts")"
+
+bash "$SCRIPT" "$VER" "$TMP" >/dev/null
+
+count() { grep -cE "$1" "$2"; }
+
+# Every mirrored literal is now 9.9.9 ...
+check "compose VERSION arg"          "1" "$(count "VERSION: \"$VER\"" "$TMP/deploy/docker-compose.yml")"
+check "compose backend image"        "1" "$(count "image: marauder-backend:$VER" "$TMP/deploy/docker-compose.yml")"
+check "ghcr default fallbacks (x3)"  "3" "$(count ":-$VER}" "$TMP/deploy/docker-compose.ghcr.yml")"
+check "ghcr comment default"         "1" "$(count "defaults to $VER below" "$TMP/deploy/docker-compose.ghcr.yml")"
+check "env.example pin"              "1" "$(count "MARAUDER_VERSION=$VER" "$TMP/deploy/.env.example")"
+check "seo.ts software version"      "1" "$(count "version: \"$VER\"" "$TMP/site/src/data/seo.ts")"
+check "install.astro example output" "1" "$(count "\"version\": \"$VER\"" "$TMP/site/src/pages/install.astro")"
+check "install.astro default note"   "1" "$(count "defaults to <code>$VER</code>" "$TMP/site/src/pages/install.astro")"
+
+# ... and no stale 1.0.x version literals linger in the edited spots.
+check "no stale ghcr fallback"       "0" "$(count ":-1\.0\.[0-9]+}" "$TMP/deploy/docker-compose.ghcr.yml")"
+check "no stale env pin"             "0" "$(count "MARAUDER_VERSION=1\.0\.[0-9]+" "$TMP/deploy/.env.example")"
+
+# releaseDate (JSON-LD datePublished) must be untouched.
+check "releaseDate unchanged" "$RELDATE_BEFORE" "$(grep -E 'releaseDate:' "$TMP/site/src/data/seo.ts")"
+
+# Bad input is rejected.
+bash "$SCRIPT" "not-a-version" "$TMP" >/dev/null 2>&1
+check "rejects bad version (exit 2)" "2" "$?"
+
+echo "-----------------------------------------"
+echo "bump-version-refs: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
       - name: Run release-helpers tests
         run: bash .github/scripts/release-helpers_test.sh
 
+      - name: Run bump-version-refs tests
+        run: bash .github/scripts/bump-version-refs_test.sh
+
   # ---------------------------------------------------------------- frontend
   frontend:
     name: Frontend (Node ${{ matrix.node }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,3 +298,29 @@ jobs:
           git add deploy/docker-compose.yml
           git commit -m "chore: set dev stack version to ${VER} [skip ci]"
           git push origin main
+
+      - name: Set marketing-site version to the released version
+        # Separate step (and separate commit) on purpose: the displayed site
+        # version lives in site/src/data/seo.ts, which is under site/**, so this
+        # commit deliberately does NOT carry [skip ci] — it must trigger
+        # site.yml to redeploy marauder.cc with the new version. The previous
+        # step may have exited early (compose already current), so re-establish
+        # git identity here.
+        run: |
+          set -euo pipefail
+          VER="${GITHUB_REF_NAME#v}"
+
+          # Replace the single `version: "X.Y.Z"` literal in the SITE.software
+          # block. releaseDate and other fields are left untouched.
+          sed -i -E "s|(version: \")[0-9]+\.[0-9]+\.[0-9]+(\")|\1${VER}\2|" site/src/data/seo.ts
+
+          if git diff --quiet -- site/src/data/seo.ts; then
+            echo "site/src/data/seo.ts already at ${VER}, nothing to do"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add site/src/data/seo.ts
+          git commit -m "chore(site): set displayed version to ${VER}"
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,13 +258,14 @@ jobs:
               || echo "::warning::Failed to comment on issue #$n (non-fatal)."
           done
 
-  # ----------------------------------------------- bump source-build version
-  # Keep the source-build (dev) stack's stamped version in sync with the
-  # latest release, so a local `docker compose up --build` reports the real
-  # released version instead of a hand-maintained marker. Commits the bump
-  # back to main with [skip ci] so it doesn't re-trigger CI.
+  # -------------------------------------------- sync version references
+  # Stamp the released version into every file that mirrors it, so the source
+  # build, the prebuilt ghcr stack, the example env, and the marketing site all
+  # report the real released version instead of hand-maintained markers. The
+  # actual edits live in .github/scripts/bump-version-refs.sh (tested by
+  # bump-version-refs_test.sh).
   bump-dev-version:
-    name: Bump dev stack version
+    name: Sync version references
     needs: [release]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
@@ -277,50 +278,33 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Set dev stack version to the released version
+      - name: Stamp released version and commit
         run: |
           set -euo pipefail
           VER="${GITHUB_REF_NAME#v}"
 
-          # Update the source-build VERSION build arg and the marauder-* image
-          # tags in the base compose file. Other images (postgres, nginx) are
-          # left untouched by the marauder- prefix anchor.
-          sed -i -E "s|(VERSION: \")[^\"]+(\")|\1${VER}\2|" deploy/docker-compose.yml
-          sed -i -E "s#(image: marauder-(backend|frontend|cfsolver):).*#\1${VER}#" deploy/docker-compose.yml
-
-          if git diff --quiet -- deploy/docker-compose.yml; then
-            echo "deploy/docker-compose.yml already at ${VER}, nothing to do"
-            exit 0
-          fi
+          bash .github/scripts/bump-version-refs.sh "$VER"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add deploy/docker-compose.yml
-          git commit -m "chore: set dev stack version to ${VER} [skip ci]"
-          git push origin main
 
-      - name: Set marketing-site version to the released version
-        # Separate step (and separate commit) on purpose: the displayed site
-        # version lives in site/src/data/seo.ts, which is under site/**, so this
-        # commit deliberately does NOT carry [skip ci] — it must trigger
-        # site.yml to redeploy marauder.cc with the new version. The previous
-        # step may have exited early (compose already current), so re-establish
-        # git identity here.
-        run: |
-          set -euo pipefail
-          VER="${GITHUB_REF_NAME#v}"
-
-          # Replace the single `version: "X.Y.Z"` literal in the SITE.software
-          # block. releaseDate and other fields are left untouched.
-          sed -i -E "s|(version: \")[0-9]+\.[0-9]+\.[0-9]+(\")|\1${VER}\2|" site/src/data/seo.ts
-
-          if git diff --quiet -- site/src/data/seo.ts; then
-            echo "site/src/data/seo.ts already at ${VER}, nothing to do"
-            exit 0
+          # Deploy/repo artifacts: nothing to redeploy -> [skip ci].
+          if ! git diff --quiet -- deploy/docker-compose.yml deploy/docker-compose.ghcr.yml deploy/.env.example; then
+            git add deploy/docker-compose.yml deploy/docker-compose.ghcr.yml deploy/.env.example
+            git commit -m "chore: pin deploy stack to ${VER} [skip ci]"
+          else
+            echo "deploy version references already at ${VER}"
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add site/src/data/seo.ts
-          git commit -m "chore(site): set displayed version to ${VER}"
+          # Site content: must trigger site.yml to redeploy marauder.cc, so this
+          # commit deliberately does NOT carry [skip ci]. It is committed LAST so
+          # it is the push HEAD (GitHub evaluates [skip ci] on the head commit).
+          if ! git diff --quiet -- site/src/data/seo.ts site/src/pages/install.astro; then
+            git add site/src/data/seo.ts site/src/pages/install.astro
+            git commit -m "chore(site): set displayed version to ${VER}"
+          else
+            echo "site version references already at ${VER}"
+          fi
+
+          # Pushes any commits made above (no-op if both were already current).
           git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,13 +250,17 @@ an escape hatch). The flow:
   **plus** the PR description read from the tag annotation. A `notify-issues`
   job then comments on every linked issue (closing keywords in the PR body
   **and** an issue-number branch prefix like `48-...`) once artifacts exist.
-- `release.yml`'s `bump-dev-version` job (runs on every tag) also keeps two
-  version markers in sync with the release: `deploy/docker-compose.yml`
-  (source-build stack, committed `[skip ci]`) **and** `site/src/data/seo.ts`
-  (`SITE.software.version`, the marketing-site version shown in the homepage
-  hero + `SoftwareApplication` JSON-LD). The `seo.ts` bump is a **separate
-  commit without `[skip ci]`** so it triggers `site.yml`, which redeploys
-  marauder.cc with the new version. Don't hand-edit `seo.ts`'s version.
+- `release.yml`'s `bump-dev-version` job (runs on every tag) stamps the released
+  version into **every** file that mirrors it, via
+  `.github/scripts/bump-version-refs.sh` (tested by `bump-version-refs_test.sh`):
+  `deploy/docker-compose.yml` (source-build), `deploy/docker-compose.ghcr.yml`
+  (`${MARAUDER_VERSION:-X.Y.Z}` defaults), `deploy/.env.example`,
+  `site/src/data/seo.ts` (`SITE.software.version`), and `site/src/pages/install.astro`
+  (example output + default note). It makes **two commits**: deploy/repo files
+  `[skip ci]`, then the `site/**` files **without** `[skip ci]` (committed last
+  so it's the push HEAD) so `site.yml` redeploys marauder.cc. **Don't hand-edit
+  these version literals** — and note `seo.ts` `releaseDate` is intentionally
+  NOT bumped (it's JSON-LD `datePublished`, the stable original publish date).
 - The version/bump/issue parsing lives in `.github/scripts/release-helpers.sh`
   (pure functions, unit-tested by `release-helpers_test.sh`, run as the
   `release-scripts` CI job). **Edit the script + its test, not inline YAML.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,13 @@ an escape hatch). The flow:
   **plus** the PR description read from the tag annotation. A `notify-issues`
   job then comments on every linked issue (closing keywords in the PR body
   **and** an issue-number branch prefix like `48-...`) once artifacts exist.
+- `release.yml`'s `bump-dev-version` job (runs on every tag) also keeps two
+  version markers in sync with the release: `deploy/docker-compose.yml`
+  (source-build stack, committed `[skip ci]`) **and** `site/src/data/seo.ts`
+  (`SITE.software.version`, the marketing-site version shown in the homepage
+  hero + `SoftwareApplication` JSON-LD). The `seo.ts` bump is a **separate
+  commit without `[skip ci]`** so it triggers `site.yml`, which redeploys
+  marauder.cc with the new version. Don't hand-edit `seo.ts`'s version.
 - The version/bump/issue parsing lives in `.github/scripts/release-helpers.sh`
   (pure functions, unit-tested by `release-helpers_test.sh`, run as the
   `release-scripts` CI job). **Edit the script + its test, not inline YAML.**

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -27,7 +27,7 @@ MARAUDER_ADMIN_INITIAL_PASSWORD=pleasechangeme
 # Which published image tag to pull from ghcr.io/artyomsv/marauder-*.
 # Pin to a release for reproducible deploys; `latest` floats with every
 # release. Ignored by the build-from-source stack (docker-compose.yml).
-MARAUDER_VERSION=1.0.1
+MARAUDER_VERSION=1.0.3
 
 # --- Database -------------------------------------------------------
 POSTGRES_DB=marauder

--- a/deploy/docker-compose.ghcr.yml
+++ b/deploy/docker-compose.ghcr.yml
@@ -21,7 +21,7 @@
 #   - The GHCR packages must be public. If `docker compose pull` fails with
 #     "denied" / 403, the maintainer has not flipped package visibility yet.
 #
-# Pin the version with MARAUDER_VERSION in .env (defaults to 1.0.1 below).
+# Pin the version with MARAUDER_VERSION in .env (defaults to 1.0.3 below).
 # `latest` also exists but floats with every release — pin for reproducible
 # deployments.
 
@@ -56,7 +56,7 @@ services:
         max-file: "3"
 
   backend:
-    image: ghcr.io/artyomsv/marauder-backend:${MARAUDER_VERSION:-1.0.1}
+    image: ghcr.io/artyomsv/marauder-backend:${MARAUDER_VERSION:-1.0.3}
     restart: unless-stopped
     depends_on:
       db:
@@ -96,7 +96,7 @@ services:
         max-file: "3"
 
   frontend:
-    image: ghcr.io/artyomsv/marauder-frontend:${MARAUDER_VERSION:-1.0.1}
+    image: ghcr.io/artyomsv/marauder-frontend:${MARAUDER_VERSION:-1.0.3}
     restart: unless-stopped
     depends_on:
       - backend
@@ -115,7 +115,7 @@ services:
 
   cfsolver:
     profiles: ["cfsolver"]
-    image: ghcr.io/artyomsv/marauder-cfsolver:${MARAUDER_VERSION:-1.0.1}
+    image: ghcr.io/artyomsv/marauder-cfsolver:${MARAUDER_VERSION:-1.0.3}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9244/health"]

--- a/site/src/data/seo.ts
+++ b/site/src/data/seo.ts
@@ -29,9 +29,12 @@ export const SITE = {
     url: "https://github.com/artyomsv",
   },
 
-  /** Software metadata for SoftwareApplication JSON-LD. */
+  /** Software metadata for SoftwareApplication JSON-LD.
+   *  `version` is kept in sync with the latest GitHub release automatically by
+   *  release.yml's bump-dev-version job (sed + commit) — do not hand-edit it
+   *  except to correct drift. */
   software: {
-    version: "1.0.1",
+    version: "1.0.3",
     license: "MIT",
     operatingSystem: "Linux, Docker, macOS, Windows",
     applicationCategory: "Utility",

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -62,7 +62,7 @@ const cmdHealth = `curl -fsS http://localhost:34080/health
 
 curl -sS http://localhost:34080/api/v1/system/info | jq .version
 # {
-#   "version": "1.0.1",
+#   "version": "1.0.3",
 #   "commit":  "...",
 #   "buildDate": "..."
 # }`;
@@ -117,7 +117,7 @@ const cmdLogin = `curl -sS -X POST http://localhost:34080/api/v1/auth/login \\
       <p class="mt-3 text-muted-foreground">
         Then open <a href="http://localhost:34080" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">http://localhost:34080</a>.
         Pin the release with <code>MARAUDER_VERSION</code> in <code>.env</code>
-        (defaults to <code>1.0.1</code>); <code>latest</code> also exists.
+        (defaults to <code>1.0.3</code>); <code>latest</code> also exists.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary

Closes the gap where a version bump never updated the marketing site (marauder.cc) — and, more broadly, centralizes version stamping so **every** mirrored version literal stays in sync with releases. All were stale at `1.0.1` while the latest release is `1.0.3`.

### Files synced (now `1.0.3`, auto-bumped on every future release)
- `site/src/data/seo.ts` — `SITE.software.version` (homepage hero + `SoftwareApplication` JSON-LD)
- `site/src/pages/install.astro` — example `/system/info` output + the `MARAUDER_VERSION` default note
- `deploy/docker-compose.ghcr.yml` — `${MARAUDER_VERSION:-X.Y.Z}` ×3 + the "defaults to" comment
- `deploy/.env.example` — `MARAUDER_VERSION` pin
- `deploy/docker-compose.yml` — source-build `VERSION` + `marauder-*` image tags (was already automated)

### How
- New tested script **`.github/scripts/bump-version-refs.sh`** (`bump-version-refs_test.sh`, 12 assertions, wired into the `release-scripts` CI job) is the single place that stamps the version.
- `release.yml`'s `bump-dev-version` job calls it on every tag and makes **two commits**: deploy/repo files `[skip ci]`, then the `site/**` files **without** `[skip ci]` (committed last → push HEAD) so `site.yml` redeploys marauder.cc.

### Intentionally NOT changed
- `seo.ts` `releaseDate` → it's JSON-LD `datePublished` (stable original publish date); mutating it per release is an SEO anti-signal. The sitemap lastmod uses `new Date()`, not this field.

## Test Plan
1. Merge → marauder.cc redeploys showing `v1.0.3`. (PR is `ci:`/`chore:` → no release cut.)
2. Next real release → `bump-version-refs.sh` runs; `docker-compose.ghcr.yml`, `.env.example`, `seo.ts`, `install.astro` all show the new version and `site.yml` redeploys.

Verified locally: `bump-version-refs_test.sh` 12/12 + `release-helpers_test.sh` 40/40; `sed` touches only intended lines (`releaseDate` untouched); Astro build exit 0 with the install page rendering only `1.0.3`; actionlint clean.