### PR TITLE
ci: make release + dependabot pipelines work under branch ruleset

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,12 +11,19 @@ name: Dependabot auto-merge
 # Note: E2E runs nightly/on-tag, NOT per-PR, so auto-merged deps are only
 # stack-tested by the next nightly E2E. CI (build/test/lint/codeql) gates.
 #
+# Works with the `protect-default` branch ruleset as follows:
+#   * required_status_checks gates the merge (nothing merges red).
+#   * require_code_owner_review is OFF, so this bot's own approval satisfies
+#     the 1-approving-review rule (a bot can't be a CODEOWNER). Human PRs are
+#     unaffected — only the owner can approve them, and the bot only approves
+#     Dependabot PRs (the `github.actor == 'dependabot[bot]'` job guard).
+# The ruleset dismisses stale approvals on push, so the approve step also runs
+# on `synchronize` to re-approve Dependabot's rebases/regroups.
+#
 # ONE-TIME repo settings required for this to work (Settings ->):
 #   * Actions -> General -> Workflow permissions ->
 #       "Allow GitHub Actions to create and approve pull requests"  (approve step)
 #   * General -> Pull Requests -> "Allow auto-merge"                (--auto)
-#   * Branch protection on `main` -> require the CI status checks    (gates merge)
-# Without branch protection requiring checks, --auto may merge immediately.
 
 on:
   pull_request:
@@ -37,9 +44,10 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@v2
 
-      - name: Approve (minor/patch, on open)
+      - name: Approve (minor/patch)
         if: >-
-          (github.event.action == 'opened' || github.event.action == 'reopened') &&
+          (github.event.action == 'opened' || github.event.action == 'reopened' ||
+           github.event.action == 'synchronize') &&
           (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
            steps.meta.outputs.update-type == 'version-update:semver-patch')
         # Fail-soft: if "Allow GitHub Actions to create and approve pull

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,12 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # Push as the owner (RELEASE_PAT) so these direct-to-main commits
+          # clear the branch ruleset's "require a pull request" rule — the
+          # default GITHUB_TOKEN (github-actions[bot]) is not a bypass actor and
+          # would be rejected. Falls back to GITHUB_TOKEN if the PAT is unset
+          # (works only if the ruleset is absent/relaxed).
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Stamp released version and commit
         run: |


### PR DESCRIPTION
## Summary

The new `protect-default` branch ruleset (require PR + code-owner review on `main`) broke two automated git paths. This restores them **without weakening protection for human PRs**.

- **`release.yml` → `bump-dev-version`**: was pushing the version-sync commits to `main` with the default `GITHUB_TOKEN` (`github-actions[bot]`), which is **not** a ruleset bypass actor — so "require a pull request" rejected the push. Now checks out with `RELEASE_PAT` (you, the owner = a bypass actor), the same identity `auto-release.yml` already uses for its direct push + tag.
- **`dependabot-auto-merge.yml`**: also re-approves on `synchronize` so Dependabot rebases/regroups don't lose the bot approval (the ruleset dismisses stale approvals on push).

## Companion ruleset change (applied separately via API)
- `require_code_owner_review: false` (keep `required_approving_review_count: 1`) — a bot can't be a CODEOWNER, so this lets the Dependabot workflow's own approval satisfy the review rule. Human PRs are unaffected: only the owner can approve them, and the bot only approves Dependabot PRs.
- Add `required_status_checks` (the PR-time CI jobs) — so nothing (bot or human) merges red; restores the CI gate the original auto-merge design relied on.

## Test Plan
1. Merge → next release runs `bump-dev-version` and its `RELEASE_PAT` push to `main` succeeds (no ruleset rejection); version sync + site redeploy happen.
2. Next minor/patch Dependabot PR → bot approves, CI passes, auto-merge completes hands-free.