### PR TITLE
test(e2e): table-driven Go full-stack e2e harness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,96 +80,20 @@ jobs:
           docker logs deploy-qbittorrent-1
           exit 1
 
-      - name: Run the magnet -> qBittorrent walkthrough
+      - name: Run the Go e2e harness
         env:
           QBIT_PASSWORD: ${{ steps.qbit.outputs.password }}
+        # Runs inside the compose network so the test reaches gateway:6688 and
+        # qbittorrent:6611 by service DNS — avoids qBittorrent 5.x's host-port
+        # 401. Network name `deploy_default` follows the compose project name
+        # (this workflow runs compose from deploy/ with no -p); keep in sync.
         run: |
-          set -e
-
-          echo "[1] login to Marauder"
-          LOGIN=$(curl -sS -X POST http://localhost:34080/api/v1/auth/login \
-            -H "Content-Type: application/json" \
-            -d '{"username":"admin","password":"pleasechangeme"}')
-          TOK=$(echo "$LOGIN" | awk -F'"access_token":"' '{print $2}' | awk -F'"' '{print $1}')
-          test -n "$TOK"
-
-          echo "[2] create qBittorrent client"
-          CLIENT_JSON=$(curl -sS -X POST http://localhost:34080/api/v1/clients \
-            -H "Authorization: Bearer $TOK" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"client_name\": \"qbittorrent\",
-              \"display_name\": \"E2E qBit\",
-              \"is_default\": true,
-              \"config\": {
-                \"url\": \"http://qbittorrent:6611\",
-                \"username\": \"admin\",
-                \"password\": \"${QBIT_PASSWORD}\"
-              }
-            }")
-          echo "$CLIENT_JSON"
-          CLIENT_ID=$(echo "$CLIENT_JSON" | awk -F'"id":"' '{print $2}' | awk -F'"' '{print $1}')
-          test -n "$CLIENT_ID"
-
-          echo "[3] add magnet topic with a category (issue #75)"
-          INFOHASH=0123456789abcdef0123456789abcdef01234567
-          CATEGORY=sonarr-e2e
-          MAG="magnet:?xt=urn:btih:${INFOHASH}&dn=marauder-e2e"
-          TOPIC_JSON=$(curl -sS -X POST http://localhost:34080/api/v1/topics \
-            -H "Authorization: Bearer $TOK" \
-            -H "Content-Type: application/json" \
-            -d "{\"url\":\"$MAG\",\"client_id\":\"$CLIENT_ID\",\"category\":\"$CATEGORY\"}")
-          echo "$TOPIC_JSON"
-          TOPIC_ID=$(echo "$TOPIC_JSON" | awk -F'"ID":"' '{print $2}' | awk -F'"' '{print $1}')
-          test -n "$TOPIC_ID"
-
-          echo "[4] wait for the scheduler to push the torrent (up to ~135s)"
-          # Verify through Marauder's own API, which exercises the real
-          # backend -> qBittorrent delivery path and records topic_deliveries.
-          # We deliberately do NOT poke the qBittorrent WebUI directly:
-          # qBittorrent 5.x rejects requests whose Host-header port differs
-          # from its WebUI port, which the published host port (34611 -> 6611)
-          # does, so a host-side login returns 401.
-          sleep 75
-          echo "[5] verify delivery via Marauder topic status API"
-          DELIVERED=
-          for _ in $(seq 1 6); do
-            STATUS=$(curl -sS -H "Authorization: Bearer $TOK" \
-              "http://localhost:34080/api/v1/topics/$TOPIC_ID/status")
-            echo "$STATUS"
-            if echo "$STATUS" | grep -q "$INFOHASH"; then
-              echo "delivery recorded for $INFOHASH"
-              DELIVERED=1
-              break
-            fi
-            sleep 10
-          done
-          [ -n "$DELIVERED" ] || { echo "torrent $INFOHASH never appeared in topic status"; exit 1; }
-
-          echo "[6] verify qBittorrent recorded the category (issue #75)"
-          # Query qBittorrent from INSIDE the compose network so the Host
-          # header is qbittorrent:6611 (matching its WebUI port) — a host-side
-          # login would 401 on qBittorrent 5.x (see the step [4] note).
-          # The password and infohash are forwarded as container env vars (-e)
-          # and the body is single-quoted, so nothing is string-interpolated
-          # into the shell command.
-          QBIT_INFO=$(docker run --rm --network deploy_default \
-            -e QBIT_PASSWORD -e INFOHASH="$INFOHASH" \
-            curlimages/curl:8.11.1 sh -c '
-              SID=$(curl -sS -i -X POST "http://qbittorrent:6611/api/v2/auth/login" \
-                --data-urlencode "username=admin" \
-                --data-urlencode "password=$QBIT_PASSWORD" \
-                | grep -i "^set-cookie:" | sed "s/.*SID=//I" | cut -d";" -f1)
-              test -n "$SID" || { echo "qBit login failed (no SID cookie)" >&2; exit 1; }
-              curl -sS -H "Cookie: SID=$SID" \
-                "http://qbittorrent:6611/api/v2/torrents/info?hashes=$INFOHASH"')
-          echo "$QBIT_INFO"
-          if echo "$QBIT_INFO" | grep -q "\"category\":\"$CATEGORY\""; then
-            echo "qBittorrent category correctly set to $CATEGORY"
-            exit 0
-          fi
-          echo "qBittorrent did NOT record category=$CATEGORY (issue #75 regression)"
-          exit 1
+          docker run --rm --network deploy_default \
+            -v "$PWD/backend:/backend" -w /backend \
+            -e MARAUDER_BASE_URL=http://gateway:6688 \
+            -e MARAUDER_ADMIN_USER=admin -e MARAUDER_ADMIN_PASS=pleasechangeme \
+            -e QBIT_URL=http://qbittorrent:6611 -e QBIT_PASSWORD \
+            golang:1.25 go test -tags=e2e -count=1 -v ./e2e/...
 
       - name: Print stack logs on failure
         if: failure()

--- a/backend/e2e/delivery_test.go
+++ b/backend/e2e/delivery_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDelivery drives the full pipeline: create a qBittorrent client and a
+// magnet topic with a category, wait for the scheduler to push it, then assert
+// the delivery was recorded (via Marauder) and that qBittorrent set the native
+// category and save path (issue #75).
+func TestDelivery(t *testing.T) {
+	env := readEnv(t) // skips if MARAUDER_BASE_URL unset
+
+	m := newMarauder(env)
+	m.Login(t)
+	clientID := m.CreateQbitClient(t, "/downloads")
+
+	q := newQbit(t, env)
+	q.Login(t)
+
+	cases := []struct {
+		name             string
+		category         string
+		wantSavePath     string
+		wantQbitCategory string
+	}{
+		{
+			name:             "category sets qbit label and nests save path",
+			category:         "sonarr-e2e",
+			wantSavePath:     "/downloads/sonarr-e2e",
+			wantQbitCategory: "sonarr-e2e",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			infohash := uniqueInfohash(t)
+			topicID := m.CreateTopic(t, magnet(infohash), clientID, tc.category)
+
+			// Delivery: poll Marauder's status API until the scheduler pushes
+			// the torrent (real tick, bounded at 135s).
+			if !pollUntil(10*time.Second, 135*time.Second, func() bool {
+				return m.StatusHasInfohash(t, topicID, infohash)
+			}) {
+				t.Fatalf("torrent %s never appeared in topic %s status", infohash, topicID)
+			}
+
+			// Category + save path: read back from qBittorrent directly.
+			var info qbitTorrent
+			if !pollUntil(2*time.Second, 15*time.Second, func() bool {
+				var ok bool
+				info, ok = q.TorrentInfo(t, infohash)
+				return ok
+			}) {
+				t.Fatalf("torrent %s not found in qBittorrent", infohash)
+			}
+			if info.Category != tc.wantQbitCategory {
+				t.Errorf("qBit category = %q, want %q", info.Category, tc.wantQbitCategory)
+			}
+			if info.SavePath != tc.wantSavePath {
+				t.Errorf("qBit save_path = %q, want %q", info.SavePath, tc.wantSavePath)
+			}
+		})
+	}
+}

--- a/backend/e2e/doc.go
+++ b/backend/e2e/doc.go
@@ -1,0 +1,5 @@
+// Package e2e holds Marauder's full-stack end-to-end tests. The tests drive a
+// running Marauder stack (and a real qBittorrent) over HTTP and are guarded by
+// the "e2e" build tag, so they run only via `go test -tags=e2e ./e2e/...` and
+// never during the normal `go test ./...` suite.
+package e2e

--- a/backend/e2e/harness_test.go
+++ b/backend/e2e/harness_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+type config struct {
+	BaseURL      string
+	AdminUser    string
+	AdminPass    string
+	QbitURL      string
+	QbitUser     string
+	QbitPassword string
+}
+
+// readEnv loads the e2e config from the environment. If MARAUDER_BASE_URL is
+// unset the whole suite is skipped, so a stray local `go test -tags=e2e` is
+// inert rather than a hard failure.
+func readEnv(t *testing.T) config {
+	t.Helper()
+	base := os.Getenv("MARAUDER_BASE_URL")
+	if base == "" {
+		t.Skip("MARAUDER_BASE_URL unset; skipping full-stack e2e")
+	}
+	return config{
+		BaseURL:      base,
+		AdminUser:    envOr("MARAUDER_ADMIN_USER", "admin"),
+		AdminPass:    envOr("MARAUDER_ADMIN_PASS", "pleasechangeme"),
+		QbitURL:      envOr("QBIT_URL", "http://qbittorrent:6611"),
+		QbitUser:     envOr("QBIT_USER", "admin"),
+		QbitPassword: os.Getenv("QBIT_PASSWORD"),
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// uniqueInfohash returns an obviously-synthetic 40-hex-char infohash that is
+// stable per test name, so multiple table rows do not collide in qBittorrent.
+// The "deadbeef" prefix marks it as a test value; it is never a real torrent.
+func uniqueInfohash(t *testing.T) string {
+	t.Helper()
+	var sum uint32
+	for _, r := range t.Name() {
+		sum = sum*31 + uint32(r)
+	}
+	return fmt.Sprintf("deadbeef%032x", sum)
+}
+
+func magnet(infohash string) string {
+	return "magnet:?xt=urn:btih:" + infohash + "&dn=marauder-e2e"
+}
+
+// pollUntil calls fn every interval until it returns true or timeout elapses.
+func pollUntil(interval, timeout time.Duration, fn func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if fn() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(interval)
+	}
+}

--- a/backend/e2e/marauder_test.go
+++ b/backend/e2e/marauder_test.go
@@ -1,0 +1,140 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type marauderClient struct {
+	cfg   config
+	token string
+	hc    *http.Client
+}
+
+func newMarauder(cfg config) *marauderClient {
+	return &marauderClient{cfg: cfg, hc: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// do performs a JSON request against the Marauder API, attaches the bearer
+// token when present, and fails the test on any non-2xx response.
+func (m *marauderClient) do(t *testing.T, method, path string, body any) []byte {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal %s %s: %v", method, path, err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, strings.TrimRight(m.cfg.BaseURL, "/")+path, rdr)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if m.token != "" {
+		req.Header.Set("Authorization", "Bearer "+m.token)
+	}
+	resp, err := m.hc.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("%s %s -> HTTP %d: %s", method, path, resp.StatusCode, string(data))
+	}
+	return data
+}
+
+func (m *marauderClient) Login(t *testing.T) {
+	t.Helper()
+	data := m.do(t, http.MethodPost, "/api/v1/auth/login", map[string]string{
+		"username": m.cfg.AdminUser,
+		"password": m.cfg.AdminPass,
+	})
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode login: %v (%s)", err, string(data))
+	}
+	if out.AccessToken == "" {
+		t.Fatalf("login returned empty access_token: %s", string(data))
+	}
+	m.token = out.AccessToken
+}
+
+// CreateQbitClient creates a qBittorrent client with a known base download_dir
+// (so the resulting save path is deterministic) and returns its id.
+func (m *marauderClient) CreateQbitClient(t *testing.T, downloadDir string) string {
+	t.Helper()
+	clientCfg := map[string]string{
+		"url":          m.cfg.QbitURL,
+		"username":     m.cfg.QbitUser,
+		"password":     m.cfg.QbitPassword,
+		"download_dir": downloadDir,
+	}
+	data := m.do(t, http.MethodPost, "/api/v1/clients", map[string]any{
+		"client_name":  "qbittorrent",
+		"display_name": "E2E qBit",
+		"is_default":   true,
+		"config":       clientCfg,
+	})
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil || out.ID == "" {
+		t.Fatalf("decode create-client: %v (%s)", err, string(data))
+	}
+	return out.ID
+}
+
+// CreateTopic adds a topic and returns its id. domain.Topic has no JSON tags,
+// so the id field marshals as "ID".
+func (m *marauderClient) CreateTopic(t *testing.T, url, clientID, category string) string {
+	t.Helper()
+	data := m.do(t, http.MethodPost, "/api/v1/topics", map[string]any{
+		"url":       url,
+		"client_id": clientID,
+		"category":  category,
+	})
+	var out struct {
+		ID string `json:"ID"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil || out.ID == "" {
+		t.Fatalf("decode create-topic: %v (%s)", err, string(data))
+	}
+	return out.ID
+}
+
+// StatusHasInfohash reports whether the topic's status endpoint lists a
+// delivery for infohash (case-insensitive).
+func (m *marauderClient) StatusHasInfohash(t *testing.T, topicID, infohash string) bool {
+	t.Helper()
+	data := m.do(t, http.MethodGet, fmt.Sprintf("/api/v1/topics/%s/status", topicID), nil)
+	var out struct {
+		Deliveries []struct {
+			Infohash string `json:"infohash"`
+		} `json:"deliveries"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode status: %v (%s)", err, string(data))
+	}
+	for _, d := range out.Deliveries {
+		if strings.EqualFold(d.Infohash, infohash) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/e2e/qbit_test.go
+++ b/backend/e2e/qbit_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type qbitClient struct {
+	cfg config
+	hc  *http.Client
+}
+
+func newQbit(t *testing.T, cfg config) *qbitClient {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar: %v", err)
+	}
+	return &qbitClient{cfg: cfg, hc: &http.Client{Jar: jar, Timeout: 30 * time.Second}}
+}
+
+// Login authenticates against the qBittorrent WebUI; the SID cookie is stored
+// in the client's jar for subsequent calls. qBittorrent answers 200 "Ok."
+// (<=5.1) or 204 No Content (>=5.2) on success.
+func (q *qbitClient) Login(t *testing.T) {
+	t.Helper()
+	resp, err := q.hc.PostForm(strings.TrimRight(q.cfg.QbitURL, "/")+"/api/v2/auth/login",
+		url.Values{"username": {q.cfg.QbitUser}, "password": {q.cfg.QbitPassword}})
+	if err != nil {
+		t.Fatalf("qbit login: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("qbit login HTTP %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+type qbitTorrent struct {
+	Category string `json:"category"`
+	SavePath string `json:"save_path"`
+	State    string `json:"state"`
+}
+
+// TorrentInfo returns the qBittorrent record for infohash and whether it was
+// found. An unknown hash yields an empty 200 array, i.e. (zero, false).
+func (q *qbitClient) TorrentInfo(t *testing.T, infohash string) (qbitTorrent, bool) {
+	t.Helper()
+	resp, err := q.hc.Get(strings.TrimRight(q.cfg.QbitURL, "/") +
+		"/api/v2/torrents/info?hashes=" + infohash)
+	if err != nil {
+		t.Fatalf("qbit info: %v", err)
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("qbit info HTTP %d: %s", resp.StatusCode, string(data))
+	}
+	var arr []qbitTorrent
+	if err := json.Unmarshal(data, &arr); err != nil {
+		t.Fatalf("decode qbit info: %v (%s)", err, string(data))
+	}
+	if len(arr) == 0 {
+		return qbitTorrent{}, false
+	}
+	return arr[0], true
+}

--- a/docs/superpowers/plans/2026-06-22-e2e-go-harness.md
+++ b/docs/superpowers/plans/2026-06-22-e2e-go-harness.md
@@ -1,0 +1,666 @@
+# Go full-stack E2E harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the inline-bash full-stack e2e in `.github/workflows/e2e.yml` with a table-driven Go harness that drives the live stack over HTTP from inside the compose network.
+
+**Architecture:** A new black-box system-test package `backend/e2e` (build tag `e2e`) drives the already-running Marauder stack and qBittorrent over HTTP. It does **not** reuse `e2etest.RunFullPipeline` (the in-process fake runner) — different layer. CI brings the stack up (unchanged) and runs `go test -tags=e2e` in a `golang:1.25` container joined to the `deploy_default` network, reaching services by Docker DNS (`gateway:6688`, `qbittorrent:6611`).
+
+**Tech Stack:** Go 1.25, stdlib `net/http` + `testing` only (no new deps), GitHub Actions, docker-compose.
+
+## Global Constraints
+
+- All harness Go files except `doc.go` carry `//go:build e2e`; the package must be invisible to `go test ./...` and `go build ./...` without the tag.
+- No new test dependencies — stdlib `net/http` + `testing` only (manual clients, no frameworks).
+- Go: tabs for indentation, `gofmt` mandatory, errors wrapped with context, `MixedCaps` naming.
+- No-synthetic-data: infohash is an obviously-synthetic 40-hex value (`deadbeef`-prefixed); category `sonarr-e2e` — test markers only.
+- Commit type `test(e2e):` (the auto-release flow does NOT bump on `test`/`ci`/`chore` — do not use `feat`/`fix`/`perf`).
+- Marauder API base in CI: `http://gateway:6688`; qBittorrent: `http://qbittorrent:6611`.
+- Docker network name `deploy_default` (compose project `deploy`, no `-p`). If `e2e.yml` ever adds `-p`, the `--network` value must change in lockstep.
+
+## File Structure
+
+```
+backend/e2e/
+├── doc.go             // NO build tag — package decl + doc, keeps untagged build clean
+├── harness_test.go    // //go:build e2e — config, readEnv, envOr, uniqueInfohash, magnet, pollUntil
+├── marauder_test.go   // //go:build e2e — Marauder API client: Login, CreateQbitClient, CreateTopic, StatusHasInfohash
+├── qbit_test.go       // //go:build e2e — qBittorrent API client: Login, TorrentInfo
+└── delivery_test.go   // //go:build e2e — TestDelivery (table-driven scenario)
+```
+
+- Helpers live in `_test.go` files so the package compiles only under `go test`. `doc.go` (no tag) makes the untagged package a valid empty package (no "build constraints exclude all Go files" noise).
+- `.github/workflows/e2e.yml` — modified (swap inline walkthrough for the Go harness step).
+- `docs/test-e2e-magnet.md` — modified (pointer to the automated harness).
+
+**Verification note (read before starting):** This package *is* a test; its helpers are thin HTTP wrappers whose real verification is the live e2e run, not unit tests of the wrappers (writing fakes to test the test client would be YAGNI). Per-task verification is therefore: (a) it compiles under `-tags=e2e`, (b) it is invisible without the tag, (c) `gofmt`/`go vet -tags=e2e` clean. The behavioural green is the live dry-run in Task 5 and the CI run after Task 6.
+
+---
+
+### Task 1: Package scaffold, build-tag isolation, config + shared helpers
+
+**Files:**
+- Create: `backend/e2e/doc.go`
+- Create: `backend/e2e/harness_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type config struct { BaseURL, AdminUser, AdminPass, QbitURL, QbitUser, QbitPassword string }`
+  - `func readEnv(t *testing.T) config` — skips when `MARAUDER_BASE_URL` unset
+  - `func uniqueInfohash(t *testing.T) string` — 40-hex synthetic, stable per test name
+  - `func magnet(infohash string) string`
+  - `func pollUntil(interval, timeout time.Duration, fn func() bool) bool`
+
+- [ ] **Step 1: Create `backend/e2e/doc.go`** (no build tag)
+
+```go
+// Package e2e holds Marauder's full-stack end-to-end tests. The tests drive a
+// running Marauder stack (and a real qBittorrent) over HTTP and are guarded by
+// the "e2e" build tag, so they run only via `go test -tags=e2e ./e2e/...` and
+// never during the normal `go test ./...` suite.
+package e2e
+```
+
+- [ ] **Step 2: Create `backend/e2e/harness_test.go`**
+
+```go
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+type config struct {
+	BaseURL      string
+	AdminUser    string
+	AdminPass    string
+	QbitURL      string
+	QbitUser     string
+	QbitPassword string
+}
+
+// readEnv loads the e2e config from the environment. If MARAUDER_BASE_URL is
+// unset the whole suite is skipped, so a stray local `go test -tags=e2e` is
+// inert rather than a hard failure.
+func readEnv(t *testing.T) config {
+	t.Helper()
+	base := os.Getenv("MARAUDER_BASE_URL")
+	if base == "" {
+		t.Skip("MARAUDER_BASE_URL unset; skipping full-stack e2e")
+	}
+	return config{
+		BaseURL:      base,
+		AdminUser:    envOr("MARAUDER_ADMIN_USER", "admin"),
+		AdminPass:    envOr("MARAUDER_ADMIN_PASS", "pleasechangeme"),
+		QbitURL:      envOr("QBIT_URL", "http://qbittorrent:6611"),
+		QbitUser:     envOr("QBIT_USER", "admin"),
+		QbitPassword: os.Getenv("QBIT_PASSWORD"),
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// uniqueInfohash returns an obviously-synthetic 40-hex-char infohash that is
+// stable per test name, so multiple table rows do not collide in qBittorrent.
+// The "deadbeef" prefix marks it as a test value; it is never a real torrent.
+func uniqueInfohash(t *testing.T) string {
+	t.Helper()
+	var sum uint32
+	for _, r := range t.Name() {
+		sum = sum*31 + uint32(r)
+	}
+	return fmt.Sprintf("deadbeef%032x", sum)
+}
+
+func magnet(infohash string) string {
+	return "magnet:?xt=urn:btih:" + infohash + "&dn=marauder-e2e"
+}
+
+// pollUntil calls fn every interval until it returns true or timeout elapses.
+func pollUntil(interval, timeout time.Duration, fn func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if fn() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(interval)
+	}
+}
+```
+
+- [ ] **Step 3: Verify the package is invisible without the tag**
+
+Run: `docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 sh -c "go build ./... && go vet ./e2e/... && go test ./e2e/..."`
+Expected: build succeeds; `go test ./e2e/...` prints `?   github.com/artyomsv/marauder/backend/e2e   [no test files]` (the `_test.go` files are excluded without the tag).
+
+- [ ] **Step 4: Verify it compiles WITH the tag**
+
+Run: `docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 sh -c "go vet -tags=e2e ./e2e/... && gofmt -l e2e/"`
+Expected: no output (vet clean, gofmt clean). It will not *run* anything yet — no `Test*` functions exist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/e2e/doc.go backend/e2e/harness_test.go
+git commit -m "test(e2e): scaffold build-tagged e2e package with config + helpers"
+```
+
+---
+
+### Task 2: Marauder API client
+
+**Files:**
+- Create: `backend/e2e/marauder_test.go`
+
+**Interfaces:**
+- Consumes: `config` (Task 1).
+- Produces:
+  - `func newMarauder(cfg config) *marauderClient`
+  - `func (m *marauderClient) Login(t *testing.T)`
+  - `func (m *marauderClient) CreateQbitClient(t *testing.T, downloadDir string) string` — returns client id
+  - `func (m *marauderClient) CreateTopic(t *testing.T, url, clientID, category string) string` — returns topic id
+  - `func (m *marauderClient) StatusHasInfohash(t *testing.T, topicID, infohash string) bool`
+
+- [ ] **Step 1: Create `backend/e2e/marauder_test.go`**
+
+```go
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type marauderClient struct {
+	cfg   config
+	token string
+	hc    *http.Client
+}
+
+func newMarauder(cfg config) *marauderClient {
+	return &marauderClient{cfg: cfg, hc: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// do performs a JSON request against the Marauder API, attaches the bearer
+// token when present, and fails the test on any non-2xx response.
+func (m *marauderClient) do(t *testing.T, method, path string, body any) []byte {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal %s %s: %v", method, path, err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, strings.TrimRight(m.cfg.BaseURL, "/")+path, rdr)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if m.token != "" {
+		req.Header.Set("Authorization", "Bearer "+m.token)
+	}
+	resp, err := m.hc.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("%s %s -> HTTP %d: %s", method, path, resp.StatusCode, string(data))
+	}
+	return data
+}
+
+func (m *marauderClient) Login(t *testing.T) {
+	t.Helper()
+	data := m.do(t, http.MethodPost, "/api/v1/auth/login", map[string]string{
+		"username": m.cfg.AdminUser,
+		"password": m.cfg.AdminPass,
+	})
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode login: %v (%s)", err, string(data))
+	}
+	if out.AccessToken == "" {
+		t.Fatalf("login returned empty access_token: %s", string(data))
+	}
+	m.token = out.AccessToken
+}
+
+// CreateQbitClient creates a qBittorrent client with a known base download_dir
+// (so the resulting save path is deterministic) and returns its id.
+func (m *marauderClient) CreateQbitClient(t *testing.T, downloadDir string) string {
+	t.Helper()
+	clientCfg := map[string]string{
+		"url":          m.cfg.QbitURL,
+		"username":     m.cfg.QbitUser,
+		"password":     m.cfg.QbitPassword,
+		"download_dir": downloadDir,
+	}
+	data := m.do(t, http.MethodPost, "/api/v1/clients", map[string]any{
+		"client_name":  "qbittorrent",
+		"display_name": "E2E qBit",
+		"is_default":   true,
+		"config":       clientCfg,
+	})
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil || out.ID == "" {
+		t.Fatalf("decode create-client: %v (%s)", err, string(data))
+	}
+	return out.ID
+}
+
+// CreateTopic adds a topic and returns its id. domain.Topic has no JSON tags,
+// so the id field marshals as "ID".
+func (m *marauderClient) CreateTopic(t *testing.T, url, clientID, category string) string {
+	t.Helper()
+	data := m.do(t, http.MethodPost, "/api/v1/topics", map[string]any{
+		"url":       url,
+		"client_id": clientID,
+		"category":  category,
+	})
+	var out struct {
+		ID string `json:"ID"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil || out.ID == "" {
+		t.Fatalf("decode create-topic: %v (%s)", err, string(data))
+	}
+	return out.ID
+}
+
+// StatusHasInfohash reports whether the topic's status endpoint lists a
+// delivery for infohash (case-insensitive).
+func (m *marauderClient) StatusHasInfohash(t *testing.T, topicID, infohash string) bool {
+	t.Helper()
+	data := m.do(t, http.MethodGet, fmt.Sprintf("/api/v1/topics/%s/status", topicID), nil)
+	var out struct {
+		Deliveries []struct {
+			Infohash string `json:"infohash"`
+		} `json:"deliveries"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode status: %v (%s)", err, string(data))
+	}
+	for _, d := range out.Deliveries {
+		if strings.EqualFold(d.Infohash, infohash) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Verify it compiles with the tag and is invisible without it**
+
+Run: `docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 sh -c "go vet -tags=e2e ./e2e/... && gofmt -l e2e/ && go build ./..."`
+Expected: no output from vet/gofmt; `go build ./...` succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/e2e/marauder_test.go
+git commit -m "test(e2e): add Marauder API client for the harness"
+```
+
+---
+
+### Task 3: qBittorrent API client
+
+**Files:**
+- Create: `backend/e2e/qbit_test.go`
+
+**Interfaces:**
+- Consumes: `config` (Task 1).
+- Produces:
+  - `func newQbit(t *testing.T, cfg config) *qbitClient`
+  - `func (q *qbitClient) Login(t *testing.T)`
+  - `type qbitTorrent struct { Category, SavePath, State string }`
+  - `func (q *qbitClient) TorrentInfo(t *testing.T, infohash string) (qbitTorrent, bool)`
+
+- [ ] **Step 1: Create `backend/e2e/qbit_test.go`**
+
+```go
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type qbitClient struct {
+	cfg config
+	hc  *http.Client
+}
+
+func newQbit(t *testing.T, cfg config) *qbitClient {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar: %v", err)
+	}
+	return &qbitClient{cfg: cfg, hc: &http.Client{Jar: jar, Timeout: 30 * time.Second}}
+}
+
+// Login authenticates against the qBittorrent WebUI; the SID cookie is stored
+// in the client's jar for subsequent calls. qBittorrent answers 200 "Ok."
+// (<=5.1) or 204 No Content (>=5.2) on success.
+func (q *qbitClient) Login(t *testing.T) {
+	t.Helper()
+	resp, err := q.hc.PostForm(strings.TrimRight(q.cfg.QbitURL, "/")+"/api/v2/auth/login",
+		url.Values{"username": {q.cfg.QbitUser}, "password": {q.cfg.QbitPassword}})
+	if err != nil {
+		t.Fatalf("qbit login: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("qbit login HTTP %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+type qbitTorrent struct {
+	Category string `json:"category"`
+	SavePath string `json:"save_path"`
+	State    string `json:"state"`
+}
+
+// TorrentInfo returns the qBittorrent record for infohash and whether it was
+// found. An unknown hash yields an empty 200 array, i.e. (zero, false).
+func (q *qbitClient) TorrentInfo(t *testing.T, infohash string) (qbitTorrent, bool) {
+	t.Helper()
+	resp, err := q.hc.Get(strings.TrimRight(q.cfg.QbitURL, "/") +
+		"/api/v2/torrents/info?hashes=" + infohash)
+	if err != nil {
+		t.Fatalf("qbit info: %v", err)
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("qbit info HTTP %d: %s", resp.StatusCode, string(data))
+	}
+	var arr []qbitTorrent
+	if err := json.Unmarshal(data, &arr); err != nil {
+		t.Fatalf("decode qbit info: %v (%s)", err, string(data))
+	}
+	if len(arr) == 0 {
+		return qbitTorrent{}, false
+	}
+	return arr[0], true
+}
+```
+
+- [ ] **Step 2: Verify compile + gofmt + invisible-without-tag**
+
+Run: `docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 sh -c "go vet -tags=e2e ./e2e/... && gofmt -l e2e/ && go build ./..."`
+Expected: no output from vet/gofmt; `go build ./...` succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/e2e/qbit_test.go
+git commit -m "test(e2e): add qBittorrent API client for the harness"
+```
+
+---
+
+### Task 4: The delivery test (table-driven)
+
+**Files:**
+- Create: `backend/e2e/delivery_test.go`
+
+**Interfaces:**
+- Consumes: `readEnv`, `uniqueInfohash`, `magnet`, `pollUntil` (Task 1); `newMarauder`, `Login`, `CreateQbitClient`, `CreateTopic`, `StatusHasInfohash` (Task 2); `newQbit`, `qbitClient.Login`, `qbitTorrent`, `TorrentInfo` (Task 3).
+- Produces: `func TestDelivery(t *testing.T)` — the runnable e2e scenario.
+
+- [ ] **Step 1: Create `backend/e2e/delivery_test.go`**
+
+```go
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDelivery drives the full pipeline: create a qBittorrent client and a
+// magnet topic with a category, wait for the scheduler to push it, then assert
+// the delivery was recorded (via Marauder) and that qBittorrent set the native
+// category and save path (issue #75).
+func TestDelivery(t *testing.T) {
+	env := readEnv(t) // skips if MARAUDER_BASE_URL unset
+
+	m := newMarauder(env)
+	m.Login(t)
+	clientID := m.CreateQbitClient(t, "/downloads")
+
+	q := newQbit(t, env)
+	q.Login(t)
+
+	cases := []struct {
+		name             string
+		category         string
+		wantSavePath     string
+		wantQbitCategory string
+	}{
+		{
+			name:             "category sets qbit label and nests save path",
+			category:         "sonarr-e2e",
+			wantSavePath:     "/downloads/sonarr-e2e",
+			wantQbitCategory: "sonarr-e2e",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			infohash := uniqueInfohash(t)
+			topicID := m.CreateTopic(t, magnet(infohash), clientID, tc.category)
+
+			// Delivery: poll Marauder's status API until the scheduler pushes
+			// the torrent (real tick, bounded at 135s).
+			if !pollUntil(10*time.Second, 135*time.Second, func() bool {
+				return m.StatusHasInfohash(t, topicID, infohash)
+			}) {
+				t.Fatalf("torrent %s never appeared in topic %s status", infohash, topicID)
+			}
+
+			// Category + save path: read back from qBittorrent directly.
+			var info qbitTorrent
+			if !pollUntil(2*time.Second, 15*time.Second, func() bool {
+				var ok bool
+				info, ok = q.TorrentInfo(t, infohash)
+				return ok
+			}) {
+				t.Fatalf("torrent %s not found in qBittorrent", infohash)
+			}
+			if info.Category != tc.wantQbitCategory {
+				t.Errorf("qBit category = %q, want %q", info.Category, tc.wantQbitCategory)
+			}
+			if info.SavePath != tc.wantSavePath {
+				t.Errorf("qBit save_path = %q, want %q", info.SavePath, tc.wantSavePath)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Verify compile + gofmt; confirm it SKIPS without env**
+
+Run: `docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 sh -c "go vet -tags=e2e ./e2e/... && gofmt -l e2e/ && go test -tags=e2e ./e2e/..."`
+Expected: vet/gofmt clean; the test run prints `--- SKIP: TestDelivery` (because `MARAUDER_BASE_URL` is unset) and `ok` / `[no tests to run]` — proving the skip guard works.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/e2e/delivery_test.go
+git commit -m "test(e2e): add table-driven delivery + qbit-category test"
+```
+
+---
+
+### Task 5: Local live dry-run (behavioural green)
+
+**Files:** none (verification task).
+
+**Interfaces:**
+- Consumes: the full harness (Tasks 1–4) + a running dev stack.
+
+- [ ] **Step 1: Bring up the dev stack with qBittorrent**
+
+```bash
+cd deploy
+cp .env.example .env
+MASTER=$(openssl rand -base64 32); METRICS=$(openssl rand -hex 32)
+sed -i "s|MARAUDER_MASTER_KEY=.*|MARAUDER_MASTER_KEY=$MASTER|" .env
+sed -i "s|MARAUDER_METRICS_TOKEN=.*|MARAUDER_METRICS_TOKEN=$METRICS|" .env
+docker compose --env-file .env -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+```
+
+- [ ] **Step 2: Grab the qBittorrent temporary password**
+
+Run: `docker logs deploy-qbittorrent-1 2>&1 | grep "temporary password" | awk '{print $NF}' | tail -1`
+Expected: a short alphanumeric token. Save it as `QPW`.
+
+- [ ] **Step 3: Run the harness in-network against the live stack**
+
+```bash
+docker run --rm --network deploy_default \
+  -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend \
+  -e MARAUDER_BASE_URL=http://gateway:6688 \
+  -e MARAUDER_ADMIN_USER=admin -e MARAUDER_ADMIN_PASS=pleasechangeme \
+  -e QBIT_URL=http://qbittorrent:6611 -e QBIT_PASSWORD="$QPW" \
+  golang:1.25 go test -tags=e2e -count=1 -v ./e2e/...
+```
+
+Expected: `--- PASS: TestDelivery/category_sets_qbit_label_and_nests_save_path` then `PASS` / `ok`. The test logs show the torrent delivered and `category="sonarr-e2e"`, `save_path="/downloads/sonarr-e2e"`.
+
+- [ ] **Step 4: Tear down**
+
+```bash
+cd deploy && docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v
+```
+
+- [ ] **Step 5: No commit** (verification only). If the run failed, fix the harness in the relevant task before proceeding.
+
+---
+
+### Task 6: Swap CI to the Go harness + update docs
+
+**Files:**
+- Modify: `.github/workflows/e2e.yml` (replace the inline walkthrough run step)
+- Modify: `docs/test-e2e-magnet.md` (pointer to the automated harness)
+
+**Interfaces:**
+- Consumes: the harness (Tasks 1–4); the existing `e2e.yml` stack-up + `steps.qbit.outputs.password` (with `::add-mask::`).
+
+- [ ] **Step 1: Replace the inline walkthrough step in `.github/workflows/e2e.yml`**
+
+Find the step named `Run the magnet -> qBittorrent walkthrough` (its `env: QBIT_PASSWORD:` and the `run: |` block containing steps `[1]`–`[6]`). Replace the **entire step** with:
+
+```yaml
+      - name: Run the Go e2e harness
+        env:
+          QBIT_PASSWORD: ${{ steps.qbit.outputs.password }}
+        # Runs inside the compose network so the test reaches gateway:6688 and
+        # qbittorrent:6611 by service DNS — avoids qBittorrent 5.x's host-port
+        # 401. Network name `deploy_default` follows the compose project name
+        # (this workflow runs compose from deploy/ with no -p); keep in sync.
+        run: |
+          docker run --rm --network deploy_default \
+            -v "$PWD/backend:/backend" -w /backend \
+            -e MARAUDER_BASE_URL=http://gateway:6688 \
+            -e MARAUDER_ADMIN_USER=admin -e MARAUDER_ADMIN_PASS=pleasechangeme \
+            -e QBIT_URL=http://qbittorrent:6611 -e QBIT_PASSWORD \
+            golang:1.25 go test -tags=e2e -count=1 -v ./e2e/...
+```
+
+Leave the `Print stack logs on failure` and `Tear down` steps unchanged.
+
+- [ ] **Step 2: Verify the workflow YAML is valid**
+
+Run: `docker run --rm -v "E:/Projects/Stukans/Marauder:/repo" -w //repo node:20-alpine sh -c "npx --yes js-yaml .github/workflows/e2e.yml >/dev/null && echo YAML-OK"`
+Expected: `YAML-OK` (parses cleanly).
+
+- [ ] **Step 3: Add a pointer in `docs/test-e2e-magnet.md`**
+
+Immediately after the title `# End-to-End Test: Magnet → qBittorrent` and its intro paragraph, insert:
+
+```markdown
+> **Automated version:** this walkthrough is automated as a Go harness in
+> `backend/e2e/` (run with `go test -tags=e2e ./e2e/...`), exercised nightly by
+> `.github/workflows/e2e.yml`. The manual steps below remain for humans who want
+> to drive the flow by hand.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/e2e.yml docs/test-e2e-magnet.md
+git commit -m "test(e2e): run the Go harness in CI, retire inline bash walkthrough"
+```
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin test/e2e-go-harness
+gh pr create --base main --title "test(e2e): table-driven Go full-stack e2e harness" \
+  --body "Replaces the inline-bash full-stack e2e walkthrough with a build-tagged Go harness in backend/e2e/ that drives the live stack over HTTP from inside the compose network. 1:1 migration of the existing delivery + qBit-category assertions; the table is built to grow. See docs/superpowers/specs/2026-06-22-e2e-go-harness-design.md."
+```
+
+(Confirm with the user before this push/PR step per their commit/PR policy.)
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Build tag / invisible without tag → Tasks 1–4 (every `_test.go` has `//go:build e2e`; `doc.go` tagless; verified in Steps).
+- Run inside compose network → Task 6 CI step + Task 5 dry-run.
+- Env config + skip-when-unset → Task 1 `readEnv`; verified in Task 4 Step 2.
+- Marauder API client → Task 2. qBit client → Task 3. Condition-based wait (replaces fixed sleep) → Task 1 `pollUntil`, used in Task 4.
+- Delivery via Marauder + category via qBit + deterministic save path (`download_dir=/downloads`) → Tasks 2 & 4.
+- No-synthetic-data infohash → Task 1 `uniqueInfohash`.
+- CI swap + docs pointer → Task 6. Non-goals (RunFullPipeline, client-acceptance, deliver-now trigger, extra scenarios) → untouched.
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows full content; commands have expected output.
+
+**3. Type consistency:** `config` fields used by `newMarauder`/`newQbit` match Task 1. `marauderClient.CreateQbitClient(t, downloadDir)`, `CreateTopic(t, url, clientID, category)`, `StatusHasInfohash(t, topicID, infohash)`, `qbitClient.TorrentInfo(t, infohash) (qbitTorrent, bool)`, and `qbitTorrent{Category,SavePath,State}` are referenced identically in Task 4. `pollUntil(interval, timeout, fn)` signature matches its two call sites.

--- a/docs/superpowers/specs/2026-06-22-e2e-go-harness-design.md
+++ b/docs/superpowers/specs/2026-06-22-e2e-go-harness-design.md
@@ -1,0 +1,205 @@
+# Design: Go full-stack E2E harness
+
+Date: 2026-06-22
+Status: Approved (design phase)
+Topic: Replace the inline-bash full-stack e2e in `.github/workflows/e2e.yml`
+with a maintainable, table-driven Go harness.
+
+## Problem
+
+The full-stack end-to-end test (real docker-compose stack + real qBittorrent +
+real scheduler/DB) is currently an inline bash script inside `e2e.yml`
+(steps `[1]`–`[6]`: login → create client → create topic → wait → assert
+delivery → assert qBit category). It works, but it does not scale:
+
+1. **Not runnable locally** — to test the test you push to CI and wait.
+2. **YAML quoting is fragile** — nested quotes / `docker run … sh -c '…'` / `-e`
+   passing are easy to break silently.
+3. **Brittle assertions** — `grep -q '"category":"sonarr-e2e"'` substring-matches
+   JSON; can false-positive, cannot assert absence or structure, gives a poor
+   failure diff.
+4. **Shared mutable state** — one client, one topic, one infohash, linear
+   script. New scenarios either couple to that state or grow the script.
+5. **No tooling** — no `shellcheck`, no type checking, no test runner.
+6. **Sequential by construction** — every assertion adds wall-clock to one
+   monolithic job.
+
+Adding more e2e coverage over time makes all six worse. This design moves the
+*test logic* into Go (where it is typed, table-driven, and locally runnable)
+while leaving *orchestration* (stack up/down) in the workflow.
+
+## Non-goals
+
+- **Not** replacing `e2etest.RunFullPipeline` — that is the in-process,
+  fake-based plugin runner (`backend/internal/plugins/e2etest`) that runs in
+  normal `go test ./...`. It is a different layer and stays as-is.
+- **Not** touching `client-acceptance.yml` — the shallow create-client/`Test()`
+  matrix across client versions has a different purpose and stays as-is.
+- **Not** adding a "deliver now" test-only trigger endpoint. The harness keeps
+  using the real scheduler tick. (Noted as a possible future optimization.)
+- **Not** adding new e2e scenarios beyond the one being ported. This is a 1:1
+  migration; the table is *built to* grow but ships with one row.
+- **Not** introducing any new test dependency (no hurl/venom/testcontainers).
+  Stdlib `net/http` + `testing` only, matching the repo's "manual fakes, no
+  frameworks" stance.
+
+## Architecture & execution model
+
+A new black-box **system-test** package that drives the *already-running* full
+stack over HTTP.
+
+- **Build tag** `//go:build e2e` on every file. `go test ./...` (normal CI)
+  never compiles or runs it. It runs only via `go test -tags=e2e ./e2e/...`.
+- **Execution in CI**: `e2e.yml` brings up the stack (unchanged), then runs the
+  harness in a `golang:1.25` container joined to the `deploy_default` network.
+  The test reaches services by Docker DNS — `gateway:6688` (Marauder API) and
+  `qbittorrent:6611` (qBittorrent API). Using in-network service names avoids
+  qBittorrent 5.x's host-port `401` (it rejects requests whose Host-header port
+  differs from its WebUI port, which the published `34611 → 6611` mapping
+  triggers) and needs no production code change.
+- **Config via env** (no flags):
+  - `MARAUDER_BASE_URL` (e.g. `http://gateway:6688`)
+  - `MARAUDER_ADMIN_USER` / `MARAUDER_ADMIN_PASS`
+  - `QBIT_URL` (e.g. `http://qbittorrent:6611`)
+  - `QBIT_PASSWORD`
+  - If `MARAUDER_BASE_URL` is unset, the test `t.Skip`s, so a stray local
+    `go test -tags=e2e` is inert rather than a failure.
+
+### Why query qBittorrent directly for the category
+
+Delivery is verified through Marauder's own topic-status API (which exercises
+the real backend → qBittorrent → `topic_deliveries` path). The qBittorrent
+*category*, however, is not exposed by Marauder's status response today, so the
+category assertion reads it back from qBittorrent directly. Running inside the
+compose network makes that read trivial and avoids the host-port `401`.
+
+## Directory layout & components
+
+```
+backend/e2e/                         (new; package e2e; all files //go:build e2e)
+├── doc.go            // package doc + build-tag rationale
+├── env_test.go       // readEnv(t) → config struct; TestMain handles the skip check
+├── marauder.go       // Marauder API client: Login, CreateQbitClient, CreateTopic, TopicStatus
+├── qbit.go           // qBittorrent API client: Login, TorrentInfo(infohash) → {Category, SavePath, State}
+├── wait.go           // pollUntil(ctx, interval, timeout, fn) — condition-based wait helper
+└── delivery_test.go  // the table-driven scenario(s)
+```
+
+- Helpers return typed structs and real `error`s; assertions live in the test
+  using stdlib `t.Fatalf` / `t.Errorf`.
+- `marauder.go` and `qbit.go` are deliberately tiny and purpose-built (one
+  method per call the test needs), not a general SDK.
+- `wait.go` replaces the current fixed `sleep 75` with condition-based polling
+  (poll the status endpoint until the infohash appears, bounded by a timeout —
+  same ~135s ceiling as today).
+
+## Test structure
+
+```go
+//go:build e2e
+
+func TestDelivery(t *testing.T) {
+    env := readEnv(t)                  // t.Skip if MARAUDER_BASE_URL unset
+    m := marauder.New(env)
+    m.Login(t)
+    // Create the client with a known base download_dir so the resulting save
+    // path is deterministic and assertable (the current bash sets none and
+    // therefore cannot assert the path). "/downloads" exists in the
+    // linuxserver/qbittorrent image.
+    clientID := m.CreateQbitClient(t, "/downloads")  // url=qbittorrent:6611
+
+    cases := []struct {
+        name, category, wantSavePath, wantQbitCategory string
+    }{
+        {"category sets qbit label", "sonarr-e2e",
+            "/downloads/sonarr-e2e", "sonarr-e2e"},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            infohash := uniqueInfohash(t)  // obviously-synthetic, per-case
+            topicID := m.CreateTopic(t, magnet(infohash), clientID, tc.category)
+
+            // delivery: poll Marauder status until the infohash appears
+            pollUntil(ctx, 10*time.Second, 135*time.Second, func() bool {
+                return m.TopicStatus(t, topicID).Contains(infohash)
+            })
+
+            // category: read back from qBittorrent directly
+            info := qb.TorrentInfo(t, infohash)
+            if info.Category != tc.wantQbitCategory { t.Errorf(...) }
+            if info.SavePath != tc.wantSavePath { t.Errorf(...) }
+        })
+    }
+}
+```
+
+- **Delivery** verified via Marauder's status API; **category** verified via
+  qBittorrent directly — the same two assertions as today, now typed/structured.
+  The **save-path** assertion is a small addition enabled by setting a known
+  `download_dir` on the client (the bash asserted neither path nor save_path);
+  it strengthens the test at zero extra cost and is deterministic.
+- Adding a future scenario = one struct row. First cut ships the single row.
+- **No-synthetic-data compliance:** the infohash is an obviously-synthetic
+  constant (sequential / `dead…` hex), the category is `sonarr-e2e` — both
+  unmistakable test markers; nothing is rendered as real user-facing data.
+
+### Per-case infohash note
+
+The current bash uses one fixed infohash. The table introduces `uniqueInfohash`
+so multiple rows do not collide in qBittorrent. For the single shipped row this
+is equivalent to a constant; it exists so added rows are isolated. It remains an
+obviously-synthetic value (e.g. a fixed prefix plus the case index).
+
+## CI wiring (`e2e.yml`)
+
+The stack bring-up, health-wait, qBit-password grab (with `::add-mask::`), the
+"print stack logs on failure", and the "tear down" steps all stay. Only the
+inline walkthrough bash (steps `[1]`–`[6]`) is replaced by:
+
+```yaml
+- name: Run Go e2e harness
+  env:
+    QBIT_PASSWORD: ${{ steps.qbit.outputs.password }}
+  run: |
+    docker run --rm --network deploy_default \
+      -v "$PWD/backend:/backend" -w /backend \
+      -e MARAUDER_BASE_URL=http://gateway:6688 \
+      -e MARAUDER_ADMIN_USER=admin -e MARAUDER_ADMIN_PASS=pleasechangeme \
+      -e QBIT_URL=http://qbittorrent:6611 -e QBIT_PASSWORD \
+      golang:1.25 go test -tags=e2e -count=1 ./e2e/...
+```
+
+Notes:
+- `-e QBIT_PASSWORD` forwards the masked step output into the container env;
+  it is never string-interpolated into a shell command.
+- `-count=1` disables Go's test cache so the e2e always actually runs.
+- The Docker network name `deploy_default` matches the `e2e.yml` compose
+  project (the workflow runs compose from `deploy/` with no `-p`, so the
+  default project name is `deploy`).
+
+## Documentation
+
+`docs/test-e2e-magnet.md` gets a short pointer that the *automated* full-stack
+path now lives in `backend/e2e/` (run with `go test -tags=e2e`), while the
+manual curl walkthrough remains for humans.
+
+## Testing strategy for this change
+
+- The harness itself is the test; its "passing" is observable in the nightly
+  `e2e.yml` run (and on `workflow_dispatch` / tag push).
+- Local dry-run: bring up the dev stack, then run the same `docker run … go test
+  -tags=e2e` against `deploy_default` to confirm green before merge.
+- `go vet -tags=e2e ./e2e/...` and `gofmt` must pass; the package must compile
+  under the tag and be invisible without it (verified via `go build ./...`).
+
+## Risks / open considerations
+
+- **Runtime unchanged** — still gated by a real scheduler tick (~up to 135s).
+  This design improves maintainability, not speed. A "deliver now" trigger is
+  the future lever if runtime becomes painful.
+- **Module download in CI** — running `go test` in a fresh `golang:1.25`
+  container downloads modules each run. Acceptable for a nightly job; can be
+  cached later if needed.
+- **Network-name coupling** — `deploy_default` is derived from the compose
+  project name; if `e2e.yml` ever adds `-p`, the `--network` value must change
+  in lockstep. Called out in the workflow comment.

--- a/docs/test-e2e-magnet.md
+++ b/docs/test-e2e-magnet.md
@@ -7,6 +7,11 @@ API appears in qBittorrent within one scheduler tick.
 The test relies only on Docker and assumes nothing is installed on the
 host besides Docker and git.
 
+> **Automated version:** this walkthrough is automated as a Go harness in
+> `backend/e2e/` (run with `go test -tags=e2e ./e2e/...`), exercised nightly by
+> `.github/workflows/e2e.yml`. The manual steps below remain for humans who want
+> to drive the flow by hand.
+
 ## 1. Bring up the dev stack
 
 The dev overlay (`deploy/docker-compose.dev.yml`) publishes the database


### PR DESCRIPTION
## Summary

Replaces the inline-bash full-stack e2e walkthrough in `.github/workflows/e2e.yml`
with a build-tagged Go test harness in `backend/e2e/` that drives the live
Marauder stack + a real qBittorrent over HTTP **from inside the compose
network**. A 1:1 migration of the existing delivery + qBit-category assertions;
the table is built to grow (one row per scenario).

Motivation: the inline bash was not locally runnable, had fragile YAML quoting,
brittle `grep`-on-JSON assertions, shared mutable state, and grew linearly with
each new scenario. See `docs/superpowers/specs/2026-06-22-e2e-go-harness-design.md`.

## What changed

- **New `backend/e2e/` package** (all `//go:build e2e`, except `doc.go`): typed
  Marauder + qBittorrent API clients, condition-based `pollUntil`, and a
  table-driven `TestDelivery`. Invisible to the normal `go test ./...` suite.
- **`e2e.yml`**: the inline walkthrough step is replaced by one step that runs
  `go test -tags=e2e` in a `golang:1.25` container on the `deploy_default`
  network (reaches `gateway:6688` / `qbittorrent:6611` by DNS — avoids qBit
  5.x's host-port 401). `QBIT_PASSWORD` is forwarded by name (masked), not
  string-interpolated. Stack bring-up / teardown / log steps unchanged.
- **`docs/test-e2e-magnet.md`**: pointer to the automated harness; manual
  walkthrough retained for humans.

Net coverage **increases**: keeps delivery (via Marauder status) + qBit
`category`, and adds a deterministic `save_path` assertion (client created with
a known `download_dir`).

## Test plan

- `go build ./... && go vet ./... && go test ./...` (untagged) green;
  `backend/e2e` shows `[no test files]` — package correctly invisible without
  the tag.
- **Live dry-run**: brought up an isolated stack + real qBittorrent and ran the
  harness in-network — `TestDelivery` passed (~50s), confirming
  `category="sonarr-e2e"` and `save_path="/downloads/sonarr-e2e"`. Stack torn
  down clean.
- Nightly `e2e.yml` exercises it going forward.

## Notes

- Out of scope (unchanged): `client-acceptance.yml` matrix; no "deliver-now"
  trigger (still a real scheduler tick).
- Follow-up (non-blocking): widen `uniqueInfohash` beyond a uint32 hash when a
  second table row is added.
- `test:` PR type — does not trigger a release bump.
