### PR TITLE
fix(site): show current version on monitorrent comparison page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The "Marauder vs monitorrent" comparison page (`/vs/monitorrent`) advertised
+  a stale "Latest release v1.0.0"; it now renders the current version from the
+  shared site config so it stays in sync with releases (#55).
+
+## [1.0.3] - 2026-06-21
+
 ### Added
 
 - **Kinozal metadata resolution** (`WithMetadata`): the AddTopic form now

--- a/site/src/pages/vs/monitorrent.astro
+++ b/site/src/pages/vs/monitorrent.astro
@@ -1,6 +1,7 @@
 ---
 import Page from "@/layouts/Page.astro";
 import { breadcrumbSchema } from "@/data/schemas";
+import { SITE } from "@/data/seo";
 
 const seo = {
   title: "Marauder vs monitorrent — the modern monitorrent successor",
@@ -41,7 +42,7 @@ const matrix = [
   { feature: "Newznab / Usenet indexer support",      mt: "no",                        ma: "yes (newznab plugin)" },
   { feature: "Torrent clients",                       mt: "Transmission, Deluge, µTorrent, qBittorrent", ma: "Transmission, Deluge, µTorrent, qBittorrent + watch folder" },
   { feature: "Language / runtime",                    mt: "Python",                    ma: "Go (single static binary)" },
-  { feature: "Latest release",                        mt: "v1.4.0 — July 2023",        ma: "v1.0.0 — 2026, active" },
+  { feature: "Latest release",                        mt: "v1.4.0 — July 2023",        ma: `v${SITE.software.version} — 2026, active` },
   { feature: "AES-256-GCM encrypted credentials",     mt: "no",                        ma: "yes" },
   { feature: "OpenID Connect / SSO",                  mt: "no",                        ma: "yes (Keycloak bundled)" },
   { feature: "Multi-user with per-user isolation",    mt: "no (single user)",          ma: "yes" },


### PR DESCRIPTION
Closes #55

## Summary
The `/vs/monitorrent` comparison table hardcoded Marauder's "Latest release" as **v1.0.0**, two releases stale. It now renders from `SITE.software.version` (synced on every release), so it stays current automatically.

Also rolls the CHANGELOG: the Kinozal work that shipped in **v1.0.3** was never moved out of `[Unreleased]`; this records it under `[1.0.3]` so this release's notes are clean.

## Test Plan
This PR doubles as the end-to-end pipeline verification: merging it should bump to **v1.0.4** (a `fix:`), build/sign/publish images, create the GitHub Release from the CHANGELOG + this PR body, comment on #55, sync version references, and redeploy marauder.cc showing 1.0.4.

Verified locally: Astro build exit 0; comparison page renders the dynamic version.