### PR TITLE
ci: commit README version markers on release (catch up to 1.1.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,12 +351,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Deploy/repo artifacts: nothing to redeploy -> [skip ci].
-          if ! git diff --quiet -- deploy/docker-compose.yml deploy/docker-compose.ghcr.yml deploy/.env.example; then
-            git add deploy/docker-compose.yml deploy/docker-compose.ghcr.yml deploy/.env.example
-            git commit -m "chore: pin deploy stack to ${VER} [skip ci]"
+          # Deploy/repo artifacts (incl. README version markers): nothing to
+          # redeploy -> [skip ci]. README.md MUST be in this add list — the
+          # bump script edits its release badge / latest-release marker /
+          # MARAUDER_VERSION default, but those edits are dropped if the file is
+          # never staged (which froze README at an old version for many releases).
+          if ! git diff --quiet -- deploy/docker-compose.yml deploy/docker-compose.ghcr.yml deploy/.env.example README.md; then
+            git add deploy/docker-compose.yml deploy/docker-compose.ghcr.yml deploy/.env.example README.md
+            git commit -m "chore: pin deploy stack and README to ${VER} [skip ci]"
           else
-            echo "deploy version references already at ${VER}"
+            echo "deploy/README version references already at ${VER}"
           fi
 
           # Site content: must trigger site.yml to redeploy marauder.cc, so this

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **A modern, self-hosted torrent topic monitor for the trackers the *arr stack can't reach.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release: v1.0.6](https://img.shields.io/badge/release-v1.0.6-success.svg)](CHANGELOG.md)
+[![Release: v1.1.3](https://img.shields.io/badge/release-v1.1.3-success.svg)](CHANGELOG.md)
 
 [![CI](https://github.com/artyomsv/marauder/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/artyomsv/marauder/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/codeql.yml)
@@ -69,7 +69,7 @@ Read the full rationale: [VISION.md](docs/VISION.md) ·
 
 ## Project status
 
-**v1.0.6** — latest release (v1.0.0 was the initial production cut;
+**v1.1.3** — latest release (v1.0.0 was the initial production cut;
 v1.0.1 was the first release to publish container images to GHCR).
 
 What works **today**:
@@ -133,7 +133,7 @@ docker compose -f docker-compose.ghcr.yml --env-file .env up -d
 ```
 
 Requires Docker Compose **v2.23.1+**. Pin the release with `MARAUDER_VERSION`
-in `.env` (defaults to `1.0.6`); `latest` also exists.
+in `.env` (defaults to `1.1.3`); `latest` also exists.
 
 ### Build from source (contributors)
 


### PR DESCRIPTION
## Summary

The README version markers (release badge, the **vX.Y.Z** "latest release"
marker, and the `MARAUDER_VERSION` default note) had been **frozen at v1.0.6**
across the 1.0.7 → 1.1.3 releases, even though every other versioned file
(deploy/, site/) bumped correctly.

**Root cause:** the release `Sync version references` job runs
`bump-version-refs.sh`, which *does* edit `README.md` — but the job's `git add`
only staged the `deploy/` and `site/` files. README's edits were never staged,
so they were silently discarded on the ephemeral runner every release. The
script and its unit test were already correct (patterns match; 18/18 pass) — the
gap was purely the missing stage step in the workflow.

## Fix

- `release.yml`: add `README.md` to the `[skip ci]` deploy-artifacts commit's
  diff-guard and `git add` (README needs no redeploy, so `[skip ci]` is right).
- `README.md`: stamp the current released version (**1.1.3**) to catch it up
  now. From the next release on, it stays in sync automatically.

## Test plan

- `bump-version-refs_test.sh` → 18 passed, 0 failed.
- `release.yml` parses (js-yaml).
- Verified locally: running `bump-version-refs.sh 1.1.3` updates exactly the
  three README markers (badge line, latest-release marker, `MARAUDER_VERSION`
  default) and nothing else (deploy/site already current).

`ci:` type — does not trigger an auto-release bump.
