### PR TITLE
fix(docker): build arm64 images with matching binary arch

### DIFF
--- a/.github/scripts/verify-arch.sh
+++ b/.github/scripts/verify-arch.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# verify-arch.sh — assert a compiled binary's ELF architecture matches its
+# target platform. Extracted from release.yml so the arch-match decision is
+# unit-testable without Docker (see verify-arch_test.sh).
+#
+# Issue #74: the release pipeline builds multi-arch images, but the Dockerfiles
+# once hardcoded GOARCH=amd64, so the arm64 manifest shipped an amd64 binary
+# that died with "exec format error" on real aarch64 hosts. This compares
+# GNU `file`'s ELF machine description against the token expected for the arch.
+#
+# Subcommands:
+#   token   <amd64|arm64>             -> the `file` substring expected for the arch
+#   matches "<file -b output>" <arch> -> exit 0 if the description matches, else 1
+#   assert-file <path> <arch>         -> run `file -b <path>` and assert it matches
+#
+# All decision logic lives in pure functions (arch_token / arch_matches) so the
+# test can feed synthetic `file` descriptions without building any image.
+
+set -euo pipefail
+
+# Map a Docker/Go arch to the substring GNU `file` prints for that ELF machine.
+# The two tokens are disjoint (neither is a substring of the other's output),
+# so a simple containment test is unambiguous.
+arch_token() {
+  case "$1" in
+    amd64) echo "x86-64" ;;
+    arm64) echo "aarch64" ;;
+    *) echo "verify-arch: unknown arch '$1'" >&2; return 2 ;;
+  esac
+}
+
+# Does a `file -b` description denote the expected arch? 0 = match, 1 = mismatch.
+arch_matches() {
+  local desc="$1" arch="$2" token
+  token="$(arch_token "$arch")" || return 2
+  case "$desc" in
+    *"$token"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run `file` on a binary and assert its arch. Prints the description either way.
+assert_file() {
+  local path="$1" arch="$2" desc
+  desc="$(file -b "$path")"
+  echo "  $path: $desc"
+  if arch_matches "$desc" "$arch"; then
+    echo "  OK: matches $arch"
+  else
+    echo "::error::$path is not $arch (expected $(arch_token "$arch")): $desc" >&2
+    return 1
+  fi
+}
+
+# CLI dispatch — only when executed directly, not when sourced by the test.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    token)       arch_token "$@" ;;
+    matches)     arch_matches "$@" ;;
+    assert-file) assert_file "$@" ;;
+    *) echo "usage: verify-arch.sh {token|matches|assert-file} ..." >&2; exit 2 ;;
+  esac
+fi

--- a/.github/scripts/verify-arch_test.sh
+++ b/.github/scripts/verify-arch_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Table-driven tests for verify-arch.sh. No Docker needed — feeds synthetic
+# `file -b` descriptions (taken from real static Go binaries) to arch_matches.
+#   bash .github/scripts/verify-arch_test.sh
+# Exits non-zero if any assertion fails.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=verify-arch.sh
+source "$DIR/verify-arch.sh"
+
+pass=0
+fail=0
+
+# Assert arch_matches' exit status (0 = match, 1 = mismatch).
+check_match() {
+  local desc="$1" arch="$2" want="$3" label="$4" got
+  if arch_matches "$desc" "$arch"; then got=0; else got=1; fi
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: %s\n  arch=%s want-exit=%s got-exit=%s\n  desc=%q\n' \
+      "$label" "$arch" "$want" "$got" "$desc"
+  fi
+}
+
+check_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: %s\n  expected: %q\n  actual:   %q\n' "$label" "$expected" "$actual"
+  fi
+}
+
+# Real `file -b` output for static, stripped Go binaries:
+AMD64_DESC="ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=abc, stripped"
+ARM64_DESC="ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=abc, stripped"
+
+# ---------------------------------------------------------------- arch_matches
+check_match "$AMD64_DESC" amd64 0 "amd64 binary matches amd64"
+check_match "$ARM64_DESC" arm64 0 "arm64 binary matches arm64"
+check_match "$AMD64_DESC" arm64 1 "amd64 binary does NOT match arm64 (the #74 bug)"
+check_match "$ARM64_DESC" amd64 1 "arm64 binary does NOT match amd64"
+check_match "garbage not an elf" amd64 1 "non-ELF description never matches"
+
+# ------------------------------------------------------------------ arch_token
+check_eq "token amd64" "x86-64"  "$(arch_token amd64)"
+check_eq "token arm64" "aarch64" "$(arch_token arm64)"
+
+# Guard: tokens must stay disjoint, else a containment test would mis-match.
+check_match "$AMD64_DESC" arm64 1 "amd64 desc must not contain the arm64 token"
+check_match "$ARM64_DESC" amd64 1 "arm64 desc must not contain the amd64 token"
+
+# ---------------------------------------------------------------------- tally
+if [[ "$fail" -gt 0 ]]; then
+  printf '\n%d passed, %d FAILED\n' "$pass" "$fail"
+  exit 1
+fi
+printf '%d passed, 0 failed\n' "$pass"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
       - name: Run bump-version-refs tests
         run: bash .github/scripts/bump-version-refs_test.sh
 
+      - name: Run verify-arch tests
+        run: bash .github/scripts/verify-arch_test.sh
+
   # ---------------------------------------------------------------- frontend
   frontend:
     name: Frontend (Node ${{ matrix.node }})

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,157 @@
+name: Nightly build + verify (native multi-arch)
+
+# Build all three images from main HEAD natively on each architecture
+# (amd64 + arm64) and confirm they actually run there. Catches arch/build
+# regressions on main between releases — issue #74: an arm64 image once
+# shipped an amd64 binary that died with "exec format error" on real aarch64.
+#
+# Why native runners and not QEMU: on an amd64 runner an amd64 binary inside an
+# arm64 image runs natively (the host CPU executes it), so the kernel never
+# raises "exec format error" — emulation only kicks in for foreign-arch ELFs.
+# A native ubuntu-24.04-arm runner fails for real, so the verify can stay
+# trivial while being faithful. Complements release.yml's release-time arch
+# check (which inspects the published manifest at tag time); this runs HEAD on
+# real hardware every night.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # 04:00 UTC nightly, matching e2e.yml
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-verify:
+    name: ${{ matrix.image.name }} / ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write     # to file the deduped canary issue on failure
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+        image:
+          - name: backend
+            context: ./backend
+            kind: go
+          - name: frontend
+            context: ./frontend
+            kind: nginx
+          - name: cfsolver
+            context: ./cfsolver
+            kind: go-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image natively
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.image.context }}
+          push: false
+          load: true
+          tags: marauder-${{ matrix.image.name }}:nightly
+          # No `platforms:` — build for the runner's own architecture so the
+          # verify step runs the binary on real hardware (no QEMU).
+          cache-from: type=gha,scope=nightly-${{ matrix.image.name }}-${{ matrix.runner }}
+          cache-to: type=gha,scope=nightly-${{ matrix.image.name }}-${{ matrix.runner }},mode=max
+
+      - name: Verify image runs on this architecture
+        id: verify
+        continue-on-error: true
+        env:
+          IMG: marauder-${{ matrix.image.name }}:nightly
+          KIND: ${{ matrix.image.kind }}
+        run: |
+          set -uo pipefail
+          arch="$(uname -m)"
+          echo "Verifying $IMG on $arch (kind=$KIND)"
+          fail() { echo "::error::$IMG failed to verify on $arch: $1"; exit 1; }
+
+          case "$KIND" in
+            go)
+              # Backend exits on missing config. Reaching that error proves the
+              # Go binary execs on this arch; a wrong-arch binary would instead
+              # die with "exec format error" (genuine on a native runner). It
+              # cannot reach /health without a DB, so config-load is the honest
+              # liveness signal and needs no services.
+              out="$(timeout 30 docker run --rm "$IMG" 2>&1 || true)"
+              printf '%s\n' "$out" | head -n 5
+              printf '%s' "$out" | grep -q 'exec format error' && fail "exec format error"
+              printf '%s' "$out" | grep -q 'fatal: load config:' || fail "binary never reached config load"
+              ;;
+            go-server)
+              # cfsolver has no DB dependency, so it should actually serve
+              # /health. Poll until healthy, bailing early if it crashes.
+              cid="$(docker run -d -p 9244:9244 "$IMG")"
+              ok=0
+              for _ in $(seq 1 30); do
+                if curl -fsS http://localhost:9244/health >/dev/null 2>&1; then ok=1; break; fi
+                docker ps -q --no-trunc | grep -q "$cid" || break   # container exited
+                sleep 1
+              done
+              logs="$(docker logs "$cid" 2>&1 | tail -n 20 || true)"
+              docker rm -f "$cid" >/dev/null 2>&1 || true
+              printf '%s\n' "$logs"
+              printf '%s' "$logs" | grep -q 'exec format error' && fail "exec format error"
+              [ "$ok" -eq 1 ] || fail "/health never became reachable"
+              ;;
+            nginx)
+              # Frontend is static nginx; confirm it serves its root page.
+              cid="$(docker run -d -p 8088:8081 "$IMG")"
+              ok=0
+              for _ in $(seq 1 20); do
+                if curl -fsS http://localhost:8088/ >/dev/null 2>&1; then ok=1; break; fi
+                docker ps -q --no-trunc | grep -q "$cid" || break
+                sleep 1
+              done
+              logs="$(docker logs "$cid" 2>&1 | tail -n 20 || true)"
+              docker rm -f "$cid" >/dev/null 2>&1 || true
+              printf '%s\n' "$logs"
+              [ "$ok" -eq 1 ] || fail "did not serve / "
+              ;;
+            *)
+              fail "unknown kind '$KIND'"
+              ;;
+          esac
+          echo "OK: $IMG runs on $arch"
+
+      - name: File deduped canary issue on failure
+        if: steps.verify.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ${{ matrix.image.name }}
+          RUNNER_LABEL: ${{ matrix.runner }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create build-canary --color B60205 \
+            --description "A nightly native multi-arch build/verify is failing" \
+            2>/dev/null || true
+          TITLE="[build-canary] nightly build failing: ${IMAGE} on ${RUNNER_LABEL}"
+          NUM=$(gh issue list --label build-canary --state open \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" | head -1)
+          if [ -n "${NUM}" ]; then
+            gh issue comment "${NUM}" \
+              --body "Still failing on the nightly build. Run: ${RUN_URL}"
+          else
+            gh issue create --title "${TITLE}" --label build-canary --body \
+          "The nightly native build/verify for \`${IMAGE}\` on \`${RUNNER_LABEL}\` failed. The image either did not build or did not run on that architecture (see issue #74 for the class of bug this guards). Investigate the run and fix before the next release. Run: ${RUN_URL}"
+          fi
+
+      - name: Surface verify failure as a red (non-blocking) check
+        if: steps.verify.outcome == 'failure'
+        run: |
+          echo "::warning::${{ matrix.image.name }} on ${{ matrix.runner }} failed the nightly build/verify — issue filed"
+          exit 1

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -88,15 +88,20 @@ jobs:
               out="$(timeout 30 docker run --rm "$IMG" 2>&1 || true)"
               printf '%s\n' "$out" | head -n 5
               printf '%s' "$out" | grep -q 'exec format error' && fail "exec format error"
-              printf '%s' "$out" | grep -q 'fatal: load config:' || fail "binary never reached config load"
+              # Match loosely ('load config', case-insensitive) so a reworded
+              # config-load error doesn't turn this into a spurious canary.
+              printf '%s' "$out" | grep -qi 'load config' || fail "binary never reached config load"
               ;;
             go-server)
               # cfsolver has no DB dependency, so it should actually serve
               # /health. Poll until healthy, bailing early if it crashes.
-              cid="$(docker run -d -p 9244:9244 "$IMG")"
+              # Host port is in the project's mandated 30000-49999 range
+              # (local-port-ranges.md); each matrix leg is its own GitHub-hosted
+              # VM, so a fixed port cannot collide with another leg.
+              cid="$(docker run -d -p 39244:9244 "$IMG")"
               ok=0
               for _ in $(seq 1 30); do
-                if curl -fsS http://localhost:9244/health >/dev/null 2>&1; then ok=1; break; fi
+                if curl -fsS http://localhost:39244/health >/dev/null 2>&1; then ok=1; break; fi
                 docker ps -q --no-trunc | grep -q "$cid" || break   # container exited
                 sleep 1
               done
@@ -108,10 +113,11 @@ jobs:
               ;;
             nginx)
               # Frontend is static nginx; confirm it serves its root page.
-              cid="$(docker run -d -p 8088:8081 "$IMG")"
+              # Host port in the mandated 30000-49999 range (see go-server note).
+              cid="$(docker run -d -p 38081:8081 "$IMG")"
               ok=0
               for _ in $(seq 1 20); do
-                if curl -fsS http://localhost:8088/ >/dev/null 2>&1; then ok=1; break; fi
+                if curl -fsS http://localhost:38081/ >/dev/null 2>&1; then ok=1; break; fi
                 docker ps -q --no-trunc | grep -q "$cid" || break
                 sleep 1
               done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,13 @@ jobs:
         image:
           - name: backend
             context: ./backend
+            binpath: /usr/local/bin/marauder
           - name: frontend
             context: ./frontend
+            binpath: ''            # nginx static assets, no Go binary to arch-check
           - name: cfsolver
             context: ./cfsolver
+            binpath: /usr/local/bin/cfsolver
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -99,6 +102,54 @@ jobs:
           sbom: true
           cache-from: type=gha,scope=release-${{ matrix.image.name }}
           cache-to: type=gha,scope=release-${{ matrix.image.name }},mode=max
+
+      # Verify every published platform contains a binary of the matching
+      # architecture (issue #74: the arm64 manifest shipped an amd64 binary
+      # that died with "exec format error" on real aarch64 hosts). We extract
+      # the binary from each platform image WITHOUT running it and check its
+      # ELF machine type — because executing it here would NOT catch the bug:
+      # this runner is amd64, so an amd64 binary in an arm64 image runs
+      # natively (the host CPU can execute it) and never raises a format error.
+      # The arch mismatch only surfaces on a true aarch64 host, so the reliable
+      # CI signal is the binary's declared arch vs. the manifest's platform.
+      # QEMU (set up above) additionally lets us exec each binary as a bonus
+      # liveness check; the arch assertion is the actual gate.
+      - name: Verify each platform's binary architecture (QEMU)
+        if: matrix.image.binpath != ''
+        env:
+          IMG: ${{ env.REGISTRY }}/${{ env.OWNER }}/marauder-${{ matrix.image.name }}@${{ steps.push.outputs.digest }}
+          BIN: ${{ matrix.image.binpath }}
+        run: |
+          set -euo pipefail
+          declare -A want=( [amd64]="x86-64" [arm64]="aarch64" )
+          fail=0
+          for arch in amd64 arm64; do
+            echo "== linux/$arch =="
+            # `docker create` resolves the per-platform image but does NOT run
+            # the binary, so the check is independent of the runner's own arch.
+            cid="$(docker create --platform "linux/$arch" "$IMG")"
+            docker cp "$cid:$BIN" "./bin-$arch"
+            docker rm "$cid" >/dev/null
+            desc="$(file -b "./bin-$arch")"
+            echo "  binary: $desc"
+            case "$desc" in
+              *"${want[$arch]}"*)
+                echo "  OK: matches linux/$arch" ;;
+              *)
+                echo "::error::marauder-${{ matrix.image.name }} linux/$arch contains a wrong-arch binary (expected ${want[$arch]}): $desc"
+                fail=1 ;;
+            esac
+            # Bonus liveness check: run the binary under its platform. On this
+            # amd64 runner the arm64 binary executes via QEMU. We don't require
+            # a clean exit (no --help; exits on missing config) — only that the
+            # kernel doesn't reject it outright.
+            out="$(timeout 30 docker run --rm --platform "linux/$arch" "$IMG" 2>&1 || true)"
+            if printf '%s' "$out" | grep -q 'exec format error'; then
+              echo "::error::marauder-${{ matrix.image.name }} on linux/$arch failed to exec (exec format error)"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ]
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,6 @@ jobs:
           BIN: ${{ matrix.image.binpath }}
         run: |
           set -euo pipefail
-          declare -A want=( [amd64]="x86-64" [arm64]="aarch64" )
           fail=0
           for arch in amd64 arm64; do
             echo "== linux/$arch =="
@@ -130,15 +129,9 @@ jobs:
             cid="$(docker create --platform "linux/$arch" "$IMG")"
             docker cp "$cid:$BIN" "./bin-$arch"
             docker rm "$cid" >/dev/null
-            desc="$(file -b "./bin-$arch")"
-            echo "  binary: $desc"
-            case "$desc" in
-              *"${want[$arch]}"*)
-                echo "  OK: matches linux/$arch" ;;
-              *)
-                echo "::error::marauder-${{ matrix.image.name }} linux/$arch contains a wrong-arch binary (expected ${want[$arch]}): $desc"
-                fail=1 ;;
-            esac
+            # The ELF-arch match decision lives in a unit-tested script
+            # (.github/scripts/verify-arch.sh, covered by verify-arch_test.sh).
+            bash .github/scripts/verify-arch.sh assert-file "./bin-$arch" "$arch" || fail=1
             # Bonus liveness check: run the binary under its platform. On this
             # amd64 runner the arm64 binary executes via QEMU. We don't require
             # a clean exit (no --help; exits on missing config) — only that the
@@ -198,8 +191,13 @@ jobs:
 
       - name: Extract changelog section for this tag
         id: changelog
+        env:
+          # Pass the workflow_dispatch input via env rather than interpolating
+          # ${{ }} straight into the shell, so the value can never be parsed as
+          # script (defense-in-depth; only write-access actors can dispatch).
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         run: |
-          TAG="${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}"
+          TAG="${GITHUB_REF_NAME:-$TAG_INPUT}"
           VER="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **arm64 images now contain arm64 binaries** — the `backend` and `cfsolver`
+  Dockerfiles hardcoded `GOARCH=amd64`, so the published `linux/arm64` images
+  shipped an amd64 binary that failed with `exec format error` on real
+  `aarch64` hosts. They now cross-compile to BuildKit's `TARGETARCH`. The
+  release workflow now verifies each published platform's binary architecture
+  (and execs it under QEMU as a liveness check), failing the build if a binary
+  is the wrong architecture. (#74)
+
 ## [1.1.2] - 2026-06-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,10 @@ deploy/         docker-compose stacks (source-build base + prebuilt-image
 docs/           ROADMAP, PRD, VISION, COMPETITORS, per-feature guides
 site/           Astro 5 marketing site published to marauder.cc
 techdebt/       Debt-tracking files (one per issue, see global rule)
-.github/        Workflows: ci, docker, e2e, release, auto-release, codeql
+.github/        Workflows: ci, docker, e2e, nightly-build, release,
+                auto-release, codeql (nightly-build builds all 3 images on
+                native amd64+arm64 runners nightly and runs them — guards
+                against arch regressions like #74)
                 + scripts/ (release-helpers.sh: tested bump/version/issue logic)
 ```
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,13 @@ ARG VERSION=0.0.0-dev
 ARG COMMIT=unknown
 ARG BUILD_DATE=unknown
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+# TARGETARCH is auto-populated by BuildKit/buildx for each --platform it builds
+# (e.g. "arm64"). Cross-compile the Go binary to match, so the arm64 image
+# actually contains an arm64 binary instead of an amd64 one (issue #74). The
+# :-amd64 default keeps a plain `docker build` (no buildx, TARGETARCH unset)
+# working.
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
     go build -trimpath -ldflags="-s -w \
       -X github.com/artyomsv/marauder/backend/internal/version.Version=${VERSION} \
       -X github.com/artyomsv/marauder/backend/internal/version.Commit=${COMMIT} \

--- a/cfsolver/Dockerfile
+++ b/cfsolver/Dockerfile
@@ -10,7 +10,12 @@ COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+# TARGETARCH is auto-populated by BuildKit/buildx for each --platform it builds
+# (e.g. "arm64"). Cross-compile to match so the arm64 image contains an arm64
+# binary, not an amd64 one (issue #74). The :-amd64 default keeps a plain
+# `docker build` (no buildx, TARGETARCH unset) working.
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
     go build -trimpath -ldflags="-s -w" -o /out/cfsolver .
 
 # --- Runtime stage ------------------------------------------------------

--- a/docs/superpowers/specs/2026-06-22-nightly-multiarch-build-verify-design.md
+++ b/docs/superpowers/specs/2026-06-22-nightly-multiarch-build-verify-design.md
@@ -1,0 +1,94 @@
+# Nightly multi-arch build + verify — design
+
+**Date:** 2026-06-22
+**Status:** approved
+**Related:** issue #74 (arm64 image shipped an amd64 binary), PR #79 (the fix +
+release-time arch check)
+
+## Problem
+
+`backend/Dockerfile` and `cfsolver/Dockerfile` once hardcoded `GOARCH=amd64`, so
+the published `linux/arm64` images contained an amd64 binary and died with
+`exec format error` on real `aarch64` hosts (issue #74). PR #79 fixes the
+Dockerfiles and adds a release-time arch check. That check guards the
+*published* manifest, but only at tag time. Nothing continuously verifies that
+`main` still builds **and runs** on arm64 between releases.
+
+## Goal
+
+A nightly workflow that builds all three images from `main` HEAD **natively on
+each architecture** and confirms they actually run there, filing a deduped
+canary issue on failure. Catches arch/build regressions on `main` before they
+are ever tagged.
+
+## Why native runners (not QEMU)
+
+On an **amd64** runner an amd64 binary inside an arm64 image runs *natively* —
+the kernel never raises `exec format error` (QEMU only emulates foreign-arch
+ELFs). So execution-based testing on amd64 cannot catch a wrong-arch arm64
+binary. On a **native `ubuntu-24.04-arm` runner** the same broken binary fails
+for real. This repo is public, so native arm64 runners are free. Native
+execution keeps the verify trivial ("run it, fail on `exec format error`") while
+being faithful.
+
+This is complementary to PR #79: #79 inspects the *published* manifest's binary
+arch at release time; this runs *HEAD* on real hardware every night.
+
+## Design
+
+New file: `.github/workflows/nightly-build.yml`.
+
+**Triggers**
+- `schedule: cron '0 4 * * *'` — 04:00 UTC, matching the e2e nightly.
+- `workflow_dispatch`.
+- `concurrency` group with `cancel-in-progress: true`.
+
+**Permissions:** `contents: read`, `issues: write` (canary).
+
+**Job `build-verify`** — `runs-on: ${{ matrix.runner }}`, `fail-fast: false`,
+`timeout-minutes: 20`.
+
+Matrix = image × runner (6 legs):
+
+| image | kind | binpath | runners |
+|---|---|---|---|
+| backend | go | `/usr/local/bin/marauder` | `ubuntu-24.04`, `ubuntu-24.04-arm` |
+| cfsolver | go-server | `/usr/local/bin/cfsolver` | `ubuntu-24.04`, `ubuntu-24.04-arm` |
+| frontend | nginx | — | `ubuntu-24.04`, `ubuntu-24.04-arm` |
+
+**Steps:** checkout → setup-buildx → build natively (`push: false`,
+`load: true`, **no** `--platform` so the runner's own arch is the target, no
+QEMU) → verify (branches on `kind`).
+
+**Verify — native, so `exec format error` is genuine:**
+- **backend (`go`):** `docker run --rm` the image; assert output does **not**
+  contain `exec format error` **and** does contain its own config-load error
+  (`fatal: load config:`), proving the Go runtime initialised on this arch.
+  (It cannot reach `/health` without a DB; reaching config-load is the honest
+  liveness signal and needs no services.)
+- **cfsolver (`go-server`):** run detached with a published port, poll `/health`
+  until healthy or a short timeout — it has no DB dependency, so it genuinely
+  serves. Fail on timeout.
+- **frontend (`nginx`):** run detached with a published port, `curl` the served
+  root, assert a successful response.
+
+**On failure:** `continue-on-error: true` on the verify step, then a deduped
+canary issue **per failing leg** (label `build-canary`, title
+`[build-canary] nightly build failing: <image> on <runner>`): create if absent,
+else comment the run URL. Per-leg titles (rather than one shared title) avoid
+`gh issue create` races across the 6 parallel matrix legs — the same per-key
+dedup `client-acceptance.yml` uses per-client. End each failing leg with a red
+**non-blocking** check (`::warning::` + `exit 1`).
+
+## Out of scope (YAGNI)
+
+- Full-stack `docker compose` bring-up with Postgres — heavier than the agreed
+  liveness check.
+- Pushing the nightly images anywhere — this is a build+run gate, not a publish.
+- Additional architectures beyond amd64/arm64 (only those two are published).
+
+## Placement
+
+Committed to the existing `74-...` branch / PR #79 (related theme: multi-arch
+image correctness). The PR description is extended to cover the workflow.
+`CLAUDE.md`'s workflow list gains a one-line mention.


### PR DESCRIPTION
## Summary

Fixes #74. The published `linux/arm64` backend (and `cfsolver`) images
contained an **amd64** binary, so they died with `exec format error` on real
`aarch64` hosts.

Root cause: `backend/Dockerfile` and `cfsolver/Dockerfile` hardcoded
`GOARCH=amd64`. `docker buildx` builds the arm64 *image* (correct base layers)
but the Go binary was always cross-compiled to amd64, producing an
arm64-labelled manifest with an amd64 ELF inside.

## Changes

- **`backend/Dockerfile`, `cfsolver/Dockerfile`** — replace `GOARCH=amd64` with
  `ARG TARGETARCH` + `GOARCH=${TARGETARCH:-amd64}`. BuildKit injects
  `TARGETARCH` per `--platform`; the `:-amd64` default keeps a plain
  `docker build` (no buildx) working.
- **`.github/workflows/release.yml`** — new step that, for each published
  platform, extracts the binary (`docker create` + `docker cp`, without running
  it) and asserts its ELF architecture matches the manifest. Fails the `build`
  job on a mismatch, which (via `needs: [build]`) blocks the Release,
  issue-notify, and version-bump jobs. Also execs each binary under QEMU as a
  bonus liveness check. Frontend is skipped (nginx, no Go binary).
- **`CHANGELOG.md`** — `[Unreleased]` Fixed entry.

## Why the test inspects arch instead of just running the binary

Executing the binary on the **amd64** CI runner does **not** catch this bug: an
amd64 binary inside an arm64-labelled image runs *natively* on an amd64 host, so
the kernel never raises `exec format error` (QEMU only emulates foreign-arch
ELFs). The mismatch only surfaces on a true aarch64 host. The reliable,
host-independent signal is therefore the binary's declared arch vs. the
manifest's platform.

## Test plan

Verified locally with Docker buildx + arm64 QEMU emulation:

- ✅ Fixed image: `docker buildx build --platform linux/arm64` produces an
  `aarch64` binary (`file`: *ELF 64-bit … ARM aarch64*), and it execs under
  emulation (exits on missing config, not a format error).
- ✅ Negative test: forcing the old behaviour
  (`--build-arg TARGETARCH=amd64 --platform linux/arm64`) yields an `x86-64`
  binary in the arm64 image — and the workflow's arch check correctly **fails**
  on it. The gate has teeth.
---

## Update: nightly native build + verify (commit 2)

Added `.github/workflows/nightly-build.yml` — a continuous guard for the same
regression class on `main` (not just at release time).

- Builds all three images from `main` HEAD **natively** on `ubuntu-24.04` and
  `ubuntu-24.04-arm` (3 images × 2 arches) every night (`0 4 * * *`) +
  `workflow_dispatch`.
- Runs each on its real CPU: backend asserts it reaches config-load (Go runtime
  execs on the arch), cfsolver polls `/health`, frontend serves its root. On a
  native arm64 runner a wrong-arch binary fails for real — which an amd64 runner
  cannot surface.
- On failure: deduped `build-canary` issue (per image/runner) + red
  non-blocking check, mirroring `client-acceptance.yml`.
- Design doc: `docs/superpowers/specs/2026-06-22-nightly-multiarch-build-verify-design.md`.

Verified locally on amd64 (all three verify snippets pass); the arm64 legs and
the schedule only execute once this is on `main`.