### PR TITLE
chore(readme): sync version on release + add CI status badges

### DIFF
--- a/.github/scripts/bump-version-refs.sh
+++ b/.github/scripts/bump-version-refs.sh
@@ -43,4 +43,14 @@ sed -i -E "s|(version: \")${SEMVER}(\")|\1${VER}\2|"              "$ROOT/site/sr
 sed -i -E "s|(\"version\": \")${SEMVER}(\")|\1${VER}\2|"          "$ROOT/site/src/pages/install.astro"
 sed -i -E "s|(defaults to <code>)${SEMVER}(</code>)|\1${VER}\2|"  "$ROOT/site/src/pages/install.astro"
 
+# README.md — only the three CURRENT-version markers. The shields release badge
+# (alt text + URL), the bold "**vX.Y.Z**" latest-release marker under Project
+# status, and the MARAUDER_VERSION default note. Deliberately anchored so the
+# HISTORICAL mentions in the same prose ("v1.0.0 was the initial production
+# cut", "v1.0.1 ... first to publish to GHCR") are left untouched.
+sed -i -E "s|(Release: v)${SEMVER}|\1${VER}|"                     "$ROOT/README.md"
+sed -i -E "s|(badge/release-v)${SEMVER}(-success)|\1${VER}\2|"    "$ROOT/README.md"
+sed -i -E "s|(\*\*v)${SEMVER}(\*\*)|\1${VER}\2|"                  "$ROOT/README.md"
+sed -i -E "s|(defaults to \`)${SEMVER}(\`)|\1${VER}\2|"           "$ROOT/README.md"
+
 echo "bump-version-refs: stamped ${VER} into deploy/ and site/ version references"

--- a/.github/scripts/bump-version-refs_test.sh
+++ b/.github/scripts/bump-version-refs_test.sh
@@ -35,6 +35,7 @@ cp "$REPO/deploy/docker-compose.ghcr.yml" "$TMP/deploy/"
 cp "$REPO/deploy/.env.example"            "$TMP/deploy/"
 cp "$REPO/site/src/data/seo.ts"           "$TMP/site/src/data/"
 cp "$REPO/site/src/pages/install.astro"   "$TMP/site/src/pages/"
+cp "$REPO/README.md"                       "$TMP/"
 
 # Capture releaseDate before the bump (must be unchanged after).
 RELDATE_BEFORE="$(grep -E 'releaseDate:' "$TMP/site/src/data/seo.ts")"
@@ -52,10 +53,18 @@ check "env.example pin"              "1" "$(count "MARAUDER_VERSION=$VER" "$TMP/
 check "seo.ts software version"      "1" "$(count "version: \"$VER\"" "$TMP/site/src/data/seo.ts")"
 check "install.astro example output" "1" "$(count "\"version\": \"$VER\"" "$TMP/site/src/pages/install.astro")"
 check "install.astro default note"   "1" "$(count "defaults to <code>$VER</code>" "$TMP/site/src/pages/install.astro")"
+check "README release badge alt"     "1" "$(count "Release: v$VER" "$TMP/README.md")"
+check "README release badge url"     "1" "$(count "badge/release-v$VER-success" "$TMP/README.md")"
+check "README latest-release marker" "1" "$(count "\*\*v$VER\*\*" "$TMP/README.md")"
+check "README install default"       "1" "$(count "defaults to \`$VER\`" "$TMP/README.md")"
 
 # ... and no stale 1.0.x version literals linger in the edited spots.
 check "no stale ghcr fallback"       "0" "$(count ":-1\.0\.[0-9]+}" "$TMP/deploy/docker-compose.ghcr.yml")"
 check "no stale env pin"             "0" "$(count "MARAUDER_VERSION=1\.0\.[0-9]+" "$TMP/deploy/.env.example")"
+
+# README HISTORICAL mentions must be preserved (anchored seds must not touch them).
+check "README keeps v1.0.0 history"  "1" "$(count "v1\.0\.0 was the initial production cut" "$TMP/README.md")"
+check "README keeps GHCR-first fact" "1" "$(count "v1\.0\.1 was the first release to publish" "$TMP/README.md")"
 
 # releaseDate (JSON-LD datePublished) must be untouched.
 check "releaseDate unchanged" "$RELDATE_BEFORE" "$(grep -E 'releaseDate:' "$TMP/site/src/data/seo.ts")"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,8 +255,10 @@ an escape hatch). The flow:
   `.github/scripts/bump-version-refs.sh` (tested by `bump-version-refs_test.sh`):
   `deploy/docker-compose.yml` (source-build), `deploy/docker-compose.ghcr.yml`
   (`${MARAUDER_VERSION:-X.Y.Z}` defaults), `deploy/.env.example`,
-  `site/src/data/seo.ts` (`SITE.software.version`), and `site/src/pages/install.astro`
-  (example output + default note). It makes **two commits**: deploy/repo files
+  `site/src/data/seo.ts` (`SITE.software.version`), `site/src/pages/install.astro`
+  (example output + default note), and `README.md` (release badge, the bold
+  `**vX.Y.Z**` latest-release marker, and the `MARAUDER_VERSION` default note —
+  historical version mentions are left untouched). It makes **two commits**: deploy/repo files
   `[skip ci]`, then the `site/**` files **without** `[skip ci]` (committed last
   so it's the push HEAD) so `site.yml` redeploys marauder.cc. **Don't hand-edit
   these version literals** — and note `seo.ts` `releaseDate` is intentionally

--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@
 **A modern, self-hosted torrent topic monitor for the trackers the *arr stack can't reach.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release: v1.0.1](https://img.shields.io/badge/release-v1.0.1-success.svg)](CHANGELOG.md)
+[![Release: v1.0.6](https://img.shields.io/badge/release-v1.0.6-success.svg)](CHANGELOG.md)
+
+[![CI](https://github.com/artyomsv/marauder/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/artyomsv/marauder/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/codeql.yml)
+[![Docker build + scan](https://github.com/artyomsv/marauder/actions/workflows/docker.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/docker.yml)
+[![E2E (nightly)](https://github.com/artyomsv/marauder/actions/workflows/e2e.yml/badge.svg)](https://github.com/artyomsv/marauder/actions/workflows/e2e.yml)
+[![Client acceptance (nightly)](https://github.com/artyomsv/marauder/actions/workflows/client-acceptance.yml/badge.svg)](https://github.com/artyomsv/marauder/actions/workflows/client-acceptance.yml)
+[![Deploy site](https://github.com/artyomsv/marauder/actions/workflows/site.yml/badge.svg)](https://github.com/artyomsv/marauder/actions/workflows/site.yml)
+
 [![Go](https://img.shields.io/badge/backend-Go%201.25-00ADD8.svg)](backend/)
 [![React 19](https://img.shields.io/badge/frontend-React%2019.2-61DAFB.svg)](frontend/)
 [![Postgres 18](https://img.shields.io/badge/database-Postgres%2018-336791.svg)](deploy/)
@@ -61,8 +69,8 @@ Read the full rationale: [VISION.md](docs/VISION.md) ·
 
 ## Project status
 
-**v1.0.1** — latest release (v1.0.0 was the initial production cut;
-v1.0.1 is the first release to publish container images to GHCR).
+**v1.0.6** — latest release (v1.0.0 was the initial production cut;
+v1.0.1 was the first release to publish container images to GHCR).
 
 What works **today**:
 
@@ -125,7 +133,7 @@ docker compose -f docker-compose.ghcr.yml --env-file .env up -d
 ```
 
 Requires Docker Compose **v2.23.1+**. Pin the release with `MARAUDER_VERSION`
-in `.env` (defaults to `1.0.1`); `latest` also exists.
+in `.env` (defaults to `1.0.6`); `latest` also exists.
 
 ### Build from source (contributors)
 


### PR DESCRIPTION
## Summary
Two README improvements.

### 1. Version sync (the gap reported: README version wasn't updated on release)
The release pipeline synced `seo.ts`, the deploy files, and `install.astro`, but **not the root README**, which had drifted to `v1.0.1` (badge, "latest release" marker, and `MARAUDER_VERSION` default note).

- `bump-version-refs.sh` now also stamps README's release badge (alt + shields URL), the bold `**vX.Y.Z**` latest-release marker, and the `defaults to \`X.Y.Z\`` note — **anchored** so the *historical* mentions (`v1.0.0 was the initial production cut`, `v1.0.1 was the first to publish to GHCR`) are left untouched.
- Corrected the README to the current **1.0.6** and made the GHCR-first line past tense.
- `bump-version-refs_test.sh` extended (18 assertions) — covers the README markers **and** asserts the history is preserved.

### 2. CI status badges
Added live GitHub Actions badges: **CI**, **CodeQL**, **Docker build + scan**, **E2E (nightly)**, **Client acceptance (nightly)**, **Deploy site**.

## Test Plan
- `bump-version-refs_test.sh` → 18/18 (runs in the `release-scripts` CI job).
- This PR is `chore:` → **no release cut**; future releases will keep README in sync automatically.