### PR TITLE
fix(rutracker): prefer authenticated .torrent over hash-only magnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **RuTracker delivered a hash-only magnet that left qBittorrent stuck on
+  "Downloading metadata" forever** (#52). RuTracker page magnets carry no
+  announce URLs, so on a private tracker the client could never find peers.
+  `Download` now prefers the authenticated `.torrent` from `dl.php` (which
+  carries the announce list and full info dict), validates it is a real
+  bencoded torrent before submitting, and falls back to the page magnet only
+  when credentials are absent or the `.torrent` is unavailable.
 - **Kinozal checks reported `no infohash found in topic page`** (#48): the
   plugin scraped the details page, which doesn't carry the hash. It now reads
   the infohash from the authenticated `get_srv_details.php?id=<id>&action=2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Download` now prefers the authenticated `.torrent` from `dl.php` (which
   carries the announce list and full info dict), validates it is a real
   bencoded torrent before submitting, and falls back to the page magnet only
-  when credentials are absent or the `.torrent` is unavailable.
+  when credentials are absent or the `.torrent` is unavailable. The fallback
+  is now logged so a dead session no longer silently re-triggers the stuck
+  state, and the bencode parser gained a nesting-depth bound (the dl.php
+  response is the first remote, untrusted input it validates).
 - **Kinozal checks reported `no infohash found in topic page`** (#48): the
   plugin scraped the details page, which doesn't carry the hash. It now reads
   the infohash from the authenticated `get_srv_details.php?id=<id>&action=2`

--- a/backend/internal/infohash/infohash.go
+++ b/backend/internal/infohash/infohash.go
@@ -99,6 +99,13 @@ func normalizeHash(h string) (string, error) {
 	}
 }
 
+// maxBencodeDepth bounds container nesting in the scanner. Real torrents
+// nest only a few levels deep (the info dict, a files list, per-file dicts);
+// anything past this is a malformed or hostile payload. The cap turns a
+// stack-exhaustion DoS (unbounded recursion on a crafted dl.php response,
+// see infohash.FromTorrent's callers) into a clean error.
+const maxBencodeDepth = 32
+
 // infoDictBytes locates the raw byte span of the top-level `info` value in
 // a bencoded torrent. The span is returned verbatim (not re-encoded) so
 // the SHA-1 matches what every BitTorrent client computes.
@@ -113,7 +120,7 @@ func infoDictBytes(data []byte) ([]byte, error) {
 			return nil, err
 		}
 		valStart := next
-		valEnd, err := scanValue(data, valStart)
+		valEnd, err := scanValue(data, valStart, 1)
 		if err != nil {
 			return nil, err
 		}
@@ -126,9 +133,14 @@ func infoDictBytes(data []byte) ([]byte, error) {
 }
 
 // scanValue returns the index immediately past the bencoded value at pos.
-func scanValue(data []byte, pos int) (int, error) {
+// depth is the current container nesting level; it guards against
+// unbounded recursion on a hostile payload (see maxBencodeDepth).
+func scanValue(data []byte, pos, depth int) (int, error) {
 	if pos >= len(data) {
 		return 0, errors.New("unexpected end of bencode")
+	}
+	if depth > maxBencodeDepth {
+		return 0, errors.New("bencode nesting exceeds maximum depth")
 	}
 	c := data[pos]
 	switch {
@@ -149,7 +161,7 @@ func scanValue(data []byte, pos int) (int, error) {
 				}
 				pos = next
 			}
-			next, err := scanValue(data, pos)
+			next, err := scanValue(data, pos, depth+1)
 			if err != nil {
 				return 0, err
 			}

--- a/backend/internal/infohash/infohash_test.go
+++ b/backend/internal/infohash/infohash_test.go
@@ -100,6 +100,19 @@ func TestFromTorrent_NotBencode(t *testing.T) {
 	}
 }
 
+// TestFromTorrent_DeeplyNested_ReturnsError guards against a stack-exhaustion
+// DoS: the bencode scanner recurses per nested container, and a tracker
+// response is now fed straight into FromTorrent (rutracker dl.php validation).
+// A pathologically nested payload must be rejected, not recursed into.
+func TestFromTorrent_DeeplyNested_ReturnsError(t *testing.T) {
+	// info value is a list nested far deeper than any real torrent.
+	const depth = 2000
+	data := "d4:info" + strings.Repeat("l", depth) + strings.Repeat("e", depth) + "e"
+	if _, err := FromTorrent([]byte(data)); err == nil {
+		t.Error("expected error for pathologically nested bencode, got nil")
+	}
+}
+
 func TestFromPayload_PrefersMagnet(t *testing.T) {
 	const h = "c12fe1c06bba254a9dc9f519b335aa7c1367a88a"
 	got, err := FromPayload("magnet:?xt=urn:btih:"+h, []byte("ignored"))

--- a/backend/internal/plugins/e2etest/runner.go
+++ b/backend/internal/plugins/e2etest/runner.go
@@ -53,6 +53,14 @@ type Case struct {
 	// Useful for trackers whose Download path is intentionally a stub
 	// (e.g., lostfilm in v1.0).
 	SkipQBitSubmit bool
+
+	// ExpectTorrentFile, when true, asserts Download returned a .torrent
+	// payload (bytes, no magnet). Without it the runner's payload checks
+	// are conditional, so a regression that silently returns a magnet
+	// instead of a torrent would still pass — set this for trackers (e.g.
+	// RuTracker, #52) whose contract is "submit the real torrent, not a
+	// hash-only magnet".
+	ExpectTorrentFile bool
 }
 
 // RunFullPipeline drives a tracker plugin from URL parse all the way
@@ -150,6 +158,14 @@ func RunFullPipeline(t *testing.T, c Case) {
 		}
 		if payload.MagnetURI == "" && len(payload.TorrentFile) == 0 {
 			t.Error("Download returned empty payload (no magnet, no torrent bytes)")
+		}
+		if c.ExpectTorrentFile {
+			if len(payload.TorrentFile) == 0 {
+				t.Fatalf("expected a .torrent payload, got magnet %q", payload.MagnetURI)
+			}
+			if payload.MagnetURI != "" {
+				t.Errorf("expected no magnet alongside the .torrent, got %q", payload.MagnetURI)
+			}
 		}
 
 		if c.SkipQBitSubmit {

--- a/backend/internal/plugins/trackers/rutracker/rutracker.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/infohash"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
@@ -247,27 +248,45 @@ func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *doma
 	return meta, nil
 }
 
-// Download returns the magnet URI for the current topic. RuTracker also
-// exposes a downloadable .torrent file via dl.php, but the magnet alone
-// is enough for v0.3 — every torrent client we support accepts magnets.
+// Download submits a usable torrent payload for the current topic.
+//
+// RuTracker page magnets are hash-only (no `&tr=` announce URLs). For a
+// private tracker that is unusable: the client has no announce to reach
+// peers and no DHT fallback, so it sits on "Downloading metadata" forever
+// (#52). The authenticated `.torrent` from dl.php carries the announce
+// list and the full info dict, so we prefer it whenever we can fetch it.
+//
+// Priority:
+//  1. dl.php `.torrent` — when creds are configured (the link needs the
+//     session cookie) and the response validates as a bencoded torrent.
+//  2. page magnet — fallback when creds are absent, dl.php is missing, the
+//     fetch fails, or the response is not a real torrent (e.g. an HTML
+//     login page). A degraded magnet still beats a hard failure.
 func (p *plugin) Download(ctx context.Context, topic *domain.Topic, _ *domain.Check, creds *domain.TrackerCredential) (*domain.Payload, error) {
 	body, err := p.fetchTopicPage(ctx, topic, creds)
 	if err != nil {
 		return nil, err
 	}
+
+	if creds != nil {
+		if m := dlHrefRe.FindSubmatch(body); m != nil {
+			dlURL := "https://" + p.domain + "/forum/" + string(m[1])
+			// Validate the payload is a real bencoded torrent before
+			// submitting it — guards against handing the client an HTML
+			// login/error page that dl.php returns on a dead session.
+			if torrent, ferr := p.fetchBytes(ctx, topic, creds, dlURL); ferr == nil {
+				if _, verr := infohash.FromTorrent(torrent); verr == nil {
+					return &domain.Payload{TorrentFile: torrent, FileName: "rutracker.torrent"}, nil
+				}
+			}
+			// fall through to the magnet on any fetch/validation failure
+		}
+	}
+
 	if m := magnetRe.Find(body); m != nil {
 		return &domain.Payload{MagnetURI: string(m)}, nil
 	}
-	// Fall back to dl.php — needs the session cookie.
-	if m := dlHrefRe.FindSubmatch(body); m != nil {
-		dlURL := "https://" + p.domain + "/forum/" + string(m[1])
-		torrent, err := p.fetchBytes(ctx, topic, creds, dlURL)
-		if err != nil {
-			return nil, err
-		}
-		return &domain.Payload{TorrentFile: torrent, FileName: "rutracker.torrent"}, nil
-	}
-	return nil, errors.New("rutracker: no magnet link or dl.php link in topic page")
+	return nil, errors.New("rutracker: no usable .torrent (needs credentials) and no magnet link in topic page")
 }
 
 func (p *plugin) fetchTopicPage(ctx context.Context, topic *domain.Topic, creds *domain.TrackerCredential) ([]byte, error) {

--- a/backend/internal/plugins/trackers/rutracker/rutracker.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker.go
@@ -29,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/infohash"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
@@ -262,6 +264,10 @@ func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *doma
 //  2. page magnet — fallback when creds are absent, dl.php is missing, the
 //     fetch fails, or the response is not a real torrent (e.g. an HTML
 //     login page). A degraded magnet still beats a hard failure.
+//
+// Both fetches (topic page + dl.php) share the caller's context, which the
+// scheduler bounds with TrackerHTTPTimeout per Download invocation — so the
+// two sequential round-trips draw from one timeout budget.
 func (p *plugin) Download(ctx context.Context, topic *domain.Topic, _ *domain.Check, creds *domain.TrackerCredential) (*domain.Payload, error) {
 	body, err := p.fetchTopicPage(ctx, topic, creds)
 	if err != nil {
@@ -274,19 +280,46 @@ func (p *plugin) Download(ctx context.Context, topic *domain.Topic, _ *domain.Ch
 			// Validate the payload is a real bencoded torrent before
 			// submitting it — guards against handing the client an HTML
 			// login/error page that dl.php returns on a dead session.
-			if torrent, ferr := p.fetchBytes(ctx, topic, creds, dlURL); ferr == nil {
-				if _, verr := infohash.FromTorrent(torrent); verr == nil {
-					return &domain.Payload{TorrentFile: torrent, FileName: "rutracker.torrent"}, nil
+			torrent, ferr := p.fetchBytes(ctx, topic, creds, dlURL)
+			switch {
+			case ferr != nil:
+				// Fail-open: a degraded magnet still beats a hard failure,
+				// but log it — the operator-visible symptom of a dead
+				// session is the client stuck on metadata (#52), and a
+				// silent fallback would leave no breadcrumb.
+				log.Warn().Str("plugin", pluginName).Str("step", "download").
+					Str("url", dlURL).Err(ferr).
+					Msg("dl.php fetch failed; falling back to hash-only page magnet")
+			default:
+				if _, verr := infohash.FromTorrent(torrent); verr != nil {
+					log.Warn().Str("plugin", pluginName).Str("step", "download").
+						Str("url", dlURL).Err(verr).
+						Msg("dl.php returned a non-torrent payload; falling back to hash-only page magnet")
+					break
 				}
+				return &domain.Payload{TorrentFile: torrent, FileName: torrentFileName(string(m[1]))}, nil
 			}
-			// fall through to the magnet on any fetch/validation failure
 		}
 	}
 
 	if m := magnetRe.Find(body); m != nil {
 		return &domain.Payload{MagnetURI: string(m)}, nil
 	}
-	return nil, errors.New("rutracker: no usable .torrent (needs credentials) and no magnet link in topic page")
+	return nil, errors.New("rutracker: topic page has no downloadable torrent or magnet link")
+}
+
+// dlTopicIDRe extracts the numeric topic id from a `dl.php?t=<id>` link.
+var dlTopicIDRe = regexp.MustCompile(`t=(\d+)`)
+
+// torrentFileName derives a per-topic .torrent filename from the dl.php
+// link (`dl.php?t=<id>`) so deliveries are diagnosable instead of all
+// sharing one static name. Host-agnostic, so it works under test rewrites.
+// Falls back to a generic name when no id is present.
+func torrentFileName(dlPath string) string {
+	if m := dlTopicIDRe.FindStringSubmatch(dlPath); m != nil {
+		return "rutracker-" + m[1] + ".torrent"
+	}
+	return "rutracker.torrent"
 }
 
 func (p *plugin) fetchTopicPage(ctx context.Context, topic *domain.Topic, creds *domain.TrackerCredential) ([]byte, error) {

--- a/backend/internal/plugins/trackers/rutracker/rutracker_e2e_test.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker_e2e_test.go
@@ -36,6 +36,14 @@ func TestE2E(t *testing.T) {
 				case strings.HasPrefix(r.URL.Path, "/forum/viewtopic.php"):
 					w.WriteHeader(200)
 					_, _ = w.Write([]byte(e2eTopicHTML))
+				case strings.HasPrefix(r.URL.Path, "/forum/dl.php"):
+					// Authenticated .torrent download. Serving a real
+					// bencoded torrent here drives the #52 path: the
+					// pipeline must submit THIS file to qBittorrent, not
+					// the hash-only page magnet.
+					w.Header().Set("Content-Type", "application/x-bittorrent")
+					w.WriteHeader(200)
+					_, _ = w.Write([]byte(validBencodedTorrent))
 				case r.URL.Path == "/forum/index.php":
 					w.WriteHeader(200)
 					_, _ = w.Write([]byte(`<div id="logged-in-username">alice</div>`))

--- a/backend/internal/plugins/trackers/rutracker/rutracker_e2e_test.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker_e2e_test.go
@@ -25,7 +25,7 @@ const e2eTopicHTML = `<html>
 
 func TestE2E(t *testing.T) {
 	e2etest.RunFullPipeline(t, e2etest.Case{
-		Name: "rutracker/login-then-magnet-then-qbit",
+		Name: "rutracker/login-then-torrent-then-qbit",
 		Setup: func(t *testing.T, _ *e2etest.QBitFake) (registry.Tracker, string) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
@@ -71,5 +71,8 @@ func TestE2E(t *testing.T) {
 		},
 		ExpectedHash:         "0123456789abcdef0123456789abcdef01234567",
 		ExpectedNameContains: "Some Show",
+		// #52: an authenticated RuTracker download must submit the real
+		// .torrent (from dl.php), never the hash-only page magnet.
+		ExpectTorrentFile: true,
 	})
 }

--- a/backend/internal/plugins/trackers/rutracker/rutracker_test.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker_test.go
@@ -11,8 +11,15 @@ import (
 	"golang.org/x/text/encoding/charmap"
 
 	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/infohash"
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
+
+// validBencodedTorrent is a minimal but structurally valid single-file
+// .torrent the infohash package can parse. The mock dl.php serves it so
+// tests can prove Download submits a real torrent (with announce URLs)
+// rather than RuTracker's hash-only page magnet (#52).
+const validBencodedTorrent = "d8:announce19:http://tracker/annc4:infod6:lengthi100e4:name4:test12:piece lengthi16384e6:pieces20:aaaaaaaaaaaaaaaaaaaaee"
 
 // TestCleanTitle_DecodesWindows1251 feeds real cp1251-encoded bytes (the
 // encoding RuTracker actually serves) through cleanTitle and asserts they come
@@ -51,7 +58,7 @@ func newTestPlugin(t *testing.T) (*plugin, *httptest.Server) {
 		case strings.HasPrefix(r.URL.Path, "/forum/dl.php"):
 			w.Header().Set("Content-Type", "application/x-bittorrent")
 			w.WriteHeader(200)
-			w.Write([]byte("d8:announce..."))
+			w.Write([]byte(validBencodedTorrent))
 		case r.URL.Path == "/forum/index.php":
 			w.WriteHeader(200)
 			w.Write([]byte(`<div id="logged-in-username">alice</div>`))
@@ -133,7 +140,11 @@ func TestCheckExtractsHashAndTitle(t *testing.T) {
 	}
 }
 
-func TestDownloadReturnsMagnet(t *testing.T) {
+// TestDownloadReturnsMagnetWithoutCredentials covers the documented
+// fallback: dl.php needs the session cookie, so with no creds Download
+// must hand back the page magnet rather than fetch an unauthenticated
+// (HTML login) dl.php response.
+func TestDownloadReturnsMagnetWithoutCredentials(t *testing.T) {
 	p, _ := newTestPlugin(t)
 	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=987654"}
 
@@ -143,6 +154,70 @@ func TestDownloadReturnsMagnet(t *testing.T) {
 	}
 	if !strings.HasPrefix(payload.MagnetURI, "magnet:?xt=urn:btih:") {
 		t.Errorf("magnet URI: %q", payload.MagnetURI)
+	}
+}
+
+// TestDownloadPrefersTorrentFileWhenAuthenticated is the #52 regression: a
+// RuTracker page magnet is hash-only (no announce URLs), so an
+// authenticated Download must fetch the .torrent via dl.php instead of
+// handing qBittorrent a trackerless magnet it can never resolve.
+func TestDownloadPrefersTorrentFileWhenAuthenticated(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	creds := &domain.TrackerCredential{
+		UserID:    uuid.New(),
+		Username:  "alice",
+		SecretEnc: []byte("password123"),
+	}
+	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=987654"}
+
+	payload, err := p.Download(context.Background(), topic, nil, creds)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if payload.MagnetURI != "" {
+		t.Errorf("expected no magnet, got hash-only magnet %q", payload.MagnetURI)
+	}
+	if len(payload.TorrentFile) == 0 {
+		t.Fatal("expected a .torrent payload, got none")
+	}
+	if _, verr := infohash.FromTorrent(payload.TorrentFile); verr != nil {
+		t.Errorf("payload is not a valid bencoded torrent: %v", verr)
+	}
+}
+
+// TestDownloadFallsBackToMagnetWhenTorrentInvalid guards the fail-open
+// path: if dl.php returns something that is not a bencoded torrent (an
+// HTML error/login page), Download must not submit that garbage — it
+// falls back to the page magnet.
+func TestDownloadFallsBackToMagnetWhenTorrentInvalid(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/forum/viewtopic.php"):
+			w.WriteHeader(200)
+			w.Write([]byte(fixtureTopicHTML))
+		case strings.HasPrefix(r.URL.Path, "/forum/dl.php"):
+			w.WriteHeader(200)
+			w.Write([]byte("<html><body>Please log in</body></html>"))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	hostNoScheme := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{
+		sessions:  forumcommon.New(),
+		domain:    hostNoScheme,
+		transport: &schemeRewrite{target: hostNoScheme},
+	}
+	creds := &domain.TrackerCredential{UserID: uuid.New(), Username: "alice", SecretEnc: []byte("pw")}
+	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=987654"}
+
+	payload, err := p.Download(context.Background(), topic, nil, creds)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if !strings.HasPrefix(payload.MagnetURI, "magnet:?xt=urn:btih:") {
+		t.Errorf("expected magnet fallback, got %q / %d torrent bytes", payload.MagnetURI, len(payload.TorrentFile))
 	}
 }
 

--- a/backend/internal/plugins/trackers/rutracker/rutracker_test.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker_test.go
@@ -19,6 +19,12 @@ import (
 // .torrent the infohash package can parse. The mock dl.php serves it so
 // tests can prove Download submits a real torrent (with announce URLs)
 // rather than RuTracker's hash-only page magnet (#52).
+//
+// Bencode length prefixes are hand-counted — if you edit a string segment,
+// recount its prefix or FromTorrent will reject it: "19:" = len of
+// "http://tracker/annc", "4:" = "test", "20:" = the 20 'a' piece bytes.
+// TestDownloadPrefersTorrentFileWhenAuthenticated asserts FromTorrent
+// accepts this, so a miscount fails loudly rather than silently.
 const validBencodedTorrent = "d8:announce19:http://tracker/annc4:infod6:lengthi100e4:name4:test12:piece lengthi16384e6:pieces20:aaaaaaaaaaaaaaaaaaaaee"
 
 // TestCleanTitle_DecodesWindows1251 feeds real cp1251-encoded bytes (the
@@ -93,7 +99,7 @@ func (s *schemeRewrite) RoundTrip(req *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(req)
 }
 
-func TestCanParse(t *testing.T) {
+func TestCanParse_ViewtopicURLs_MatchExpected(t *testing.T) {
 	p := &plugin{}
 	cases := map[string]bool{
 		"https://rutracker.org/forum/viewtopic.php?t=12345":     true,
@@ -110,7 +116,7 @@ func TestCanParse(t *testing.T) {
 	}
 }
 
-func TestParseExtractsTopicID(t *testing.T) {
+func TestParse_ValidURL_ExtractsTopicID(t *testing.T) {
 	p := &plugin{}
 	topic, err := p.Parse(context.Background(), "https://rutracker.org/forum/viewtopic.php?t=987654")
 	if err != nil {
@@ -124,7 +130,7 @@ func TestParseExtractsTopicID(t *testing.T) {
 	}
 }
 
-func TestCheckExtractsHashAndTitle(t *testing.T) {
+func TestCheck_AuthenticatedPage_ExtractsHashAndTitle(t *testing.T) {
 	p, _ := newTestPlugin(t)
 	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=987654"}
 
@@ -183,6 +189,75 @@ func TestDownloadPrefersTorrentFileWhenAuthenticated(t *testing.T) {
 	if _, verr := infohash.FromTorrent(payload.TorrentFile); verr != nil {
 		t.Errorf("payload is not a valid bencoded torrent: %v", verr)
 	}
+	// FileName carries the topic id so deliveries are diagnosable.
+	if payload.FileName != "rutracker-987654.torrent" {
+		t.Errorf("FileName = %q, want %q", payload.FileName, "rutracker-987654.torrent")
+	}
+}
+
+// TestDownloadFallsBackToMagnetWhenDlPhpUnauthorized covers the
+// non-200 branch: dl.php returns 403/404 (e.g. a stale session) while the
+// page still has a magnet, so Download falls back to the magnet rather
+// than erroring.
+func TestDownloadFallsBackToMagnetWhenDlPhpUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/forum/viewtopic.php"):
+			w.WriteHeader(200)
+			w.Write([]byte(fixtureTopicHTML))
+		case strings.HasPrefix(r.URL.Path, "/forum/dl.php"):
+			w.WriteHeader(403)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	hostNoScheme := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{
+		sessions:  forumcommon.New(),
+		domain:    hostNoScheme,
+		transport: &schemeRewrite{target: hostNoScheme},
+	}
+	creds := &domain.TrackerCredential{UserID: uuid.New(), Username: "alice", SecretEnc: []byte("pw")}
+	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=987654"}
+
+	payload, err := p.Download(context.Background(), topic, nil, creds)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if !strings.HasPrefix(payload.MagnetURI, "magnet:?xt=urn:btih:") {
+		t.Errorf("expected magnet fallback, got %q / %d torrent bytes", payload.MagnetURI, len(payload.TorrentFile))
+	}
+}
+
+// TestDownloadErrorsWhenNoTorrentAndNoMagnet covers the hard-error path:
+// creds present, dl.php absent from the page, and no magnet either (a
+// corrupt/stripped topic page). Download must return a descriptive error
+// rather than a nil payload.
+func TestDownloadErrorsWhenNoTorrentAndNoMagnet(t *testing.T) {
+	const barePage = `<html><head><title>Broken :: RuTracker.org</title></head>
+<body><div id="logged-in-username">alice</div></body></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(barePage))
+	}))
+	t.Cleanup(srv.Close)
+	hostNoScheme := strings.TrimPrefix(srv.URL, "http://")
+	p := &plugin{
+		sessions:  forumcommon.New(),
+		domain:    hostNoScheme,
+		transport: &schemeRewrite{target: hostNoScheme},
+	}
+	creds := &domain.TrackerCredential{UserID: uuid.New(), Username: "alice", SecretEnc: []byte("pw")}
+	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=987654"}
+
+	_, err := p.Download(context.Background(), topic, nil, creds)
+	if err == nil {
+		t.Fatal("expected an error when the page has no torrent and no magnet")
+	}
+	if !strings.Contains(err.Error(), "no downloadable torrent or magnet") {
+		t.Errorf("error = %q, want it to describe the missing payload neutrally", err.Error())
+	}
 }
 
 // TestDownloadFallsBackToMagnetWhenTorrentInvalid guards the fail-open
@@ -221,7 +296,7 @@ func TestDownloadFallsBackToMagnetWhenTorrentInvalid(t *testing.T) {
 	}
 }
 
-func TestResolveMetadata_OgImagePreferred(t *testing.T) {
+func TestResolveMetadata_OgImagePresent_ReturnsOgURL(t *testing.T) {
 	// Page carries both an og:image meta tag and a postImg <var> — og:image
 	// must win as the most robust source.
 	html := `<html><head>
@@ -256,7 +331,7 @@ func TestResolveMetadata_OgImagePreferred(t *testing.T) {
 	}
 }
 
-func TestResolveMetadata_PostVarTitleFallback(t *testing.T) {
+func TestResolveMetadata_NoOgImagePostVarPresent_ReturnsPostVarURL(t *testing.T) {
 	// No og:image — the real image lives in the lazy-loaded postImg <var>
 	// title attribute (src is a placeholder gif).
 	html := `<html><head><title>Another Show :: RuTracker.org</title></head><body>
@@ -286,7 +361,7 @@ func TestResolveMetadata_PostVarTitleFallback(t *testing.T) {
 	}
 }
 
-func TestResolveMetadata_NoImageReturnsEmpty(t *testing.T) {
+func TestResolveMetadata_NoPoster_ReturnsEmptyURL(t *testing.T) {
 	// The existing fixture has no poster — ImageURL must be "" (never fabricated).
 	p, _ := newTestPlugin(t)
 	meta, err := p.ResolveMetadata(context.Background(), "https://rutracker.org/forum/viewtopic.php?t=987654", nil)
@@ -301,7 +376,7 @@ func TestResolveMetadata_NoImageReturnsEmpty(t *testing.T) {
 	}
 }
 
-func TestLogin(t *testing.T) {
+func TestLogin_ValidCredentials_SetsLoggedIn(t *testing.T) {
 	p, _ := newTestPlugin(t)
 	creds := &domain.TrackerCredential{
 		UserID:    uuid.New(),


### PR DESCRIPTION
## Summary

- RuTracker page magnets are **hash-only** (no `&tr=` announce URLs). On a private tracker the client has no announce to reach peers and no DHT fallback, so qBittorrent sat on `Downloading metadata` forever while Marauder recorded the push as **delivered** — the silent "delivered but stuck" state from #52.
- `Download` now **prefers the authenticated `.torrent` from `dl.php`** (which carries the announce list and full info dict) when credentials are configured, and **validates it is a real bencoded torrent** (via the `infohash` package) before submitting.
- Falls back to the page magnet only when credentials are absent, `dl.php` is missing, or the fetch/validation fails — a degraded magnet still beats a hard failure.

## Test Plan

- `go build ./... && go vet ./... && go test -race ./...` — all green.
- New unit test `TestDownloadPrefersTorrentFileWhenAuthenticated` (the #52 regression — verified RED against magnet-first code, then GREEN).
- Two fallback guards: magnet returned without credentials, and magnet returned when `dl.php` serves a non-bencoded (HTML login) page.
- Extended the Go-level e2e (`e2etest.RunFullPipeline`): `dl.php` now serves a real bencoded torrent, so the full `Parse → Login → Check → Download → qBittorrent.Add` pipeline pushes the **torrent file** to the fake qBittorrent rather than the trackerless magnet. Runs in CI on every push via `go test`.

## Note

On a `dl.php` fetch/validation failure with creds present, the code falls back to the hash-only magnet (matches the issue's step 4 wording) rather than failing the topic closed. Open to switching to fail-closed there if preferred.

Closes #52