### PR TITLE
fix: relabel delivery notification and mark qBittorrent validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **qBittorrent is now validated end-to-end** and promoted from `alpha` to
+  `validated` on marauder.cc. Verified against a real qBittorrent container:
+  login, magnet/.torrent submit, and live download status by infohash.
+
 ## [1.0.6] - 2026-06-21
 
 ### Fixed

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -430,7 +430,7 @@ func (s *Scheduler) notifyUpdated(ctx context.Context, t *domain.Topic, labels [
 		overflow = len(shown) - maxList
 		shown = shown[:maxList]
 	}
-	body := "Downloaded: " + strings.Join(shown, ", ")
+	body := "Sent to client: " + strings.Join(shown, ", ")
 	if overflow > 0 {
 		body += fmt.Sprintf(" (+%d more)", overflow)
 	}

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -451,6 +451,14 @@ func TestRunCheck_SinglePayload_NotifiesUpdated(t *testing.T) {
 	if !strings.Contains(f.notifier.lastMsg.Body, "Fake Topic") {
 		t.Errorf("body = %q, want it to mention the topic name", f.notifier.lastMsg.Body)
 	}
+	// The notification fires when the torrent is handed to the client (download
+	// START), not when it finishes. The body must not claim completion.
+	if strings.Contains(f.notifier.lastMsg.Body, "Downloaded") {
+		t.Errorf("body = %q, must not claim the torrent finished downloading", f.notifier.lastMsg.Body)
+	}
+	if !strings.Contains(f.notifier.lastMsg.Body, "Sent to client") {
+		t.Errorf("body = %q, want it to say the release was sent to the client", f.notifier.lastMsg.Body)
+	}
 }
 
 func TestRunCheck_NoDownload_DoesNotNotify(t *testing.T) {

--- a/site/src/data/clients.ts
+++ b/site/src/data/clients.ts
@@ -16,7 +16,7 @@ export const clients: Client[] = [
     slug: "qbittorrent",
     name: "qBittorrent",
     description: "WebUI API v2 — qBittorrent 4.5+ and 5.x. Live download status by infohash.",
-    status: "alpha",
+    status: "validated",
   },
   {
     slug: "deluge",

--- a/site/src/pages/integrations.astro
+++ b/site/src/pages/integrations.astro
@@ -52,10 +52,10 @@ const schemas = [
       <h2 id="clients-heading" class="mb-2 text-2xl font-semibold tracking-tight">Torrent clients</h2>
       <p class="mb-6 text-muted-foreground">
         When a topic updates, Marauder hands the magnet URI or .torrent bytes
-        to one of these clients. Transmission is the end-to-end-validated
-        reference path; the others are in beta, pending live validation.
-        Transmission and qBittorrent also report live per-torrent download
-        progress back into the Topics view.
+        to one of these clients. Transmission and qBittorrent are the
+        end-to-end-validated reference paths; the others are in beta, pending
+        live validation. Transmission and qBittorrent also report live
+        per-torrent download progress back into the Topics view.
       </p>
       <div class="grid gap-4 md:grid-cols-2">
         {clients.map((c) => (


### PR DESCRIPTION
## Summary

- **Notification wording fix.** The scheduler's `updated` event fires when a torrent is handed to the download client (download *start*), but the body read `Downloaded: ...` — falsely implying the transfer had finished. Reworded to `Sent to client: ...`, matching the codebase's delivery vocabulary. No completion notification exists; this only corrects the existing event's wording.
- **qBittorrent promoted alpha → validated** on marauder.cc. Verified end-to-end against a real qBittorrent container (login, magnet/.torrent submit, live status by infohash). Updates `site/src/data/clients.ts`, the integrations-page prose, and `CHANGELOG.md`.

## Test Plan

- `go test -race ./internal/scheduler/` — passes. Extended `TestRunCheck_SinglePayload_NotifiesUpdated` to assert the body says "Sent to client" and not "Downloaded" (watched it fail first, then pass).
- `npm run build` (site) — builds clean; integrations page now shows qBittorrent with the `stable` pill.