### PR TITLE
fix(qbittorrent): set native category on torrent add (#75)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,6 +68,9 @@ jobs:
             PW=$(docker logs deploy-qbittorrent-1 2>&1 | grep "temporary password" | awk '{print $NF}' | tail -1 || true)
             if [ -n "$PW" ]; then
               echo "qBit temporary password acquired"
+              # Mask it everywhere downstream — it's a step output, not a
+              # registered secret, so it is not auto-redacted from logs.
+              echo "::add-mask::$PW"
               echo "password=$PW" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -108,13 +111,14 @@ jobs:
           CLIENT_ID=$(echo "$CLIENT_JSON" | awk -F'"id":"' '{print $2}' | awk -F'"' '{print $1}')
           test -n "$CLIENT_ID"
 
-          echo "[3] add magnet topic"
+          echo "[3] add magnet topic with a category (issue #75)"
           INFOHASH=0123456789abcdef0123456789abcdef01234567
+          CATEGORY=sonarr-e2e
           MAG="magnet:?xt=urn:btih:${INFOHASH}&dn=marauder-e2e"
           TOPIC_JSON=$(curl -sS -X POST http://localhost:34080/api/v1/topics \
             -H "Authorization: Bearer $TOK" \
             -H "Content-Type: application/json" \
-            -d "{\"url\":\"$MAG\",\"client_id\":\"$CLIENT_ID\"}")
+            -d "{\"url\":\"$MAG\",\"client_id\":\"$CLIENT_ID\",\"category\":\"$CATEGORY\"}")
           echo "$TOPIC_JSON"
           TOPIC_ID=$(echo "$TOPIC_JSON" | awk -F'"ID":"' '{print $2}' | awk -F'"' '{print $1}')
           test -n "$TOPIC_ID"
@@ -128,17 +132,43 @@ jobs:
           # does, so a host-side login returns 401.
           sleep 75
           echo "[5] verify delivery via Marauder topic status API"
+          DELIVERED=
           for _ in $(seq 1 6); do
             STATUS=$(curl -sS -H "Authorization: Bearer $TOK" \
               "http://localhost:34080/api/v1/topics/$TOPIC_ID/status")
             echo "$STATUS"
             if echo "$STATUS" | grep -q "$INFOHASH"; then
               echo "delivery recorded for $INFOHASH"
-              exit 0
+              DELIVERED=1
+              break
             fi
             sleep 10
           done
-          echo "torrent $INFOHASH never appeared in topic status"
+          [ -n "$DELIVERED" ] || { echo "torrent $INFOHASH never appeared in topic status"; exit 1; }
+
+          echo "[6] verify qBittorrent recorded the category (issue #75)"
+          # Query qBittorrent from INSIDE the compose network so the Host
+          # header is qbittorrent:6611 (matching its WebUI port) — a host-side
+          # login would 401 on qBittorrent 5.x (see the step [4] note).
+          # The password and infohash are forwarded as container env vars (-e)
+          # and the body is single-quoted, so nothing is string-interpolated
+          # into the shell command.
+          QBIT_INFO=$(docker run --rm --network deploy_default \
+            -e QBIT_PASSWORD -e INFOHASH="$INFOHASH" \
+            curlimages/curl:8.11.1 sh -c '
+              SID=$(curl -sS -i -X POST "http://qbittorrent:6611/api/v2/auth/login" \
+                --data-urlencode "username=admin" \
+                --data-urlencode "password=$QBIT_PASSWORD" \
+                | grep -i "^set-cookie:" | sed "s/.*SID=//I" | cut -d";" -f1)
+              test -n "$SID" || { echo "qBit login failed (no SID cookie)" >&2; exit 1; }
+              curl -sS -H "Cookie: SID=$SID" \
+                "http://qbittorrent:6611/api/v2/torrents/info?hashes=$INFOHASH"')
+          echo "$QBIT_INFO"
+          if echo "$QBIT_INFO" | grep -q "\"category\":\"$CATEGORY\""; then
+            echo "qBittorrent category correctly set to $CATEGORY"
+            exit 0
+          fi
+          echo "qBittorrent did NOT record category=$CATEGORY (issue #75 regression)"
           exit 1
 
       - name: Print stack logs on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **qBittorrent category is now set on the torrent** — a topic's category was
+  folded into the save path but never sent as qBittorrent's native `category`
+  field, so completed torrents had an empty category and tools like Sonarr
+  (which discover downloads by category) could not import them. The category is
+  now sent on `/api/v2/torrents/add`. (#75)
+
 ## [1.1.0] - 2026-06-22
 
 ### Added

--- a/backend/internal/plugins/clients/qbittorrent/category_test.go
+++ b/backend/internal/plugins/clients/qbittorrent/category_test.go
@@ -71,24 +71,24 @@ func TestAdd_CategoryField(t *testing.T) {
 		wantSavePath string
 	}{
 		{
-			name: "magnet with category sends field and nests save path",
+			name:    "magnet with category sends field and nests save path",
 			payload: magnet, category: "sonarr-topic",
 			wantPresent: true, wantCategory: "sonarr-topic",
 			wantSavePath: base + "/sonarr-topic",
 		},
 		{
-			name: "torrent file with category sends field too",
+			name:    "torrent file with category sends field too",
 			payload: torrent, category: "sonarr-topic",
 			wantPresent: true, wantCategory: "sonarr-topic",
 			wantSavePath: base + "/sonarr-topic",
 		},
 		{
-			name: "no category omits field",
+			name:    "no category omits field",
 			payload: magnet, category: "",
 			wantPresent: false, wantSavePath: base,
 		},
 		{
-			name: "whitespace-only category omits field",
+			name:    "whitespace-only category omits field",
 			payload: magnet, category: "   ",
 			wantPresent: false, wantSavePath: base,
 		},
@@ -96,7 +96,7 @@ func TestAdd_CategoryField(t *testing.T) {
 			// A path-ish category must be sanitised identically for the label
 			// and the save-path segment, so they stay aligned (issue #75 / the
 			// SanitizeCategory consistency fix).
-			name: "path-like category is sanitised to match save path",
+			name:    "path-like category is sanitised to match save path",
 			payload: magnet, category: "../tv",
 			wantPresent: true, wantCategory: "tv",
 			wantSavePath: base + "/tv",

--- a/backend/internal/plugins/clients/qbittorrent/category_test.go
+++ b/backend/internal/plugins/clients/qbittorrent/category_test.go
@@ -1,0 +1,126 @@
+package qbittorrent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+)
+
+// captureAddFields runs plugin.Add against a stand-in qBittorrent endpoint and
+// returns every multipart field the plugin sent to /api/v2/torrents/add.
+func captureAddFields(t *testing.T, cfg Config, payload *domain.Payload, opts domain.AddOptions) map[string]string {
+	t.Helper()
+	fields := map[string]string{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/app/version", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("v4.6.0"))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		if mr, err := r.MultipartReader(); err == nil {
+			for {
+				p, err := mr.NextPart()
+				if err != nil {
+					break
+				}
+				b, _ := io.ReadAll(p)
+				fields[p.FormName()] = string(b)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg.URL = srv.URL
+	raw, _ := json.Marshal(cfg)
+	p := &plugin{sessions: map[string]*session{}}
+	if err := p.Add(context.Background(), raw, payload, opts); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	return fields
+}
+
+// TestAdd_CategoryField is the regression test for issue #75: a topic's
+// category must reach qBittorrent as the native "category" field on
+// /api/v2/torrents/add (not only baked into the save path), otherwise tools
+// like Sonarr — which discover torrents by qBittorrent category — never see
+// it. The category is sanitised with the same helper that nests the save path
+// so the label and the folder segment can never diverge.
+func TestAdd_CategoryField(t *testing.T) {
+	const base = "/data2/torrents2/completed2"
+	magnet := &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:abc"}
+	torrent := &domain.Payload{TorrentFile: []byte("d8:announce..."), FileName: "movie.torrent"}
+
+	tests := []struct {
+		name         string
+		payload      *domain.Payload
+		category     string
+		wantPresent  bool
+		wantCategory string
+		wantSavePath string
+	}{
+		{
+			name: "magnet with category sends field and nests save path",
+			payload: magnet, category: "sonarr-topic",
+			wantPresent: true, wantCategory: "sonarr-topic",
+			wantSavePath: base + "/sonarr-topic",
+		},
+		{
+			name: "torrent file with category sends field too",
+			payload: torrent, category: "sonarr-topic",
+			wantPresent: true, wantCategory: "sonarr-topic",
+			wantSavePath: base + "/sonarr-topic",
+		},
+		{
+			name: "no category omits field",
+			payload: magnet, category: "",
+			wantPresent: false, wantSavePath: base,
+		},
+		{
+			name: "whitespace-only category omits field",
+			payload: magnet, category: "   ",
+			wantPresent: false, wantSavePath: base,
+		},
+		{
+			// A path-ish category must be sanitised identically for the label
+			// and the save-path segment, so they stay aligned (issue #75 / the
+			// SanitizeCategory consistency fix).
+			name: "path-like category is sanitised to match save path",
+			payload: magnet, category: "../tv",
+			wantPresent: true, wantCategory: "tv",
+			wantSavePath: base + "/tv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := captureAddFields(t,
+				Config{Username: "admin", Password: "secret", DownloadDir: base},
+				tt.payload,
+				domain.AddOptions{Category: tt.category},
+			)
+
+			got, present := fields["category"]
+			if present != tt.wantPresent {
+				t.Errorf("category field present = %v (value %q), want present = %v", present, got, tt.wantPresent)
+			}
+			if tt.wantPresent && got != tt.wantCategory {
+				t.Errorf("category field = %q, want %q", got, tt.wantCategory)
+			}
+			if sp := fields["savepath"]; sp != tt.wantSavePath {
+				t.Errorf("savepath = %q, want %q", sp, tt.wantSavePath)
+			}
+		})
+	}
+}

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
@@ -125,6 +125,14 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 	if dir := registry.EffectiveDownloadDir(cfg.DownloadDir, opts.DownloadDir, opts.Category); dir != "" {
 		_ = mw.WriteField("savepath", dir)
 	}
+	// Also set the native qBittorrent category (issue #75). The category is
+	// already folded into the save path above, but tools like Sonarr discover
+	// completed torrents by qBittorrent category, not by folder — so the label
+	// must be set explicitly too. Derive it from the same SanitizeCategory used
+	// for the save path so the label and the folder segment can never diverge.
+	if category := registry.SanitizeCategory(opts.Category); category != "" {
+		_ = mw.WriteField("category", category)
+	}
 	if opts.Paused {
 		_ = mw.WriteField("paused", "true")
 	}

--- a/backend/internal/plugins/registry/downloaddir.go
+++ b/backend/internal/plugins/registry/downloaddir.go
@@ -28,16 +28,19 @@ func EffectiveDownloadDir(base, override, category string) string {
 	if override != "" {
 		return override
 	}
-	category = sanitizeCategory(category)
+	category = SanitizeCategory(category)
 	if category == "" {
 		return base
 	}
 	return path.Join(base, category)
 }
 
-// sanitizeCategory normalises a user-supplied category into a safe relative
-// path segment that cannot traverse above its base folder.
-func sanitizeCategory(category string) string {
+// SanitizeCategory normalises a user-supplied category into a safe relative
+// path segment that cannot traverse above its base folder. It is exported so
+// client plugins that set a native category/label (e.g. qBittorrent) derive it
+// from the same value that nests the save path, keeping the folder and the
+// label aligned for any input.
+func SanitizeCategory(category string) string {
 	category = strings.TrimSpace(category)
 	if category == "" {
 		return ""

--- a/docs/test-e2e-magnet.md
+++ b/docs/test-e2e-magnet.md
@@ -88,10 +88,13 @@ MAG='magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=marauder-te
 curl -sS -X POST http://localhost:34080/api/v1/topics \
   -H "Authorization: Bearer $TOK" \
   -H "Content-Type: application/json" \
-  -d "{\"url\":\"$MAG\",\"client_id\":\"$CLIENT_ID\"}"
+  -d "{\"url\":\"$MAG\",\"client_id\":\"$CLIENT_ID\",\"category\":\"sonarr-test\"}"
 ```
 
-You should see a `Topic` JSON with `"TrackerName":"genericmagnet"`.
+You should see a `Topic` JSON with `"TrackerName":"genericmagnet"`. The
+optional `category` both nests the save path under `sonarr-test/` **and** sets
+qBittorrent's native category (issue #75), which is what download managers like
+Sonarr key off to import the completed files.
 
 ## 6. Wait for one scheduler tick
 
@@ -122,6 +125,13 @@ Expected: a JSON array containing at least one entry with:
 - `"name": "marauder-test-file"`
 - `"hash": "0123456789abcdef0123456789abcdef01234567"`
 - `"state": "metaDL"` (fetching metadata from DHT / trackers)
+- `"category": "sonarr-test"` (issue #75 — the native qBittorrent category)
+
+> Note: from the host, a qBittorrent 5.x login can return `401` because the
+> published host port (`34611`) differs from qBittorrent's WebUI port (`6611`),
+> which trips its Host-header check. If so, run the login/info `curl` from
+> inside the compose network instead (Host `qbittorrent:6611`), e.g. via
+> `docker run --rm --network deploy_default curlimages/curl ...`.
 
 This is the full chain working:
 


### PR DESCRIPTION
## Summary

Fixes #75. A topic's category was folded into the qBittorrent **save path**
but never sent as qBittorrent's native **`category`** field on
`/api/v2/torrents/add`. Completed torrents therefore had an empty category, so
tools like **Sonarr** — which discover downloads by qBittorrent category, not
by folder — could not import them even though the files were in the expected
place. Reproduced against a live qBittorrent before fixing.

- `Add()` now writes the `category` field, derived from the **same**
  `registry.SanitizeCategory` used to nest the save path, so the label and the
  folder segment can never diverge (e.g. `../tv` → `tv` for both). Empty /
  whitespace-only categories send no field (no empty-named category in qBit).
- Exported `registry.SanitizeCategory` (was unexported `sanitizeCategory`).

## Test Plan

- **Unit:** new table-driven `TestAdd_CategoryField` covers magnet + torrent
  payloads, empty, whitespace-only, and path-like (sanitised) categories.
  `go test -race ./...` green across all backend packages.
- **E2E (nightly):** the `magnet → qBittorrent` walkthrough now sets a topic
  category and asserts qBittorrent recorded it, queried from inside the compose
  network (avoids qBit 5.x's host-port `401`). The qBit temp password is masked
  (`::add-mask::`) and passed via container env rather than string-interpolated.
- Verified end-to-end against a live qBittorrent: `category="sonarr-topic"`,
  `save_path=".../sonarr-topic"`.

## Notes

- qBittorrent-only: Transmission has no native category (path-segment is correct
  by design); Deluge/µTorrent native labels would be a separate enhancement.
- `fix:` title intentionally cuts a patch release via the auto-release flow.
