### PR TITLE
fix(qbittorrent): treat duplicate add as idempotent delivery (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Duplicate qBittorrent deliveries are now idempotent** — when a torrent's
+  infohash is already present, qBittorrent rejects a re-submit (with `409
+  Conflict`, or `200 "Fails."` on older versions like 5.1.4), which previously
+  drove the topic into the `error` state even though the torrent was correctly
+  present and downloading. Marauder now verifies the payload's infohash is
+  actually present and treats such a rejection as a successful delivery;
+  genuine failures (infohash absent) still surface as errors. (#76)
+
 ## [1.1.1] - 2026-06-22
 
 ### Fixed

--- a/backend/e2e/duplicate_test.go
+++ b/backend/e2e/duplicate_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// topicState reads GET /topics/{id} and returns the topic's status and last
+// error. domain.Topic has no JSON tags, so the fields marshal as "Status" /
+// "LastError".
+func (m *marauderClient) topicState(t *testing.T, id string) (status, lastError string) {
+	t.Helper()
+	data := m.do(t, http.MethodGet, "/api/v1/topics/"+id, nil)
+	var out struct {
+		Status    string `json:"Status"`
+		LastError string `json:"LastError"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode topic %s: %v (%s)", id, err, string(data))
+	}
+	return out.Status, out.LastError
+}
+
+// TestDuplicateDelivery is the e2e regression for issue #76: when a torrent
+// with a given infohash is already present in qBittorrent, delivering the SAME
+// infohash again must be an idempotent success — not a topic error.
+//
+// It forces a real duplicate add through the scheduler without DB surgery by
+// creating two topics whose magnets share one infohash (differing only by the
+// display-name `dn`, so they are distinct topic URLs). The second topic's
+// delivery hits qBittorrent's duplicate signal (409, or 200 "Fails." depending
+// on version); the fix must treat it as an idempotent success so the second
+// topic records its delivery and stays active.
+func TestDuplicateDelivery(t *testing.T) {
+	env := readEnv(t) // skips if MARAUDER_BASE_URL unset
+
+	m := newMarauder(env)
+	m.Login(t)
+	clientID := m.CreateQbitClient(t, "/downloads")
+
+	q := newQbit(t, env)
+	q.Login(t)
+
+	ih := uniqueInfohash(t) // shared infohash for both topics
+
+	// Topic A delivers the infohash first.
+	topicA := m.CreateTopic(t, "magnet:?xt=urn:btih:"+ih+"&dn=dup-alpha", clientID, "dup-e2e")
+	if !pollUntil(10*time.Second, 135*time.Second, func() bool {
+		return m.StatusHasInfohash(t, topicA, ih)
+	}) {
+		t.Fatalf("topic A never delivered infohash %s", ih)
+	}
+	// Confirm it is actually present in qBittorrent before forcing the duplicate.
+	if !pollUntil(2*time.Second, 15*time.Second, func() bool {
+		_, ok := q.TorrentInfo(t, ih)
+		return ok
+	}) {
+		t.Fatalf("infohash %s not present in qBittorrent after topic A delivered", ih)
+	}
+
+	// Topic B: a different magnet URL (dn) but the SAME infohash, so its delivery
+	// is a duplicate add at the qBittorrent layer.
+	topicB := m.CreateTopic(t, "magnet:?xt=urn:btih:"+ih+"&dn=dup-beta", clientID, "dup-e2e")
+
+	// With the fix, the duplicate add is an idempotent success → topic B records
+	// its delivery. Pre-fix, the duplicate errored and B recorded nothing.
+	if !pollUntil(10*time.Second, 135*time.Second, func() bool {
+		return m.StatusHasInfohash(t, topicB, ih)
+	}) {
+		status, lastErr := m.topicState(t, topicB)
+		t.Fatalf("topic B (duplicate infohash) never recorded a delivery; status=%q last_error=%q", status, lastErr)
+	}
+
+	// And it must not have been parked in the error state by the duplicate.
+	if status, lastErr := m.topicState(t, topicB); status == "error" {
+		t.Errorf("topic B is in error state after a duplicate delivery: status=%q last_error=%q", status, lastErr)
+	}
+}

--- a/backend/e2e/duplicate_test.go
+++ b/backend/e2e/duplicate_test.go
@@ -76,7 +76,13 @@ func TestDuplicateDelivery(t *testing.T) {
 	}
 
 	// And it must not have been parked in the error state by the duplicate.
-	if status, lastErr := m.topicState(t, topicB); status == "error" {
+	status, lastErr := m.topicState(t, topicB)
+	if status == "" {
+		// domain.Topic has no JSON tags today (status marshals as "Status"); an
+		// empty decode means that shape changed and this assertion went blind.
+		t.Fatalf("topic B status decoded empty — domain.Topic JSON shape changed?")
+	}
+	if status == "error" {
 		t.Errorf("topic B is in error state after a duplicate delivery: status=%q last_error=%q", status, lastErr)
 	}
 }

--- a/backend/internal/plugins/clients/qbittorrent/duplicate_test.go
+++ b/backend/internal/plugins/clients/qbittorrent/duplicate_test.go
@@ -1,0 +1,98 @@
+package qbittorrent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+)
+
+// dupFakeQBit simulates qBittorrent's duplicate-add behaviour, which varies by
+// version: some versions answer /torrents/add with 409 Conflict, others with
+// 200 "Fails." (verified empirically against linuxserver/qbittorrent 5.1.4).
+// `present` independently controls whether /torrents/info reports the infohash,
+// so a test can model "rejected because already present" vs "rejected and
+// genuinely absent" (a real bad-torrent failure).
+type dupFakeQBit struct {
+	addStatus int    // status code for /torrents/add
+	addBody   string // body for /torrents/add
+	present   bool   // whether /torrents/info reports the infohash as present
+}
+
+func (f *dupFakeQBit) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/app/version", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("v5.1.4"))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(f.addStatus)
+		_, _ = w.Write([]byte(f.addBody))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if f.present {
+			h := r.URL.Query().Get("hashes")
+			_, _ = w.Write([]byte(`[{"hash":"` + h + `","progress":0,"state":"downloading"}]`))
+		} else {
+			_, _ = w.Write([]byte(`[]`))
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const dupInfohash = "be0500f2bac970d77fdfea3f4c63290605f92b41"
+
+func dupAdd(t *testing.T, f *dupFakeQBit) error {
+	t.Helper()
+	srv := f.server(t)
+	p := &plugin{sessions: map[string]*session{}}
+	cfg, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
+	payload := &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:" + dupInfohash + "&dn=dup"}
+	return p.Add(context.Background(), cfg, payload, domain.AddOptions{})
+}
+
+// TestAdd_Duplicate409_AlreadyPresent_IsIdempotentSuccess reproduces issue #76
+// for qBittorrent versions that reject a duplicate add with 409 Conflict (the
+// version the reporter runs). When the infohash is already present, the retry
+// must be an idempotent success, not an error.
+func TestAdd_Duplicate409_AlreadyPresent_IsIdempotentSuccess(t *testing.T) {
+	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusConflict, addBody: "Conflict", present: true}); err != nil {
+		t.Fatalf("duplicate 409 with infohash present should be an idempotent success, got: %v", err)
+	}
+}
+
+// TestAdd_DuplicateFailsBody_AlreadyPresent_IsIdempotentSuccess reproduces the
+// same bug on qBittorrent 5.1.4, which signals a duplicate with 200 "Fails."
+// rather than 409 (verified empirically). Same expectation: idempotent success.
+func TestAdd_DuplicateFailsBody_AlreadyPresent_IsIdempotentSuccess(t *testing.T) {
+	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusOK, addBody: "Fails.", present: true}); err != nil {
+		t.Fatalf(`duplicate 200 "Fails." with infohash present should be an idempotent success, got: %v`, err)
+	}
+}
+
+// TestAdd_Reject409_NotPresent_ReturnsError guards that the fix does not mask a
+// genuine failure: a 409 with the infohash absent must remain an error.
+func TestAdd_Reject409_NotPresent_ReturnsError(t *testing.T) {
+	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusConflict, addBody: "Conflict", present: false}); err == nil {
+		t.Fatal("409 with infohash absent should remain an error")
+	}
+}
+
+// TestAdd_RejectFailsBody_NotPresent_ReturnsError guards that a genuine bad
+// torrent (200 "Fails." with the infohash absent) still surfaces as an error.
+func TestAdd_RejectFailsBody_NotPresent_ReturnsError(t *testing.T) {
+	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusOK, addBody: "Fails.", present: false}); err == nil {
+		t.Fatal(`200 "Fails." with infohash absent should remain an error`)
+	}
+}

--- a/backend/internal/plugins/clients/qbittorrent/duplicate_test.go
+++ b/backend/internal/plugins/clients/qbittorrent/duplicate_test.go
@@ -12,7 +12,8 @@ import (
 
 // dupFakeQBit simulates qBittorrent's duplicate-add behaviour, which varies by
 // version: some versions answer /torrents/add with 409 Conflict, others with
-// 200 "Fails." (verified empirically against linuxserver/qbittorrent 5.1.4).
+// 200 "Fails." (verified empirically against linuxserver/qbittorrent 5.1.4), and
+// the newer multipart path with a 200 JSON summary carrying failure_count>0.
 // `present` independently controls whether /torrents/info reports the infohash,
 // so a test can model "rejected because already present" vs "rejected and
 // genuinely absent" (a real bad-torrent failure).
@@ -40,6 +41,7 @@ func (f *dupFakeQBit) server(t *testing.T) *httptest.Server {
 	mux.HandleFunc("/api/v2/torrents/info", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		if f.present {
+			// Echo the queried hash, mirroring qBittorrent's server-side filter.
 			h := r.URL.Query().Get("hashes")
 			_, _ = w.Write([]byte(`[{"hash":"` + h + `","progress":0,"state":"downloading"}]`))
 		} else {
@@ -51,48 +53,51 @@ func (f *dupFakeQBit) server(t *testing.T) *httptest.Server {
 	return srv
 }
 
-const dupInfohash = "be0500f2bac970d77fdfea3f4c63290605f92b41"
+// TestAdd_DuplicateHandling is the regression matrix for issue #76. A duplicate
+// add is rejected by qBittorrent via one of three version-dependent signals
+// (409 Conflict, 200 "Fails.", or a 200 JSON summary with failure_count>0). In
+// every case the add must be an idempotent success when the payload's infohash
+// is already present, and must still surface an error when it is genuinely
+// absent (a real bad torrent) — the fix must never mask a true failure.
+func TestAdd_DuplicateHandling(t *testing.T) {
+	const ih = "be0500f2bac970d77fdfea3f4c63290605f92b41"
+	goodMagnet := "magnet:?xt=urn:btih:" + ih + "&dn=dup"
+	// A magnet with no xt= cannot yield an infohash, so the presence check is
+	// fail-closed and the rejection must stand.
+	badMagnet := "magnet:?dn=no-infohash"
+	const jsonFailure = `{"added_torrent_ids":[],"success_count":0,"failure_count":1,"pending_count":0}`
 
-func dupAdd(t *testing.T, f *dupFakeQBit) error {
-	t.Helper()
-	srv := f.server(t)
-	p := &plugin{sessions: map[string]*session{}}
-	cfg, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
-	payload := &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:" + dupInfohash + "&dn=dup"}
-	return p.Add(context.Background(), cfg, payload, domain.AddOptions{})
-}
-
-// TestAdd_Duplicate409_AlreadyPresent_IsIdempotentSuccess reproduces issue #76
-// for qBittorrent versions that reject a duplicate add with 409 Conflict (the
-// version the reporter runs). When the infohash is already present, the retry
-// must be an idempotent success, not an error.
-func TestAdd_Duplicate409_AlreadyPresent_IsIdempotentSuccess(t *testing.T) {
-	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusConflict, addBody: "Conflict", present: true}); err != nil {
-		t.Fatalf("duplicate 409 with infohash present should be an idempotent success, got: %v", err)
+	tests := []struct {
+		name      string
+		addStatus int
+		addBody   string
+		magnet    string
+		present   bool
+		wantErr   bool
+	}{
+		{"409 duplicate, infohash present -> idempotent success", http.StatusConflict, "Conflict", goodMagnet, true, false},
+		{`200 "Fails." duplicate, infohash present -> idempotent success`, http.StatusOK, "Fails.", goodMagnet, true, false},
+		{"JSON failure_count>0, infohash present -> idempotent success", http.StatusOK, jsonFailure, goodMagnet, true, false},
+		{"409 rejection, infohash absent -> error", http.StatusConflict, "Conflict", goodMagnet, false, true},
+		{`200 "Fails." rejection, infohash absent -> error`, http.StatusOK, "Fails.", goodMagnet, false, true},
+		{"JSON failure_count>0, infohash absent -> error", http.StatusOK, jsonFailure, goodMagnet, false, true},
+		{"rejection with undecodable payload -> fail-closed error", http.StatusOK, "Fails.", badMagnet, true, true},
 	}
-}
 
-// TestAdd_DuplicateFailsBody_AlreadyPresent_IsIdempotentSuccess reproduces the
-// same bug on qBittorrent 5.1.4, which signals a duplicate with 200 "Fails."
-// rather than 409 (verified empirically). Same expectation: idempotent success.
-func TestAdd_DuplicateFailsBody_AlreadyPresent_IsIdempotentSuccess(t *testing.T) {
-	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusOK, addBody: "Fails.", present: true}); err != nil {
-		t.Fatalf(`duplicate 200 "Fails." with infohash present should be an idempotent success, got: %v`, err)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := (&dupFakeQBit{addStatus: tt.addStatus, addBody: tt.addBody, present: tt.present}).server(t)
+			p := &plugin{sessions: map[string]*session{}}
+			cfg, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
+			payload := &domain.Payload{MagnetURI: tt.magnet}
 
-// TestAdd_Reject409_NotPresent_ReturnsError guards that the fix does not mask a
-// genuine failure: a 409 with the infohash absent must remain an error.
-func TestAdd_Reject409_NotPresent_ReturnsError(t *testing.T) {
-	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusConflict, addBody: "Conflict", present: false}); err == nil {
-		t.Fatal("409 with infohash absent should remain an error")
-	}
-}
-
-// TestAdd_RejectFailsBody_NotPresent_ReturnsError guards that a genuine bad
-// torrent (200 "Fails." with the infohash absent) still surfaces as an error.
-func TestAdd_RejectFailsBody_NotPresent_ReturnsError(t *testing.T) {
-	if err := dupAdd(t, &dupFakeQBit{addStatus: http.StatusOK, addBody: "Fails.", present: false}); err == nil {
-		t.Fatal(`200 "Fails." with infohash absent should remain an error`)
+			err := p.Add(context.Background(), cfg, payload, domain.AddOptions{})
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected an idempotent success, got: %v", err)
+			}
+		})
 	}
 }

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/infohash"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 )
 
@@ -149,38 +150,78 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 		return fmt.Errorf("add torrent: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(b))
-	}
-	// qBittorrent's /torrents/add success contract varies by version:
-	//   - legacy: 200 with body "Ok." (and "Fails." on a rejected torrent).
-	//   - newer:  200 with a JSON summary, e.g.
-	//     {"added_torrent_ids":[..],"failure_count":0,"pending_count":0,"success_count":1}
-	// Detect failure precisely. A naive substring check for "fail" trips on
-	// the JSON field name "failure_count" and turns a success into a false
-	// rejection (observed against linuxserver/qbittorrent on the multipart
-	// add path).
 	b, _ := io.ReadAll(resp.Body)
 	respBody := strings.TrimSpace(string(b))
-	if strings.HasPrefix(respBody, "{") {
+
+	// A non-2xx that is NOT the duplicate-conflict signal is a hard transport
+	// error (auth, server fault, ...). 409 Conflict is handled below as a
+	// possible duplicate.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, respBody)
+	}
+
+	// Decide whether qBittorrent accepted the add. The contract is
+	// version-dependent:
+	//   - legacy: 200 "Ok." (success) / 200 "Fails." (rejection).
+	//   - newer:  200 with a JSON summary, e.g.
+	//     {"added_torrent_ids":[..],"failure_count":0,"pending_count":0,"success_count":1}.
+	//   - duplicate: 409 Conflict (newer) or 200 "Fails." (e.g. 5.1.4) when the
+	//     infohash is already present.
+	// The JSON path is parsed precisely so the field name "failure_count" is not
+	// mistaken for a "fail" rejection (regression guard, #60).
+	accepted := false
+	switch {
+	case resp.StatusCode == http.StatusConflict:
+		accepted = false // duplicate signal — verify presence below
+	case strings.HasPrefix(respBody, "{"):
 		var summary struct {
 			SuccessCount int `json:"success_count"`
 			FailureCount int `json:"failure_count"`
 			PendingCount int `json:"pending_count"`
 		}
 		if err := json.Unmarshal([]byte(respBody), &summary); err == nil {
-			if summary.FailureCount > 0 || (summary.SuccessCount == 0 && summary.PendingCount == 0) {
-				return fmt.Errorf("qbittorrent rejected torrent: %s", respBody)
-			}
-			return nil
+			accepted = summary.FailureCount == 0 && (summary.SuccessCount > 0 || summary.PendingCount > 0)
+		} else {
+			// Unparseable JSON: fall back to the legacy string contract.
+			accepted = !strings.Contains(strings.ToLower(respBody), "fails")
 		}
-		// Unparseable JSON falls through to the legacy string check below.
+	default:
+		// Legacy string contract: anything that isn't "fails" is success.
+		accepted = !strings.Contains(strings.ToLower(respBody), "fails")
 	}
-	if strings.Contains(strings.ToLower(respBody), "fails") {
-		return fmt.Errorf("qbittorrent rejected torrent: %s", respBody)
+	if accepted {
+		return nil
 	}
-	return nil
+
+	// qBittorrent rejected the add. If the payload's infohash is already present,
+	// the rejection is a duplicate and the delivery is effectively done — treat
+	// it as an idempotent success (issue #76). Otherwise it is a genuine failure
+	// (bad torrent, server problem) and must surface as an error.
+	if p.alreadyPresent(ctx, rawConfig, payload) {
+		return nil
+	}
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, respBody)
+	}
+	return fmt.Errorf("qbittorrent rejected torrent: %s", respBody)
+}
+
+// alreadyPresent reports whether the payload's infohash is already known to
+// qBittorrent. It makes a rejected /torrents/add idempotent: qBittorrent
+// rejects a duplicate add (via 409, "Fails.", or a JSON failure depending on
+// version), but the torrent is in fact present, so the delivery is done
+// (issue #76). Fail-closed: if the infohash cannot be derived or the status
+// query fails, it returns false so a genuine rejection is never swallowed.
+func (p *plugin) alreadyPresent(ctx context.Context, rawConfig []byte, payload *domain.Payload) bool {
+	ih, err := infohash.FromPayload(payload.MagnetURI, payload.TorrentFile)
+	if err != nil || ih == "" {
+		return false
+	}
+	statuses, err := p.Status(ctx, rawConfig, []string{ih})
+	if err != nil {
+		return false
+	}
+	return len(statuses) > 0
 }
 
 // Status implements registry.WithStatus. It queries

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
@@ -172,7 +172,7 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 	accepted := false
 	switch {
 	case resp.StatusCode == http.StatusConflict:
-		accepted = false // duplicate signal — verify presence below
+		// Duplicate signal — leave accepted=false so the presence check below runs.
 	case strings.HasPrefix(respBody, "{"):
 		var summary struct {
 			SuccessCount int `json:"success_count"`
@@ -193,10 +193,12 @@ func (p *plugin) Add(ctx context.Context, rawConfig []byte, payload *domain.Payl
 		return nil
 	}
 
-	// qBittorrent rejected the add. If the payload's infohash is already present,
-	// the rejection is a duplicate and the delivery is effectively done — treat
-	// it as an idempotent success (issue #76). Otherwise it is a genuine failure
-	// (bad torrent, server problem) and must surface as an error.
+	// qBittorrent rejected the add. The probe below runs for ANY rejection
+	// signal (409, "Fails.", or a JSON failure), not only 409: if the payload's
+	// infohash is already present, the rejection is a duplicate and the delivery
+	// is effectively done — treat it as an idempotent success (issue #76).
+	// Otherwise it is a genuine failure (bad torrent, server problem) and must
+	// surface as an error.
 	if p.alreadyPresent(ctx, rawConfig, payload) {
 		return nil
 	}
@@ -217,6 +219,9 @@ func (p *plugin) alreadyPresent(ctx context.Context, rawConfig []byte, payload *
 	if err != nil || ih == "" {
 		return false
 	}
+	// Status filters server-side via /torrents/info?hashes=<ih>, so a non-empty
+	// result means this exact infohash is present; we deliberately rely on that
+	// filter rather than re-matching the returned hash here.
 	statuses, err := p.Status(ctx, rawConfig, []string{ih})
 	if err != nil {
 		return false


### PR DESCRIPTION
## Summary

Fixes #76. When a torrent's infohash is already present in qBittorrent, a
re-submit of `/api/v2/torrents/add` is rejected — and Marauder treated that as a
failure, driving the topic into the `error` state even though the torrent was
correctly present and downloading. The topic then retried the same infohash
forever.

**The duplicate signal is version-dependent** (verified empirically): newer
qBittorrent returns `409 Conflict`, **5.1.4 returns `200 "Fails."`**, and the
newer multipart path can return a JSON summary with `failure_count>0`. So the
naive "treat 409 as success" fix from the report is both incomplete (misses
5.1.4) and unsafe (blindly trusting the status could record a delivery that
never happened).

## Fix

On **any** duplicate-rejection signal, `Add()` now verifies the payload's
infohash is actually present (via the plugin's existing `Status()` +
`infohash.FromPayload`):
- **present** → idempotent success (the content is there; record the delivery,
  persist `last_hash`, break the error loop);
- **absent** → keep the error (a genuine bad-torrent failure is never masked).

One code path covers all three signals; nothing is fabricated.

## Test plan

- **Unit** (`duplicate_test.go`): `409`/`200 "Fails."` with the infohash present
  → idempotent success; with it absent → still an error (regression guard).
  Existing #60 (JSON summary) and #75 (category) tests stay green; `-race` clean.
- **e2e** (`backend/e2e/duplicate_test.go`, `//go:build e2e`):
  `TestDuplicateDelivery` creates two topics sharing one infohash (distinct
  magnet URLs) so the second delivery hits the real duplicate path; asserts the
  second topic records its delivery and stays active. **Verified green against a
  real qBittorrent 5.2.1** on an isolated stack (alongside the existing
  `TestDelivery`).
- Full untagged backend suite green; gofmt clean; e2e package invisible without
  the tag.
