### PR TITLE
ci: fix arch-verify digest collision blocking releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
       frontend-digest: ${{ steps.export.outputs.frontend-digest }}
       cfsolver-digest: ${{ steps.export.outputs.cfsolver-digest }}
     strategy:
-      fail-fast: true
+      # Don't let one image's arch-verify failure cancel the others' builds —
+      # each image is independent and we want all results in one run.
+      fail-fast: false
       matrix:
         image:
           - name: backend
@@ -141,6 +143,12 @@ jobs:
               echo "::error::marauder-${{ matrix.image.name }} on linux/$arch failed to exec (exec format error)"
               fail=1
             fi
+            # Drop the digest-pinned image before the next platform. Docker keeps
+            # a single local record per digest, so a second `docker create
+            # --platform` of the SAME digest fails with "cannot overwrite digest"
+            # — which blocked the v1.1.3 release on the arm64 iteration. Removing
+            # it forces a clean per-platform pull each time.
+            docker rmi -f "$IMG" >/dev/null 2>&1 || true
           done
           [ "$fail" -eq 0 ]
 


### PR DESCRIPTION
## Summary

The v1.1.3 Release failed (and `v1.1.3` never published) because of a bug in
`release.yml`'s **"Verify each platform's binary architecture (QEMU)"** step —
not a real arch regression and not the (separate) Docker Hub outage.

The step loops `docker create --platform linux/$arch "$IMG"` over `amd64` then
`arm64`, where `$IMG` is pinned by the **manifest-list digest**. Docker keeps a
single local image record per digest, so the second platform's `docker create`
of the same digest fails with **`cannot overwrite digest …`**. Under `set -e`
that aborts the job; matrix `fail-fast: true` then cancelled the sibling image
builds, so the release's publish/sync jobs were skipped.

Observed on v1.1.3: `amd64` verified fine (`OK: matches amd64`), the `arm64`
iteration died on `cannot overwrite digest`. cfsolver and backend (Go binaries)
run the step and hit it; frontend skips it (`binpath: ''`, no binary), which is
why frontend passed.

## Fix

- `docker rmi -f "$IMG"` at the end of each platform iteration → each
  `docker create --platform` re-pulls cleanly, so `amd64` then `arm64` both
  resolve.
- `strategy.fail-fast: false` → one image's verify failure no longer cancels
  the other images' builds.

The arch assertion itself (`.github/scripts/verify-arch.sh`, unit-tested by
`verify-arch_test.sh`) is unchanged.

## Test plan

- `release.yml` parses (js-yaml) ✓.
- Real validation is the Release run: after merge, re-cut/re-run the release and
  confirm the verify step passes both platforms for backend + cfsolver and the
  GitHub Release + GHCR images publish.

Note: `ci:` type — does not trigger an auto-release bump.
