### PR TITLE
feat(nnmclub): anonymous-only support + credentials disclaimer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,18 +356,25 @@ See `docs/plugin-development.md`. The pattern: implement the
 unit test plus an e2e test using `plugins/e2etest.HostRewriteTransport`.
 
 Optional capability interfaces: `WithQuality`, `WithEpisodeFilter`,
-`WithCredentials`, `WithCloudflare`, `WithInteractiveLogin`,
-`WithSeasonCatalog`, `WithMetadata`. The frontend AddTopic form discovers most via
-`GET /api/v1/trackers/match?url=`; `supports_interactive_login` is
-**also** surfaced per-tracker in `GET /api/v1/system/info` because the
-add-credential form selects a tracker by name and has no URL.
+`WithCredentials`, `WithAnonymousDownload`, `WithCloudflare`, `WithInteractiveLogin`,
+`WithSeasonCatalog`, `WithMetadata`. `WithAnonymousDownload` (RuTracker)
+marks a `WithCredentials` tracker whose download also works without an account, so
+`/trackers/match` reports `credentials_optional` (not `requires_credentials`) and the
+AddTopic form shows an optional hint instead of a "requires login" warning. The
+frontend AddTopic form discovers most via
+`GET /api/v1/trackers/match?url=`; `supports_interactive_login` **and**
+`supports_credentials` are surfaced per-tracker in `GET /api/v1/system/info`
+because the add-credential form selects a tracker by name and has no URL — a
+tracker with `supports_credentials:false` (e.g. **NNM-Club**, which is
+anonymous-only because its login is Cloudflare-Turnstile-gated and so does NOT
+implement `WithCredentials`) shows a disclaimer and blocks the add-account form.
 `WithSeasonCatalog` (LostFilm) enumerates a series' released
 seasons/episodes from `GET /api/v1/trackers/seasons?url=` (fetches the
 public `/series/<slug>/seasons` page, reuses the episode parser); the
 AddTopic form uses it to constrain the "start from" season/episode
 selectors to released values.
 
-`WithMetadata` (RuTracker, LostFilm, Kinozal) resolves a real title + poster image
+`WithMetadata` (RuTracker, LostFilm, Kinozal, NNM-Club) resolves a real title + poster image
 from a topic URL. It is called best-effort (fail-open, short timeout) at add
 time so a new topic shows a real name + image immediately instead of a
 "RuTracker topic 123" placeholder, and powers `GET /api/v1/trackers/preview?url=`

--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ What works **today**:
 - English + Russian UI.
 
 **Validated end-to-end**: the generic magnet and `.torrent`-URL paths,
-the Torznab/Newznab indexer adapters, and the **RuTracker**, **LostFilm**
-(including interactive captcha login), and **Kinozal** plugins, each
-against a live target.
+the Torznab/Newznab indexer adapters, the **RuTracker**, **LostFilm**
+(including interactive captcha login), and **Kinozal** plugins, and
+**NNM-Club** (anonymous-only — its login is Cloudflare-Turnstile-gated,
+so accounts aren't supported), each against a live target.
 
-What's still **alpha**: the other 9 CIS forum-tracker plugins
-(NNM-Club, Anilibria, Anidub, Rutor, Toloka, Unionpeer,
+What's still **alpha**: the other 8 CIS forum-tracker plugins
+(Anilibria, Anidub, Rutor, Toloka, Unionpeer,
 Tapochek, Free-Torrents, HD-Club) are structurally complete with
 fixture-based tests but have not been validated against live sites —
 that requires real account credentials and is the first thing

--- a/backend/internal/api/handlers/system.go
+++ b/backend/internal/api/handlers/system.go
@@ -102,10 +102,12 @@ func listTrackerInfos(items []registry.Tracker) []map[string]any {
 	out := make([]map[string]any, 0, len(items))
 	for _, t := range items {
 		_, interactive := t.(registry.WithInteractiveLogin)
+		_, hasCreds := t.(registry.WithCredentials)
 		out = append(out, map[string]any{
 			"name":                       t.Name(),
 			"display_name":               t.DisplayName(),
 			"supports_interactive_login": interactive,
+			"supports_credentials":       hasCreds,
 		})
 	}
 	return out

--- a/backend/internal/api/handlers/trackers.go
+++ b/backend/internal/api/handlers/trackers.go
@@ -26,6 +26,7 @@ type trackerMatch struct {
 	DefaultQuality           string   `json:"default_quality,omitempty"`
 	SupportsEpisodeFilter    bool     `json:"supports_episode_filter"`
 	RequiresCredentials      bool     `json:"requires_credentials"`
+	CredentialsOptional      bool     `json:"credentials_optional"`
 	SupportsInteractiveLogin bool     `json:"supports_interactive_login"`
 	UsesCloudflare           bool     `json:"uses_cloudflare"`
 	SupportsSeasonCatalog    bool     `json:"supports_season_catalog"`
@@ -61,7 +62,13 @@ func (h *Trackers) Match(w http.ResponseWriter, r *http.Request) {
 		out.SupportsEpisodeFilter = ef.SupportsEpisodeFilter()
 	}
 	if _, ok := t.(registry.WithCredentials); ok {
+		// WithCredentials alone means credentials are required. A tracker that
+		// also supports anonymous download flips this to optional.
 		out.RequiresCredentials = true
+		if ad, ok := t.(registry.WithAnonymousDownload); ok && ad.SupportsAnonymousDownload() {
+			out.RequiresCredentials = false
+			out.CredentialsOptional = true
+		}
 	}
 	if _, ok := t.(registry.WithInteractiveLogin); ok {
 		out.SupportsInteractiveLogin = true

--- a/backend/internal/api/handlers/trackers_test.go
+++ b/backend/internal/api/handlers/trackers_test.go
@@ -70,10 +70,113 @@ func (f *fakeErrSeasonTracker) SeasonCatalog(_ context.Context, _ string) ([]reg
 	return nil, errors.New("boom")
 }
 
+// fakeRequiredCredsTracker implements registry.WithCredentials but NOT
+// WithAnonymousDownload — credentials are required.
+type fakeRequiredCredsTracker struct{ name string }
+
+func (f *fakeRequiredCredsTracker) Name() string        { return f.name }
+func (f *fakeRequiredCredsTracker) DisplayName() string { return "Fake Required-Creds Tracker" }
+func (f *fakeRequiredCredsTracker) CanParse(rawURL string) bool {
+	return rawURL == "https://fake-required-creds.test/topic/1"
+}
+func (f *fakeRequiredCredsTracker) Parse(context.Context, string) (*domain.Topic, error) {
+	return nil, nil
+}
+func (f *fakeRequiredCredsTracker) Check(context.Context, *domain.Topic, *domain.TrackerCredential) (*domain.Check, error) {
+	return nil, nil
+}
+func (f *fakeRequiredCredsTracker) Download(context.Context, *domain.Topic, *domain.Check, *domain.TrackerCredential) (*domain.Payload, error) {
+	return nil, nil
+}
+func (f *fakeRequiredCredsTracker) Login(context.Context, *domain.TrackerCredential) error {
+	return nil
+}
+func (f *fakeRequiredCredsTracker) Verify(context.Context, *domain.TrackerCredential) (bool, error) {
+	return true, nil
+}
+
+// fakeOptionalCredsTracker implements registry.WithCredentials AND
+// WithAnonymousDownload — credentials are optional.
+type fakeOptionalCredsTracker struct{ name string }
+
+func (f *fakeOptionalCredsTracker) Name() string        { return f.name }
+func (f *fakeOptionalCredsTracker) DisplayName() string { return "Fake Optional-Creds Tracker" }
+func (f *fakeOptionalCredsTracker) CanParse(rawURL string) bool {
+	return rawURL == "https://fake-optional-creds.test/topic/1"
+}
+func (f *fakeOptionalCredsTracker) Parse(context.Context, string) (*domain.Topic, error) {
+	return nil, nil
+}
+func (f *fakeOptionalCredsTracker) Check(context.Context, *domain.Topic, *domain.TrackerCredential) (*domain.Check, error) {
+	return nil, nil
+}
+func (f *fakeOptionalCredsTracker) Download(context.Context, *domain.Topic, *domain.Check, *domain.TrackerCredential) (*domain.Payload, error) {
+	return nil, nil
+}
+func (f *fakeOptionalCredsTracker) Login(context.Context, *domain.TrackerCredential) error {
+	return nil
+}
+func (f *fakeOptionalCredsTracker) Verify(context.Context, *domain.TrackerCredential) (bool, error) {
+	return true, nil
+}
+func (f *fakeOptionalCredsTracker) SupportsAnonymousDownload() bool { return true }
+
 func init() {
 	registry.RegisterTracker(&fakeSeasonTracker{name: "fake-season-tracker-test"})
 	registry.RegisterTracker(&fakeNoSeasonTracker{name: "fake-no-season-tracker-test"})
 	registry.RegisterTracker(&fakeErrSeasonTracker{name: "fake-err-season-tracker-test"})
+	registry.RegisterTracker(&fakeRequiredCredsTracker{name: "fake-required-creds-test"})
+	registry.RegisterTracker(&fakeOptionalCredsTracker{name: "fake-optional-creds-test"})
+}
+
+func TestTrackers_Match_RequiredCredentials(t *testing.T) {
+	h := &Trackers{BaseURL: "http://test"}
+	req := httptest.NewRequest(http.MethodGet, "/trackers/match?url=https://fake-required-creds.test/topic/1", nil)
+	w := httptest.NewRecorder()
+
+	h.Match(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		RequiresCredentials bool `json:"requires_credentials"`
+		CredentialsOptional bool `json:"credentials_optional"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.RequiresCredentials {
+		t.Error("want requires_credentials=true for a WithCredentials-only tracker")
+	}
+	if body.CredentialsOptional {
+		t.Error("want credentials_optional=false for a WithCredentials-only tracker")
+	}
+}
+
+func TestTrackers_Match_OptionalCredentials(t *testing.T) {
+	h := &Trackers{BaseURL: "http://test"}
+	req := httptest.NewRequest(http.MethodGet, "/trackers/match?url=https://fake-optional-creds.test/topic/1", nil)
+	w := httptest.NewRecorder()
+
+	h.Match(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		RequiresCredentials bool `json:"requires_credentials"`
+		CredentialsOptional bool `json:"credentials_optional"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.RequiresCredentials {
+		t.Error("want requires_credentials=false for an anonymous-capable tracker")
+	}
+	if !body.CredentialsOptional {
+		t.Error("want credentials_optional=true for an anonymous-capable tracker")
+	}
 }
 
 func TestTrackers_Seasons_OK(t *testing.T) {

--- a/backend/internal/plugins/registry/registry.go
+++ b/backend/internal/plugins/registry/registry.go
@@ -31,14 +31,27 @@ type Tracker interface {
 	Download(ctx context.Context, topic *domain.Topic, check *domain.Check, creds *domain.TrackerCredential) (*domain.Payload, error)
 }
 
-// WithCredentials is an optional capability; a tracker that requires user
-// credentials implements this interface in addition to Tracker.
+// WithCredentials is an optional capability; a tracker that can use user
+// credentials implements this interface in addition to Tracker. It does NOT
+// by itself mean credentials are mandatory — a tracker that also implements
+// WithAnonymousDownload works without them (see below).
 type WithCredentials interface {
 	Tracker
 	// Login is called before any Check/Download when a credential exists.
 	Login(ctx context.Context, creds *domain.TrackerCredential) error
 	// Verify checks whether existing cookies/session is still valid.
 	Verify(ctx context.Context, creds *domain.TrackerCredential) (bool, error)
+}
+
+// WithAnonymousDownload is an optional marker for a WithCredentials tracker
+// whose Check/Download also succeed without credentials (e.g. an anonymous
+// magnet on the topic page). The AddTopic form uses it to present credentials
+// as optional (an enhancement, e.g. enabling .torrent downloads) rather than
+// required. A WithCredentials tracker that does NOT implement this is treated
+// as credentials-required.
+type WithAnonymousDownload interface {
+	Tracker
+	SupportsAnonymousDownload() bool
 }
 
 // LoginChallenge is a captcha to present to the user during interactive

--- a/backend/internal/plugins/trackers/nnmclub/nnmclub.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub.go
@@ -76,70 +76,19 @@ func (p *plugin) Parse(_ context.Context, rawURL string) (*domain.Topic, error) 
 	}, nil
 }
 
-// --- WithCredentials ---------------------------------------------------
-
-func (p *plugin) Login(ctx context.Context, creds *domain.TrackerCredential) error {
-	if creds == nil || creds.Username == "" {
-		return errors.New("nnm-club credentials are required")
-	}
-	sess := p.sessions.GetOrCreate(forumcommon.SessionKey(pluginName, creds.UserID.String()), userAgent)
-	if p.transport != nil {
-		sess.Client.Transport = p.transport
-	}
-	form := url.Values{
-		"username": {creds.Username},
-		"password": {string(creds.SecretEnc)},
-		"redirect": {""},
-		"login":    {"%C2%F5%EE%E4"}, // "Вход" in cp1251
-	}
-	endpoint := "https://" + p.domain + "/forum/login.php"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", userAgent)
-	resp, err := sess.Client.Do(req)
-	if err != nil {
-		return fmt.Errorf("nnm-club login: %w", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
-	if err != nil {
-		return fmt.Errorf("nnm-club login: read body: %w", err)
-	}
-	if strings.Contains(string(body), "incorrect") || strings.Contains(string(body), "Неверный") {
-		return errors.New("nnm-club login failed: invalid credentials")
-	}
-	sess.LoggedIn = true
-	return nil
-}
-
-func (p *plugin) Verify(ctx context.Context, creds *domain.TrackerCredential) (bool, error) {
-	sess := p.sessions.GetOrCreate(forumcommon.SessionKey(pluginName, creds.UserID.String()), userAgent)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+p.domain+"/forum/index.php", nil)
-	if err != nil {
-		return false, err
-	}
-	req.Header.Set("User-Agent", userAgent)
-	resp, err := sess.Client.Do(req)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
-	if err != nil {
-		return false, fmt.Errorf("nnm-club verify: read body: %w", err)
-	}
-	return strings.Contains(string(body), "logout.php"), nil
-}
+// NNM-Club is anonymous-only in Marauder: its login is gated by Cloudflare
+// Turnstile, which blocks automated (headless/server-side) sign-in, so the
+// plugin deliberately does NOT implement registry.WithCredentials. Delivery
+// uses the public, account-free magnet on the topic page.
 
 // --- Check / Download --------------------------------------------------
 
 var (
 	titleRe  = regexp.MustCompile(`(?s)<title>([^<]+)</title>`)
-	hashRe   = regexp.MustCompile(`(?i)Info-?Hash[^A-Z0-9]+([A-Fa-f0-9]{40})`)
-	dlHrefRe = regexp.MustCompile(`href="(download\.php\?id=\d+)"`)
+	magnetRe = regexp.MustCompile(`magnet:\?xt=urn:btih:([A-Fa-f0-9]{40})`)
+	// ogImageRe expects property before content (the order NNM-Club emits).
+	// If that order ever reverses it fails open: ImageURL stays empty, no error.
+	ogImageRe = regexp.MustCompile(`(?i)<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']`)
 )
 
 func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.TrackerCredential) (*domain.Check, error) {
@@ -149,10 +98,9 @@ func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.T
 	}
 	check := &domain.Check{}
 	if m := titleRe.FindSubmatch(body); m != nil {
-		check.DisplayName = strings.TrimSpace(string(m[1]))
-		check.DisplayName = strings.TrimSuffix(check.DisplayName, " :: NNM-Club")
+		check.DisplayName = forumcommon.CleanTitle(string(m[1]), " :: NNM-Club")
 	}
-	if m := hashRe.FindSubmatch(body); m != nil {
+	if m := magnetRe.FindSubmatch(body); m != nil {
 		check.Hash = strings.ToLower(string(m[1]))
 	} else {
 		return nil, errors.New("nnm-club: no infohash found")
@@ -160,21 +108,50 @@ func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.T
 	return check, nil
 }
 
+// Download returns a magnet for the topic. Anonymous (no creds) is the only
+// supported mode in Phase 1: the .torrent at download.php is login-gated
+// (302 -> login), and a fresh anonymous fetch of the topic page yields a
+// hash-only magnet (NNM-Club only embeds its tracker announce in the magnet
+// for logged-in sessions). So we return the page's hash-only magnet enriched
+// with a real &dn= display name. Peer discovery relies on DHT and may stall on
+// poorly-seeded torrents — the reliable fix is the credentialed .torrent (with
+// the user's passkey'd announce, also crediting ratio), Phase 2.
 func (p *plugin) Download(ctx context.Context, topic *domain.Topic, _ *domain.Check, creds *domain.TrackerCredential) (*domain.Payload, error) {
 	body, err := p.fetch(ctx, topic.URL, creds)
 	if err != nil {
 		return nil, err
 	}
-	m := dlHrefRe.FindSubmatch(body)
+	m := magnetRe.FindSubmatch(body)
 	if m == nil {
-		return nil, errors.New("nnm-club: no download link in topic page")
+		return nil, errors.New("nnm-club: topic page has no magnet link")
 	}
-	dlURL := "https://" + p.domain + "/forum/" + string(m[1])
-	torrent, err := p.fetch(ctx, dlURL, creds)
+	magnet := "magnet:?xt=urn:btih:" + strings.ToLower(string(m[1]))
+	if mt := titleRe.FindSubmatch(body); mt != nil {
+		if name := forumcommon.CleanTitle(string(mt[1]), " :: NNM-Club"); name != "" {
+			magnet += "&dn=" + url.QueryEscape(name)
+		}
+	}
+	return &domain.Payload{MagnetURI: magnet}, nil
+}
+
+// ResolveMetadata implements registry.WithMetadata: it fetches the topic page
+// anonymously and extracts a human title + poster (og:image) for the AddTopic
+// preview card.
+var _ registry.WithMetadata = (*plugin)(nil)
+
+func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (*registry.Metadata, error) {
+	body, err := p.fetch(ctx, rawURL, creds)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nnm-club resolve metadata: %w", err)
 	}
-	return &domain.Payload{TorrentFile: torrent, FileName: "nnmclub.torrent"}, nil
+	meta := &registry.Metadata{}
+	if m := titleRe.FindSubmatch(body); m != nil {
+		meta.Title = forumcommon.CleanTitle(string(m[1]), " :: NNM-Club")
+	}
+	if m := ogImageRe.FindSubmatch(body); m != nil {
+		meta.ImageURL = strings.TrimSpace(string(m[1]))
+	}
+	return meta, nil
 }
 
 func (p *plugin) fetch(ctx context.Context, target string, creds *domain.TrackerCredential) ([]byte, error) {

--- a/backend/internal/plugins/trackers/nnmclub/nnmclub_e2e_test.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub_e2e_test.go
@@ -6,38 +6,23 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
-
-	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/plugins/e2etest"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
 
-const e2eViewtopicHTML = `<html><head><title>Big Anime Series :: NNM-Club</title></head>
-<body>
-<a href="logout.php">logout</a>
-<div>Info-Hash: 0123456789ABCDEF0123456789ABCDEF01234567</div>
-<a href="download.php?id=12345">скачать</a>
-</body></html>`
-
 func TestE2E(t *testing.T) {
 	e2etest.RunFullPipeline(t, e2etest.Case{
-		Name: "nnmclub/login-then-torrent-then-qbit",
+		Name: "nnmclub/anonymous-magnet-then-qbit",
 		Setup: func(t *testing.T, _ *e2etest.QBitFake) (registry.Tracker, string) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
-				case strings.HasPrefix(r.URL.Path, "/forum/login.php"):
-					http.SetCookie(w, &http.Cookie{Name: "phpbb2mysql_4_data", Value: "abc"})
-					w.WriteHeader(200)
-					_, _ = w.Write([]byte(`<a href="logout.php">logout</a>`))
 				case strings.HasPrefix(r.URL.Path, "/forum/viewtopic.php"):
 					w.WriteHeader(200)
-					_, _ = w.Write([]byte(e2eViewtopicHTML))
-				case strings.HasPrefix(r.URL.Path, "/forum/download.php"):
-					w.Header().Set("Content-Type", "application/x-bittorrent")
+					_, _ = w.Write([]byte(fixtureViewtopicHTML))
+				case strings.HasPrefix(r.URL.Path, "/forum/login.php"):
 					w.WriteHeader(200)
-					_, _ = w.Write([]byte("d8:announce15:http://x/announcee"))
+					_, _ = w.Write([]byte(`<a href="logout.php">logout</a>`))
 				case r.URL.Path == "/forum/index.php":
 					w.WriteHeader(200)
 					_, _ = w.Write([]byte(`<a href="logout.php">logout</a>`))
@@ -56,14 +41,10 @@ func TestE2E(t *testing.T) {
 					To:   testHost,
 				},
 			}
-			return p, "https://nnmclub.to/forum/viewtopic.php?t=12345"
+			return p, "https://nnmclub.to/forum/viewtopic.php?t=420880"
 		},
-		Creds: &domain.TrackerCredential{
-			UserID:    uuid.New(),
-			Username:  "alice",
-			SecretEnc: []byte("password123"),
-		},
-		ExpectedHash:         "0123456789abcdef0123456789abcdef01234567",
-		ExpectedNameContains: "Big Anime Series",
+		// Anonymous Phase 1: no creds, magnet payload expected.
+		ExpectedHash:      "094ec3052ed759240e4dfd89f3f7ca5c5b428ff4",
+		ExpectTorrentFile: false,
 	})
 }

--- a/backend/internal/plugins/trackers/nnmclub/nnmclub_test.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub_test.go
@@ -11,31 +11,23 @@ import (
 	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
 
-const fixtureViewtopicHTML = `<html><head><title>Big Anime Series :: NNM-Club</title></head>
+const fixtureViewtopicHTML = `<html><head>
+<title>Через тернии к звёздам (1980) DVDRip [H.264] Оригинальная версия :: NNM-Club</title>
+<meta property="og:image" content="https://a.radikal.ru/a11/2008/6f/f91ffdbf65b2.jpg"/>
+</head>
 <body>
 <a href="logout.php">logout</a>
-<div>Info-Hash: 0123456789ABCDEF0123456789ABCDEF01234567</div>
-<a href="download.php?id=12345">скачать</a>
+<a rel="nofollow" href="magnet:?xt=urn:btih:094EC3052ED759240E4DFD89F3F7CA5C5B428FF4" title="Примагнититься"><img src="https://nnmstatic.win/forum/images/magnet.png"></a>
+<a href="download.php?id=379398" rel="nofollow">Скачать</a>
 </body></html>`
 
 func newTestPlugin(t *testing.T) *plugin {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case strings.HasPrefix(r.URL.Path, "/forum/login.php"):
-			http.SetCookie(w, &http.Cookie{Name: "phpbb2mysql_4_data", Value: "abc"})
-			w.WriteHeader(200)
-			w.Write([]byte(`<a href="logout.php">logout</a>`))
 		case strings.HasPrefix(r.URL.Path, "/forum/viewtopic.php"):
 			w.WriteHeader(200)
 			w.Write([]byte(fixtureViewtopicHTML))
-		case strings.HasPrefix(r.URL.Path, "/forum/download.php"):
-			w.Header().Set("Content-Type", "application/x-bittorrent")
-			w.WriteHeader(200)
-			w.Write([]byte("d8:announce..."))
-		case r.URL.Path == "/forum/index.php":
-			w.WriteHeader(200)
-			w.Write([]byte(`<a href="logout.php">logout</a>`))
 		default:
 			w.WriteHeader(404)
 		}
@@ -100,11 +92,14 @@ func TestCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
-	if check.Hash != "0123456789abcdef0123456789abcdef01234567" {
+	if check.Hash != "094ec3052ed759240e4dfd89f3f7ca5c5b428ff4" {
 		t.Errorf("hash: %q", check.Hash)
 	}
-	if !strings.Contains(check.DisplayName, "Big Anime Series") {
+	if !strings.Contains(check.DisplayName, "Через тернии к звёздам") {
 		t.Errorf("display name: %q", check.DisplayName)
+	}
+	if strings.HasSuffix(check.DisplayName, " :: NNM-Club") {
+		t.Errorf("site suffix not stripped: %q", check.DisplayName)
 	}
 }
 
@@ -115,7 +110,27 @@ func TestDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Download: %v", err)
 	}
-	if len(payload.TorrentFile) == 0 {
-		t.Error("expected torrent bytes")
+	if len(payload.TorrentFile) != 0 {
+		t.Errorf("expected no torrent file in anonymous mode, got %d bytes", len(payload.TorrentFile))
+	}
+	if !strings.Contains(payload.MagnetURI, "urn:btih:094ec3052ed759240e4dfd89f3f7ca5c5b428ff4") {
+		t.Errorf("magnet missing infohash: %q", payload.MagnetURI)
+	}
+	if !strings.Contains(payload.MagnetURI, "dn=") {
+		t.Errorf("magnet missing display name: %q", payload.MagnetURI)
+	}
+}
+
+func TestResolveMetadata(t *testing.T) {
+	p := newTestPlugin(t)
+	meta, err := p.ResolveMetadata(context.Background(), "https://"+p.domain+"/forum/viewtopic.php?t=42", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if !strings.Contains(meta.Title, "Через тернии к звёздам") {
+		t.Errorf("title: %q", meta.Title)
+	}
+	if meta.ImageURL != "https://a.radikal.ru/a11/2008/6f/f91ffdbf65b2.jpg" {
+		t.Errorf("image url: %q", meta.ImageURL)
 	}
 }

--- a/backend/internal/plugins/trackers/rutracker/rutracker.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker.go
@@ -63,6 +63,14 @@ func init() {
 func (p *plugin) Name() string        { return pluginName }
 func (p *plugin) DisplayName() string { return displayName }
 
+// SupportsAnonymousDownload implements registry.WithAnonymousDownload: the
+// topic page exposes a magnet without login (Download falls back to it when
+// no credentials are present), so credentials are optional — they only
+// enable the preferred .torrent path.
+var _ registry.WithAnonymousDownload = (*plugin)(nil)
+
+func (p *plugin) SupportsAnonymousDownload() bool { return true }
+
 // CanParse — true for any rutracker viewtopic URL.
 func (p *plugin) CanParse(rawURL string) bool {
 	return urlPattern.MatchString(strings.TrimSpace(rawURL))

--- a/docs/superpowers/plans/2026-06-23-nnmclub-anonymous.md
+++ b/docs/superpowers/plans/2026-06-23-nnmclub-anonymous.md
@@ -1,0 +1,438 @@
+# NNM-Club Phase 1 (anonymous) Implementation Plan
+
+> **Status (2026-06-23):** Phase 1 implemented (anonymous-only). **Phase 2 (authenticated) was abandoned** — Cloudflare Turnstile blocks every automated login path; see the design doc's "Phase 2 — ABANDONED" section. The plugin does not implement `WithCredentials`; the add-account UI shows a disclaimer.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing `nnmclub` tracker plugin correctly extract the infohash, return a usable (display-name-enriched) magnet, and resolve title+poster — for everything an unauthenticated user can reach — validated against a real captured page fixture and a live smoke check.
+
+**Architecture:** Surgical fixes to the existing plugin (`backend/internal/plugins/trackers/nnmclub/`). Replace the broken `Info-Hash`-label hash regex with quote-agnostic magnet extraction, rewrite `Download` to return an enriched magnet (no anonymous `download.php` call — it 302s to login), add `WithMetadata.ResolveMetadata`, and replace the fabricated test fixture with one captured from the real page. Authenticated `.torrent` flow is Phase 2 (out of scope).
+
+**Tech Stack:** Go 1.25, stdlib `net/http` + `regexp`, `forumcommon` session/text helpers, `e2etest.RunFullPipeline` harness.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-23-nnmclub-anonymous-design.md`.
+- **Build/test only in Docker** (never install Go locally). Shorthand used below:
+  `DOCKER_GO = docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25`
+- **No commits during implementation.** The user commits everything at the end, on `main`. Each task ends with a test-checkpoint, NOT a commit. The final commit (Task 6) is gated on explicit user confirmation.
+- **Stay on `main`** — no feature branch.
+- **No fabricated data.** The test fixture uses only values observed from the live page `https://nnmclub.to/forum/viewtopic.php?t=420880`:
+  - title: `Через тернии к звёздам (1980) DVDRip [H.264] Оригинальная версия :: NNM-Club`
+  - magnet: `magnet:?xt=urn:btih:094EC3052ED759240E4DFD89F3F7CA5C5B428FF4` (hash lowercased: `094ec3052ed759240e4dfd89f3f7ca5c5b428ff4`)
+  - download link: `download.php?id=379398`
+  - og:image: `https://a.radikal.ru/a11/2008/6f/f91ffdbf65b2.jpg`
+- **Go conventions:** tabs, `gofmt`, wrap errors with `%w`, `MixedCaps`.
+- **Confirmed external APIs** (verified to exist — do not re-derive):
+  - `forumcommon.CleanTitle(raw, siteSuffix string) string`
+  - `forumcommon.DecodeWindows1251(s string) string`
+  - `registry.Metadata{ Title string; ImageURL string }`
+  - `registry.WithMetadata` requires `ResolveMetadata(ctx, rawURL string, creds *domain.TrackerCredential) (*registry.Metadata, error)`
+  - `e2etest.Case` fields: `ExpectedHash string`, `ExpectTorrentFile bool` (false ⇒ a magnet payload is accepted and asserted through qbitfake).
+
+---
+
+## File Structure
+
+- `backend/internal/plugins/trackers/nnmclub/nnmclub.go` — modify regexes, `Check`, `Download`; add `ResolveMetadata` + `WithMetadata` assertion.
+- `backend/internal/plugins/trackers/nnmclub/nnmclub_test.go` — replace fabricated fixture with real-derived HTML; rewrite `TestCheck`/`TestDownload`; add `TestResolveMetadata`.
+- `backend/internal/plugins/trackers/nnmclub/nnmclub_e2e_test.go` — serve the real fixture, assert magnet pipeline (`ExpectedHash`, magnet payload).
+- `CLAUDE.md` — add `nnmclub` to the `WithMetadata` tracker list.
+
+---
+
+## Task 1: Replace fabricated fixture and fix `Check` hash extraction
+
+**Files:**
+- Modify: `backend/internal/plugins/trackers/nnmclub/nnmclub_test.go:14-19` (fixture const), `:96-109` (TestCheck)
+- Modify: `backend/internal/plugins/trackers/nnmclub/nnmclub.go:139-161` (regexes + Check)
+
+**Interfaces:**
+- Consumes: `forumcommon.CleanTitle`, existing `p.fetch`, `titleRe`.
+- Produces: package-level `magnetRe = regexp.MustCompile(\`magnet:\?xt=urn:btih:([A-Fa-f0-9]{40})\`)` reused by Task 2; `Check` returning `domain.Check{Hash, DisplayName}`.
+
+- [ ] **Step 1: Replace the fabricated fixture with real-derived HTML**
+
+In `nnmclub_test.go`, replace the `fixtureViewtopicHTML` const (lines 14-19) with:
+
+```go
+const fixtureViewtopicHTML = `<html><head>
+<title>Через тернии к звёздам (1980) DVDRip [H.264] Оригинальная версия :: NNM-Club</title>
+<meta property="og:image" content="https://a.radikal.ru/a11/2008/6f/f91ffdbf65b2.jpg"/>
+</head>
+<body>
+<a href="logout.php">logout</a>
+<a rel="nofollow" href="magnet:?xt=urn:btih:094EC3052ED759240E4DFD89F3F7CA5C5B428FF4" title="Примагнититься"><img src="https://nnmstatic.win/forum/images/magnet.png"></a>
+<a href="download.php?id=379398" rel="nofollow">Скачать</a>
+</body></html>`
+```
+
+- [ ] **Step 2: Rewrite `TestCheck` to assert the real hash + title**
+
+Replace `TestCheck` (lines 96-109) with:
+
+```go
+func TestCheck(t *testing.T) {
+	p := newTestPlugin(t)
+	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=42"}
+	check, err := p.Check(context.Background(), topic, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if check.Hash != "094ec3052ed759240e4dfd89f3f7ca5c5b428ff4" {
+		t.Errorf("hash: %q", check.Hash)
+	}
+	if !strings.Contains(check.DisplayName, "Через тернии к звёздам") {
+		t.Errorf("display name: %q", check.DisplayName)
+	}
+	if strings.HasSuffix(check.DisplayName, " :: NNM-Club") {
+		t.Errorf("site suffix not stripped: %q", check.DisplayName)
+	}
+}
+```
+
+- [ ] **Step 3: Run the test to verify it FAILS**
+
+Run: `DOCKER_GO sh -c "go test ./internal/plugins/trackers/nnmclub/ -run TestCheck -v"`
+Expected: FAIL — current `hashRe` looks for an `Info-Hash` label absent from the fixture, so `Check` returns `nnm-club: no infohash found`.
+
+- [ ] **Step 4: Fix the regexes and `Check` in `nnmclub.go`**
+
+Replace the `var ( … )` regex block (lines 139-143) with:
+
+```go
+var (
+	titleRe  = regexp.MustCompile(`(?s)<title>([^<]+)</title>`)
+	magnetRe = regexp.MustCompile(`magnet:\?xt=urn:btih:([A-Fa-f0-9]{40})`)
+)
+```
+
+Replace `Check` (lines 145-161) with:
+
+```go
+func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.TrackerCredential) (*domain.Check, error) {
+	body, err := p.fetch(ctx, topic.URL, creds)
+	if err != nil {
+		return nil, err
+	}
+	check := &domain.Check{}
+	if m := titleRe.FindSubmatch(body); m != nil {
+		check.DisplayName = forumcommon.CleanTitle(string(m[1]), " :: NNM-Club")
+	}
+	if m := magnetRe.FindSubmatch(body); m != nil {
+		check.Hash = strings.ToLower(string(m[1]))
+	} else {
+		return nil, errors.New("nnm-club: no infohash found")
+	}
+	return check, nil
+}
+```
+
+- [ ] **Step 5: Run the test to verify it PASSES**
+
+Run: `DOCKER_GO sh -c "go test ./internal/plugins/trackers/nnmclub/ -run TestCheck -v"`
+Expected: PASS.
+
+---
+
+## Task 2: Rewrite `Download` to return an enriched magnet
+
+**Files:**
+- Modify: `backend/internal/plugins/trackers/nnmclub/nnmclub.go:163-178` (Download), import block (drop unused `download.php` regex; ensure `net/url` still imported)
+- Modify: `backend/internal/plugins/trackers/nnmclub/nnmclub_test.go:111-121` (TestDownload)
+
+**Interfaces:**
+- Consumes: `magnetRe`, `titleRe`, `forumcommon.CleanTitle`, `p.fetch`, `net/url.QueryEscape`.
+- Produces: `Download` returning `domain.Payload{MagnetURI: "magnet:?xt=urn:btih:<hash>&dn=<title>"}` with empty `TorrentFile` when no creds.
+
+- [ ] **Step 1: Rewrite `TestDownload` to assert a magnet payload**
+
+Replace `TestDownload` (lines 111-121) with:
+
+```go
+func TestDownload(t *testing.T) {
+	p := newTestPlugin(t)
+	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=42"}
+	payload, err := p.Download(context.Background(), topic, nil, nil)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if len(payload.TorrentFile) != 0 {
+		t.Errorf("expected no torrent file in anonymous mode, got %d bytes", len(payload.TorrentFile))
+	}
+	if !strings.Contains(payload.MagnetURI, "urn:btih:094ec3052ed759240e4dfd89f3f7ca5c5b428ff4") {
+		t.Errorf("magnet missing infohash: %q", payload.MagnetURI)
+	}
+	if !strings.Contains(payload.MagnetURI, "dn=") {
+		t.Errorf("magnet missing display name: %q", payload.MagnetURI)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `DOCKER_GO sh -c "go test ./internal/plugins/trackers/nnmclub/ -run TestDownload -v"`
+Expected: FAIL — current `Download` looks for `download.php` and returns a `TorrentFile`, so `MagnetURI` is empty and `TorrentFile` is non-empty.
+
+- [ ] **Step 3: Rewrite `Download` in `nnmclub.go`**
+
+Replace `Download` (lines 163-178) with:
+
+```go
+// Download returns a magnet for the topic. Anonymous (no creds) is the only
+// supported mode in Phase 1: the .torrent at download.php is login-gated
+// (302 -> login), so we return the page's hash-only magnet enriched with a
+// real &dn= display name. The magnet carries no trackers (NNM-Club strips
+// them), so peer discovery relies on DHT and may stall — the reliable fix is
+// the credentialed .torrent (with NNM-Club's passkey'd announce), Phase 2.
+func (p *plugin) Download(ctx context.Context, topic *domain.Topic, _ *domain.Check, creds *domain.TrackerCredential) (*domain.Payload, error) {
+	body, err := p.fetch(ctx, topic.URL, creds)
+	if err != nil {
+		return nil, err
+	}
+	m := magnetRe.FindSubmatch(body)
+	if m == nil {
+		return nil, errors.New("nnm-club: topic page has no magnet link")
+	}
+	magnet := "magnet:?xt=urn:btih:" + strings.ToLower(string(m[1]))
+	if mt := titleRe.FindSubmatch(body); mt != nil {
+		if name := forumcommon.CleanTitle(string(mt[1]), " :: NNM-Club"); name != "" {
+			magnet += "&dn=" + url.QueryEscape(name)
+		}
+	}
+	return &domain.Payload{MagnetURI: magnet}, nil
+}
+```
+
+- [ ] **Step 4: Remove the now-unused `download.php` regex if present**
+
+If a `dlHrefRe` package var remains in `nnmclub.go` (it was used only by the old `Download`), delete its declaration. Confirm `net/url` is still in the import block (it is used by `Login` and now `Download`).
+
+- [ ] **Step 5: Run the test to verify it PASSES**
+
+Run: `DOCKER_GO sh -c "go test ./internal/plugins/trackers/nnmclub/ -run TestDownload -v"`
+Expected: PASS.
+
+---
+
+## Task 3: Add `WithMetadata.ResolveMetadata`
+
+**Files:**
+- Modify: `backend/internal/plugins/trackers/nnmclub/nnmclub.go` (add `ogImageRe`, `ResolveMetadata`, `WithMetadata` assertion)
+- Modify: `backend/internal/plugins/trackers/nnmclub/nnmclub_test.go` (add `TestResolveMetadata`)
+
+**Interfaces:**
+- Consumes: `titleRe`, `forumcommon.CleanTitle`, `p.fetch`, `registry.Metadata`.
+- Produces: `ResolveMetadata(ctx, rawURL, creds) (*registry.Metadata, error)` returning `{Title, ImageURL}`.
+
+- [ ] **Step 1: Add `TestResolveMetadata`**
+
+Append to `nnmclub_test.go`:
+
+```go
+func TestResolveMetadata(t *testing.T) {
+	p := newTestPlugin(t)
+	meta, err := p.ResolveMetadata(context.Background(), "https://"+p.domain+"/forum/viewtopic.php?t=42", nil)
+	if err != nil {
+		t.Fatalf("ResolveMetadata: %v", err)
+	}
+	if !strings.Contains(meta.Title, "Через тернии к звёздам") {
+		t.Errorf("title: %q", meta.Title)
+	}
+	if meta.ImageURL != "https://a.radikal.ru/a11/2008/6f/f91ffdbf65b2.jpg" {
+		t.Errorf("image url: %q", meta.ImageURL)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `DOCKER_GO sh -c "go test ./internal/plugins/trackers/nnmclub/ -run TestResolveMetadata -v"`
+Expected: FAIL to compile — `p.ResolveMetadata` undefined.
+
+- [ ] **Step 3: Implement `ResolveMetadata` in `nnmclub.go`**
+
+Add the og:image regex next to the other regexes:
+
+```go
+var ogImageRe = regexp.MustCompile(`(?i)<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']`)
+```
+
+Add the capability assertion and method (place after `Download`):
+
+```go
+// ResolveMetadata implements registry.WithMetadata: it fetches the topic page
+// anonymously and extracts a human title + poster (og:image) for the AddTopic
+// preview card.
+var _ registry.WithMetadata = (*plugin)(nil)
+
+func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (*registry.Metadata, error) {
+	body, err := p.fetch(ctx, rawURL, creds)
+	if err != nil {
+		return nil, fmt.Errorf("nnm-club resolve metadata: %w", err)
+	}
+	meta := &registry.Metadata{}
+	if m := titleRe.FindSubmatch(body); m != nil {
+		meta.Title = forumcommon.CleanTitle(string(m[1]), " :: NNM-Club")
+	}
+	if m := ogImageRe.FindSubmatch(body); m != nil {
+		meta.ImageURL = strings.TrimSpace(string(m[1]))
+	}
+	return meta, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it PASSES**
+
+Run: `DOCKER_GO sh -c "go test ./internal/plugins/trackers/nnmclub/ -run TestResolveMetadata -v"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole package to confirm no regressions**
+
+Run: `DOCKER_GO sh -c "go test -race ./internal/plugins/trackers/nnmclub/..."`
+Expected: PASS (TestCanParse, TestUsesCloudflare, TestParse, TestCheck, TestDownload, TestResolveMetadata).
+
+---
+
+## Task 4: e2e magnet pipeline assertion
+
+**Files:**
+- Modify: `backend/internal/plugins/trackers/nnmclub/nnmclub_e2e_test.go`
+
+**Interfaces:**
+- Consumes: `e2etest.RunFullPipeline`, `e2etest.Case{ExpectedHash, ExpectTorrentFile}`, `e2etest.HostRewriteTransport`.
+- Produces: a passing end-to-end test asserting the magnet (hash `094ec3…`) flows Parse→Check→Download→qBit.
+
+- [ ] **Step 1: Rewrite the e2e test to serve the real fixture and assert the magnet**
+
+Replace the body of `nnmclub_e2e_test.go` with (keep the existing package clause and imports; add any missing):
+
+```go
+package nnmclub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/artyomsv/marauder/backend/internal/plugins/e2etest"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+func TestE2E(t *testing.T) {
+	e2etest.RunFullPipeline(t, e2etest.Case{
+		Name: "nnmclub/anonymous-magnet-then-qbit",
+		Setup: func(t *testing.T, _ *e2etest.QBitFake) (registry.Tracker, string) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/forum/viewtopic.php"):
+					w.WriteHeader(200)
+					_, _ = w.Write([]byte(fixtureViewtopicHTML))
+				case r.URL.Path == "/forum/index.php":
+					w.WriteHeader(200)
+					_, _ = w.Write([]byte(`<a href="logout.php">logout</a>`))
+				default:
+					w.WriteHeader(404)
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			testHost := strings.TrimPrefix(srv.URL, "http://")
+			p := &plugin{
+				sessions: forumcommon.New(),
+				domain:   "nnmclub.to",
+				transport: &e2etest.HostRewriteTransport{
+					From: "nnmclub.to",
+					To:   testHost,
+				},
+			}
+			return p, "https://nnmclub.to/forum/viewtopic.php?t=420880"
+		},
+		// Anonymous Phase 1: no creds, magnet payload expected.
+		ExpectedHash:      "094ec3052ed759240e4dfd89f3f7ca5c5b428ff4",
+		ExpectTorrentFile: false,
+	})
+}
+```
+
+Note: `fixtureViewtopicHTML` is shared from `nnmclub_test.go` (same package). If a duplicate `e2eTopicHTML` const exists in the e2e file, remove it.
+
+- [ ] **Step 2: Run the e2e test**
+
+Run: `DOCKER_GO sh -c "go test -race ./internal/plugins/trackers/nnmclub/ -run TestE2E -v"`
+Expected: PASS. If it fails because `RunFullPipeline` attempts a login that the fixture server 404s, add a `case strings.HasPrefix(r.URL.Path, "/forum/login.php")` arm that writes `<a href="logout.php">logout</a>` (mirroring `nnmclub_test.go`). Re-run; expect PASS.
+
+---
+
+## Task 5: Docs + full backend verification + live smoke (Definition of Done)
+
+**Files:**
+- Modify: `CLAUDE.md` (WithMetadata tracker list)
+
+- [ ] **Step 1: Update `CLAUDE.md` WithMetadata list**
+
+Find the `WithMetadata` description line (it reads `WithMetadata (RuTracker, LostFilm, Kinozal) resolves a real title + poster…`) and add NNM-Club:
+
+```
+WithMetadata (RuTracker, LostFilm, Kinozal, NNM-Club) resolves a real title + poster image
+```
+
+- [ ] **Step 2: Full backend build + vet + test**
+
+Run: `DOCKER_GO sh -c "go build ./... && go vet ./... && go test -race ./..."`
+Expected: PASS across the whole backend (catches import/compile regressions and the registry wiring).
+
+- [ ] **Step 3: Live smoke check against the real site**
+
+Bring up the dev stack (per CLAUDE.md) with cfsolver available, then add the example topic and confirm a real infohash comes back. Using the running gateway at `http://localhost:34080` (admin/`pleasechangeme`), via the UI or API:
+
+- Add a topic with URL `https://nnmclub.to/forum/viewtopic.php?t=420880`.
+- Confirm `Check` returns hash `094ec3052ed759240e4dfd89f3f7ca5c5b428ff4` and the preview shows the real title + poster.
+- Confirm `Download` yields a magnet containing that infohash and a `dn=` name.
+
+Expected: real infohash returned (NOT `nnm-club: no infohash found`). If a plain Go GET is Cloudflare-challenged (non-200 from `p.fetch`), that is the signal to verify the cfsolver route is wired and reachable; capture the failure mode and address before declaring done.
+
+- [ ] **Step 4: Report results to the user**
+
+Summarize: unit + e2e green (paste the `go test` summary line), CLAUDE.md updated, and the live-smoke outcome (real hash + whether Cloudflare needed cfsolver). Do not claim done until Step 3 returns a real hash.
+
+---
+
+## Task 6: Final commit (GATED — only on explicit user confirmation)
+
+**Do not run this task until the user explicitly says to commit.** Per project rules: no AI attribution in the message, imperative mood, ≤72-char subject.
+
+- [ ] **Step 1: Show the diff and ask**
+
+Run: `git status` and `git --no-pager diff --stat`, then ask the user to confirm committing on `main`.
+
+- [ ] **Step 2: Commit (after the user confirms)**
+
+```bash
+git add backend/internal/plugins/trackers/nnmclub/ CLAUDE.md docs/superpowers/specs/2026-06-23-nnmclub-anonymous-design.md docs/superpowers/plans/2026-06-23-nnmclub-anonymous.md
+git commit -m "feat(nnmclub): fix anonymous infohash + magnet, add metadata"
+```
+
+(`feat(nnmclub):` so auto-release cuts a minor bump when this eventually merges. Subject is 53 chars.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Check hash fix → Task 1 ✅
+- Download enriched magnet → Task 2 ✅
+- WithMetadata title+poster → Task 3 ✅
+- Honest real-page fixture → Task 1 Step 1 ✅
+- e2e magnet pipeline → Task 4 ✅
+- Cloudflare + live smoke DoD → Task 5 Step 3 ✅
+- CLAUDE.md WithMetadata list → Task 5 Step 1 ✅
+- Phase 2 (login/.torrent/passkey) explicitly deferred → not in plan ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✅
+
+**Type consistency:** `magnetRe` (Task 1) reused in Task 2; `fixtureViewtopicHTML` (Task 1) reused in Task 4; `ResolveMetadata` signature matches `registry.WithMetadata`; `registry.Metadata{Title, ImageURL}` field names match the verified struct. ✅
+
+**Known limitation (documented, not a gap):** the unit fixture is UTF-8, so it exercises the `CleanTitle` pass-through path but not real cp1251 decoding; the live smoke (Task 5 Step 3) covers the cp1251 path against the real site.

--- a/docs/superpowers/specs/2026-06-23-nnmclub-anonymous-design.md
+++ b/docs/superpowers/specs/2026-06-23-nnmclub-anonymous-design.md
@@ -1,0 +1,146 @@
+# NNM-Club tracker — Phase 1 (anonymous) design
+
+- **Date:** 2026-06-23
+- **Status:** Phase 1 implemented (anonymous). **Phase 2 (authenticated) ABANDONED — see below.**
+- **Scope:** Make the existing `nnmclub` tracker plugin work for everything an
+  unauthenticated user can reach. Authenticated `.torrent` / passkey'd-announce flow was
+  explored as Phase 2 and dropped.
+
+## Phase 2 (authenticated) — ABANDONED (2026-06-23)
+
+NNM-Club's `login.php` is gated by a **Cloudflare Turnstile** widget that fingerprints the
+browser (TLS/HTTP-2 + automation protocol) *before* JS runs. Every automated path was tested
+and failed or is structurally impossible:
+
+- **cfsolver headless login (chromedp):** Turnstile never solved.
+- **patchright (undetected Chromium) + camoufox (anti-detect Firefox), headless AND real
+  virtual display, from the user's own residential IP:** Turnstile widget never even rendered
+  (`iframes:0`, `401` from the challenge platform). Cloudflare detects the automation protocol
+  regardless of IP/stealth.
+- **In-app interactive (relay the token / iframe):** structurally impossible — Turnstile tokens
+  are origin-bound to nnmclub.to + Same-Origin-Policy/`X-Frame-Options: SAMEORIGIN` block reading
+  the token or cookie from a cross-origin frame.
+- **Paid solver service (CapSolver/2Captcha):** would work, but rejected — costs money + 3rd-party
+  dependency in a free, self-hosted product.
+
+**Decision:** keep NNM-Club **anonymous-only**. The plugin does NOT implement
+`registry.WithCredentials`; the add-account UI shows a disclaimer. The only viable free path
+left (not built) is a **companion browser extension / Tampermonkey userscript** that reads the
+session cookie from the user's real (Turnstile-passed) browser via `chrome.cookies`/`GM_cookie`
+and syncs it to Marauder — revisit if/when there's demand. Methodology note saved:
+`memory/browser-probe-cache-nostore.md`.
+
+Original Phase-1 design follows.
+
+## Problem
+
+`backend/internal/plugins/trackers/nnmclub/` already exists, is registered in
+`cmd/server/main.go`, and ships green unit tests — but it was never validated against the
+live site (its own godoc, `nnmclub.go:8-11`, says so). The tests pass against a **fabricated
+fixture** that does not match the real page, so they prove nothing. Confirmed live:
+registering a topic and checking it returns `nnm-club: no infohash found`.
+
+### Verified live-site facts (`https://nnmclub.to/forum/viewtopic.php?t=420880`, unauthenticated)
+
+| Fact | Value |
+|---|---|
+| Magnet present anonymously | ✅ `magnet:?xt=urn:btih:094EC3052ED759240E4DFD89F3F7CA5C5B428FF4` (hash-only) |
+| Magnet shape (anonymous) | **hash-only** — no `&tr=`, no `&dn=`. Trackers appear only for logged-in sessions. |
+| Infohash as a text label (`Info-Hash:`) | ❌ absent — the 40-hex appears **only** inside the magnet `href` |
+| `.torrent` link | `download.php?id=379398` present, but **302-redirects to login** for anon users |
+| `og:image` (poster) | ✅ present, content host `a.radikal.ru` |
+| Title | `<title>…Оригинальная версия :: NNM-Club</title>` (strip ` :: NNM-Club`) |
+| Cloudflare | `server: cloudflare`, `cf-ray` present (real browser passed without a challenge) |
+
+### Anonymous magnet is hash-only; trackers require login (verified twice)
+
+A **fresh** anonymous fetch of the topic page yields a **hash-only** magnet. Confirmed three
+ways, all ~74 KB with `tr` count 0: `curl` with our `Marauder/0.3` UA, `curl` with a Chrome
+UA, and a browser `fetch(…, {cache:'no-store', credentials:'omit'})`.
+
+> **Lesson — cache artifact:** an earlier investigation used `fetch(…, {credentials:'omit'})`
+> *without* `cache:'no-store'` and saw a magnet *with* `bt.searchtor.to` trackers. That was a
+> **cached copy of a logged-in response**, not the anonymous page. Always pass `cache:'no-store'`
+> when probing what an anonymous/server-side client receives. The logged-in magnet's
+> `/<32-hex>/announce` key is a candidate **per-user passkey** and must never be committed.
+
+Consequence: the anonymous magnet is hash-only, so Phase 1 delivery relies on **DHT** — fine
+for well-seeded torrents, at risk of stalling on poorly-seeded ones. The reliable fix (and
+ratio credit) is the authenticated `.torrent` with the user's passkey'd announce — **Phase 2**.
+
+## Goals / Non-goals
+
+**Goals (Phase 1):**
+- `Check` returns the correct infohash + clean title from the anonymous page.
+- `Download` returns the anonymous (hash-only) magnet, enriched with a real `&dn=<title>`.
+- `WithMetadata.ResolveMetadata` returns real title + poster for the preview card.
+- Tests run against a **real captured page fixture**, not invented HTML.
+- One live smoke check against `nnmclub.to` confirms a real infohash end-to-end.
+
+**Non-goals (deferred to Phase 2):**
+- Login / `Verify` validation against the live site.
+- Credentialed `.torrent` download (with `infohash.FromTorrent` validation + magnet fallback).
+- Passkey'd `.torrent` announce — the reliability fix for the DHT-stall risk **and** ratio credit.
+
+## Design (Approach A — surgical fixes to the existing plugin)
+
+The plugin already mirrors RuTracker's structure (forumcommon sessions, regex parsing,
+registration). Fix the three real defects in place and add `WithMetadata`.
+
+### 1. `Check` — fix hash extraction (`nnmclub.go:141,155`)
+- Replace `hashRe` (the non-existent `Info-Hash` text label) with magnet extraction:
+  `magnet:\?xt=urn:btih:([A-Fa-f0-9]{40})`, tolerant of `href=['"]`.
+- Route the `<title>` through `forumcommon.CleanTitle(raw, " :: NNM-Club")` so cp1251 bytes
+  from the Go client decode correctly (current bare `TrimSpace` risks mojibake server-side).
+- Error `nnm-club: no infohash found` only when the magnet is genuinely absent.
+
+### 2. `Download` — return enriched magnet (`nnmclub.go:163`)
+- Phase 1 (no creds): extract the same infohash, build
+  `magnet:?xt=urn:btih:<hash>&dn=<url-encoded real title>`, return
+  `domain.Payload{MagnetURI: …}`. **Do not** call `download.php` anonymously (it 302s to login,
+  yielding login HTML, not a torrent).
+- Structure the method so Phase 2 can slot a credentialed `.torrent`-preferred branch on top
+  (mirroring RuTracker's validated path + magnet fallback). Phase 1 ships only the magnet branch.
+
+### 3. `WithMetadata.ResolveMetadata` — new (mirrors `rutracker.go:220`)
+- Anonymous fetch → real title (`CleanTitle`) + poster from `og:image` (primary selector;
+  confirmed present, host `a.radikal.ru`).
+- Powers `/api/v1/trackers/preview`; `/trackers/match` already auto-detects the capability via
+  type assertion. Add `nnmclub` to the `WithMetadata` list in `CLAUDE.md`.
+
+### 4. Tests — honest fixtures (`nnmclub_test.go`)
+- **Replace** the fabricated `<div>Info-Hash: …</div>` fixture with HTML **captured from the
+  real `t=420880` page** (trimmed; public movie data). This is the core anti-regression: the
+  regex is forced to work against ground truth, including the single-quoted magnet `href`.
+- Unit tests: `Check` extracts the real btih + clean title; `Download` returns a magnet carrying
+  that hash + `&dn=`; `ResolveMetadata` returns title + poster.
+- e2e: `RunFullPipeline` with a magnet-payload expectation. Verify the `e2etest` harness supports
+  a magnet payload; if it only asserts `ExpectTorrentFile`, add a magnet assertion path.
+
+### 5. Cloudflare + live smoke (Definition of Done)
+- Keep `UsesCloudflare() == true`. Final gate: one live `Check`+`Download` against `nnmclub.to`
+  through the running backend. If a plain Go GET is CF-challenged, that is the trigger to validate
+  the cfsolver route. Phase 1 is done when unit + e2e are green on real fixtures **and** the live
+  smoke returns a real infohash.
+
+## Error handling
+
+- `Check` fail-closed on missing magnet → scheduler backs off per existing design.
+- All outbound calls keep the existing per-request context + `forumcommon` 30s client timeout.
+- Anonymous magnet-only delivery's DHT-stall risk is documented honestly in godoc; no fabricated trackers.
+
+## Risks
+
+- **DHT-stall (anonymous hash-only magnet):** well-seeded torrents download via DHT; poorly-seeded
+  ones may stall. Resolved by Phase 2's authenticated `.torrent` (passkey'd announce), which also
+  credits the user's NNM-Club ratio.
+- **Cloudflare challenge on server-side GET:** unknown until live smoke; mitigated by the existing
+  `WithCloudflare` + cfsolver route.
+- **cp1251 vs UTF-8 title:** `CleanTitle` is idempotent on already-valid UTF-8, so safe either way.
+
+## Files touched (Phase 1)
+
+- `backend/internal/plugins/trackers/nnmclub/nnmclub.go` — Check, Download, ResolveMetadata, regexes.
+- `backend/internal/plugins/trackers/nnmclub/nnmclub_test.go` — real fixture + rewritten assertions.
+- `backend/internal/plugins/trackers/nnmclub/nnmclub_e2e_test.go` — magnet-payload pipeline assertion.
+- `CLAUDE.md` — add `nnmclub` to the `WithMetadata` tracker list.

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -85,6 +85,9 @@ expects you to add an account on `/accounts` before adding any
 topics. Marauder validates the credential by attempting Login when
 you save the account — bad credentials are rejected immediately.
 
+> **NNM-Club** is listed separately below — it is anonymous-only
+> and does not require an account.
+
 ### LostFilm.tv
 
 | | |
@@ -169,24 +172,30 @@ page `<title>` (cp1251-decoded) and `og:image`.
 (2026-06) — login, infohash resolution, metadata, and download → client
 delivery all confirmed.
 
-### NNM-Club
+---
+
+## NNM-Club (anonymous, no account)
 
 | | |
 |---|---|
 | **Plugin name** | `nnmclub` |
-| **Account required** | Yes (free) |
+| **Account required** | No (anonymous) |
 | **Quality selection** | No |
 | **Episode filter** | No |
 | **Cloudflare** | **Yes** — requires the cfsolver sidecar |
 | **URL format** | `https://nnmclub.to/forum/viewtopic.php?t=<id>` |
 
-phpBB tracker wrapped in Cloudflare. Marauder routes through the
-`cfsolver` sidecar profile (start it with
-`docker compose --profile cfsolver up -d`) which uses headless
-Chromium via chromedp to solve the Cloudflare interstitial and
-hand the cookies back.
+phpBB tracker wrapped in Cloudflare. Works anonymously — account
+login is not supported because Cloudflare Turnstile blocks automated
+login flows. Marauder routes through the `cfsolver` sidecar profile
+(start it with `docker compose --profile cfsolver up -d`) which uses
+headless Chromium via chromedp to solve the Cloudflare interstitial
+and hand the cookies back. No credentials needed; do **not** add an
+NNM-Club account entry on `/accounts`.
 
-### Other CIS trackers
+---
+
+## Other CIS trackers
 
 | Plugin name | Display name | Account | Quality | Episode filter | Cloudflare |
 |---|---|---|---|---|---|

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -28,6 +28,20 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # index.html is the unhashed pointer to the hashed /assets bundles, so it
+    # must always be revalidated — otherwise the browser heuristically caches
+    # it and keeps loading a stale bundle after a deploy. no-cache = store but
+    # revalidate via ETag (cheap 304 when unchanged). Security headers are
+    # re-declared because add_header does not inherit into a location that
+    # sets its own add_header.
+    location = /index.html {
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Cache-Control "no-cache" always;
+    }
+
     # API is proxied by the gateway, not by this container. In a single-
     # host deployment, place Caddy/Traefik/nginx in front and route /api
     # to the backend directly.

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -101,7 +101,11 @@ export function AppShell() {
       </aside>
 
       {/* Main */}
-      <main className="flex-1 md:ml-64">
+      {/* min-w-0: a flex item defaults to min-width:auto and won't shrink
+          below its content's intrinsic width — a long topic title would then
+          push main past the viewport. min-w-0 lets inner truncate/break-words
+          constrain instead. */}
+      <main className="min-w-0 flex-1 md:ml-64">
         <header className="sticky top-0 z-20 flex h-16 items-center gap-4 border-b border-border/60 bg-background/40 px-6 backdrop-blur-xl">
           <div className="flex md:hidden items-center gap-2">
             <Logo />

--- a/frontend/src/components/topics/TopicForm.tsx
+++ b/frontend/src/components/topics/TopicForm.tsx
@@ -22,6 +22,7 @@ export interface TrackerMatch {
   supports_episode_filter: boolean;
   supports_season_catalog: boolean;
   requires_credentials: boolean;
+  credentials_optional: boolean;
   uses_cloudflare: boolean;
 }
 
@@ -308,11 +309,25 @@ export function TopicForm({
         </div>
       )}
 
-      {match?.requires_credentials && hasCredential && (
-        <div className="rounded-md border border-success/40 bg-success/10 px-3 py-2 text-xs text-success">
-          ✓ Using your {match.display_name} account.
+      {match?.credentials_optional && !hasCredential && (
+        <div className="rounded-md border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+          Works without an account. Optionally{" "}
+          <a
+            href="/accounts"
+            className="font-semibold underline-offset-4 hover:underline"
+          >
+            add a {match.display_name} account →
+          </a>{" "}
+          to enable .torrent downloads.
         </div>
       )}
+
+      {(match?.requires_credentials || match?.credentials_optional) &&
+        hasCredential && (
+          <div className="rounded-md border border-success/40 bg-success/10 px-3 py-2 text-xs text-success">
+            ✓ Using your {match.display_name} account.
+          </div>
+        )}
 
       <div className="space-y-1.5">
         <Label htmlFor="client">Client (optional)</Label>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -98,6 +98,10 @@
       transparent 60%
     ),
     hsl(var(--background));
+    /* Pin the ambient glows to the viewport. Without this the gradient
+       scrolls with the (content-tall) body and renders as a hard-edged
+       band partway down once the list overflows one screen. */
+    background-attachment: fixed;
     color: hsl(var(--foreground));
     font-feature-settings: "rlig" 1, "calt" 1;
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -298,7 +298,12 @@ export type Topic = {
 
 export type SystemInfo = {
   version: { version: string; commit: string; buildDate: string };
-  trackers: { name: string; display_name: string; supports_interactive_login: boolean }[];
+  trackers: {
+    name: string;
+    display_name: string;
+    supports_interactive_login: boolean;
+    supports_credentials: boolean;
+  }[];
   clients: { name: string; display_name: string }[];
   notifiers: { name: string; display_name: string }[];
 };

--- a/frontend/src/pages/Credentials.test.tsx
+++ b/frontend/src/pages/Credentials.test.tsx
@@ -42,6 +42,13 @@ vi.mock("@/lib/hooks/useSystemInfo", () => ({
           name: "lostfilm",
           display_name: "LostFilm",
           supports_interactive_login: supportsInteractiveLogin,
+          supports_credentials: true,
+        },
+        {
+          name: "nnmclub",
+          display_name: "NNM-Club.to",
+          supports_interactive_login: false,
+          supports_credentials: false,
         },
       ],
     },
@@ -103,6 +110,26 @@ async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>) {
   await user.type(screen.getByLabelText(/^password$/i), "hunter2");
   await user.click(screen.getByRole("button", { name: /login & save/i }));
 }
+
+describe("CredentialsPage — anonymous-only tracker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supportsInteractiveLogin = true;
+    mockApi.get.mockResolvedValue({ credentials: [] });
+  });
+
+  it("shows a disclaimer and disables submit when the tracker has no credential support", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole("button", { name: /add account/i }));
+    await user.selectOptions(screen.getByLabelText(/^tracker$/i), "nnmclub");
+
+    expect(await screen.findByText(/anonymous mode only/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /login & save/i }),
+    ).toBeDisabled();
+  });
+});
 
 describe("CredentialsPage — interactive captcha flow", () => {
   beforeEach(() => {

--- a/frontend/src/pages/Credentials.tsx
+++ b/frontend/src/pages/Credentials.tsx
@@ -226,7 +226,12 @@ export function CredentialsPage() {
 
 // ---------------------------------------------------------------------
 
-type Tracker = { name: string; display_name: string; supports_interactive_login: boolean };
+type Tracker = {
+  name: string;
+  display_name: string;
+  supports_interactive_login: boolean;
+  supports_credentials: boolean;
+};
 
 // CaptchaState groups every captcha-step field into ONE useState object
 // so AddCredentialCard stays within the project's 8-useState limit.
@@ -266,6 +271,12 @@ function AddCredentialCard({
   // sniffing. True → interactive (captcha) flow; false → plain create.
   const supportsInteractiveLogin =
     available.find((tr) => tr.name === trackerName)?.supports_interactive_login ?? false;
+
+  // Some trackers work anonymously and don't implement credentialed login
+  // (e.g. NNM-Club, gated by Cloudflare Turnstile which blocks automated
+  // sign-in). For those we show a disclaimer and block the form.
+  const selectedTracker = available.find((tr) => tr.name === trackerName);
+  const supportsCredentials = selectedTracker?.supports_credentials ?? true;
 
   // Plain create — used for trackers that don't support interactive login.
   const create = useMutation({
@@ -398,7 +409,7 @@ function AddCredentialCard({
                 id="cred-username"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
-                disabled={!!captcha}
+                disabled={!!captcha || !supportsCredentials}
                 autoComplete="username"
                 required
               />
@@ -410,7 +421,7 @@ function AddCredentialCard({
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                disabled={!!captcha}
+                disabled={!!captcha || !supportsCredentials}
                 autoComplete="new-password"
                 required
               />
@@ -420,6 +431,18 @@ function AddCredentialCard({
               </p>
             </div>
           </div>
+
+          {!supportsCredentials && (
+            <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+              <span>
+                {selectedTracker?.display_name} works in <strong>anonymous mode
+                only</strong> — authenticated login is not supported (its sign-in
+                is gated by a Cloudflare Turnstile that blocks automated login).
+                No account is needed; just add topic URLs directly.
+              </span>
+            </div>
+          )}
 
           {captcha && (
             <CaptchaChallenge
@@ -457,7 +480,10 @@ function AddCredentialCard({
                 {t("credentials.captchaSubmit")}
               </Button>
             ) : (
-              <Button type="submit" disabled={submitting || !trackerName}>
+              <Button
+                type="submit"
+                disabled={submitting || !trackerName || !supportsCredentials}
+              >
                 {submitting && <Loader2 className="size-4 animate-spin" />}
                 Login &amp; save
               </Button>

--- a/frontend/src/pages/Topics.test.tsx
+++ b/frontend/src/pages/Topics.test.tsx
@@ -43,6 +43,7 @@ const catalogMatch = {
   supports_episode_filter: true,
   supports_season_catalog: true,
   requires_credentials: false,
+  credentials_optional: false,
   uses_cloudflare: false,
 };
 
@@ -186,6 +187,63 @@ describe("AddTopicCard — season/episode catalog dropdowns", () => {
   });
 });
 
+describe("AddTopicCard — credentials hint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const NNM_URL = "https://nnmclub.to/forum/viewtopic.php?t=420880";
+
+  function mockMatch(opts: { requires: boolean; optional: boolean }) {
+    mockApi.get.mockImplementation((path: string) => {
+      if (path.startsWith("/trackers/match")) {
+        return Promise.resolve({
+          tracker_name: "nnmclub",
+          display_name: "NNM-Club.to",
+          supports_episode_filter: false,
+          supports_season_catalog: false,
+          requires_credentials: opts.requires,
+          credentials_optional: opts.optional,
+          uses_cloudflare: true,
+        });
+      }
+      if (path.startsWith("/clients")) return Promise.resolve(clientsList);
+      return Promise.resolve({ credentials: [] });
+    });
+    mockApi.previewTracker.mockResolvedValue({ title: "", image_url: "" });
+  }
+
+  it("shows an optional (not required) hint when credentials are optional", async () => {
+    const user = userEvent.setup();
+    mockMatch({ requires: false, optional: true });
+
+    renderCard();
+    await user.type(screen.getByLabelText(/url or magnet link/i), NNM_URL);
+
+    expect(
+      await screen.findByText(/works without an account/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/requires login credentials/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the required hint when credentials are required", async () => {
+    const user = userEvent.setup();
+    mockMatch({ requires: true, optional: false });
+
+    renderCard();
+    await user.type(screen.getByLabelText(/url or magnet link/i), NNM_URL);
+
+    expect(
+      await screen.findByText(/requires login credentials/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/works without an account/i),
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("AddTopicCard — display name auto-fill on URL change", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -203,6 +261,7 @@ describe("AddTopicCard — display name auto-fill on URL change", () => {
           supports_episode_filter: false,
           supports_season_catalog: false,
           requires_credentials: false,
+          credentials_optional: false,
           uses_cloudflare: false,
         });
       }

--- a/site/src/data/faq.ts
+++ b/site/src/data/faq.ts
@@ -12,7 +12,7 @@ export const homeFaq: FaqItem[] = [
   {
     question: "How is Marauder different from Sonarr or Radarr?",
     answer:
-      "Sonarr and Radarr are built around Torznab indexers. They cannot monitor a forum thread on RuTracker, LostFilm, or NNM-Club because those sites are forums, not API-driven indexers. Marauder is built specifically to watch forum threads, log in with your credentials, scrape topic pages, and detect when an uploader replaces the .torrent attachment. It also speaks Torznab and Newznab so you can use it on top of Jackett or Prowlarr if you want.",
+      "Sonarr and Radarr are built around Torznab indexers. They cannot monitor a forum thread on RuTracker, LostFilm, or NNM-Club because those sites are forums, not API-driven indexers. Marauder is built specifically to watch forum threads, scrape topic pages, and detect when an uploader replaces the .torrent attachment — logging in with your account where the tracker requires it, or fetching anonymously where it does not (NNM-Club). It also speaks Torznab and Newznab so you can use it on top of Jackett or Prowlarr if you want.",
   },
   {
     question: "Is Marauder a replacement for monitorrent?",

--- a/site/src/data/trackerPages.ts
+++ b/site/src/data/trackerPages.ts
@@ -143,7 +143,7 @@ export const trackerPages: TrackerPageContent[] = [
   {
     slug: "nnmclub",
     description:
-      "Monitor NNM-Club.to topics behind Cloudflare. Marauder routes through a headless-Chromium solver to pass the interstitial, logs in, and auto-downloads new torrents to your client.",
+      "Monitor NNM-Club.to topics behind Cloudflare — no account needed. Marauder routes through a headless-Chromium solver to pass the interstitial and auto-downloads new torrents anonymously.",
     keywords: [
       "nnm-club monitor",
       "nnmclub auto download",
@@ -152,18 +152,23 @@ export const trackerPages: TrackerPageContent[] = [
       "nnm club tracker",
     ],
     intro:
-      "NNM-Club.to is a Russian-language phpBB tracker sitting behind a Cloudflare interstitial — which makes it doubly hard for conventional tools to reach. Marauder pairs a dedicated Cloudflare solver sidecar with its forum plugin to pass the challenge, log in, and watch the topic for new releases.",
+      "NNM-Club.to is a Russian-language phpBB tracker sitting behind a Cloudflare interstitial — which makes it hard for conventional tools to reach. Marauder pairs a dedicated Cloudflare solver sidecar with its NNM-Club plugin to pass the challenge and watch topics for new releases. No account is required: NNM-Club's magnet flow works anonymously, so you can add topic URLs and start monitoring straight away.",
     howItWorks: [
-      "Routes requests through the cfsolver sidecar (headless Chromium via chromedp) to clear the Cloudflare interstitial and collect cookies.",
-      "Logs in with your NNM-Club account and scrapes the topic page for .torrent changes.",
+      "Routes requests through the cfsolver sidecar (headless Chromium via chromedp) to clear the Cloudflare interstitial and collect the necessary cookies.",
+      "Scrapes the topic page anonymously for magnet link changes — no login or account needed.",
       "Hands new releases to your configured client like any other Marauder topic.",
     ],
     setup: [
       "Enable the cfsolver compose profile (Cloudflare solver sidecar).",
-      "Add your NNM-Club credentials under Credentials.",
-      "Paste the topic URL; Marauder handles the Cloudflare challenge transparently on each check.",
+      "Paste the topic URL directly as a new topic — no credentials to add.",
+      "Marauder handles the Cloudflare challenge transparently on each check.",
     ],
     faq: [
+      {
+        question: "Do I need an NNM-Club account to use this plugin?",
+        answer:
+          "No. NNM-Club's magnet flow is publicly accessible, so Marauder monitors topics without logging in. You do not need to add any credentials — just paste the topic URL.",
+      },
       {
         question: "How does Marauder get past Cloudflare on NNM-Club?",
         answer:

--- a/site/src/data/trackers.ts
+++ b/site/src/data/trackers.ts
@@ -57,10 +57,10 @@ export const trackers: Tracker[] = [
   {
     slug: "nnmclub",
     name: "NNM-Club.to",
-    description: "Russian-language phpBB tracker, Cloudflare-protected.",
+    description: "Russian-language phpBB tracker, Cloudflare-protected. Works anonymously — no account needed.",
     category: "forum-cis",
     region: "RU",
-    auth: "account",
+    auth: "public",
     status: "alpha",
     cloudflare: true,
   },

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -47,7 +47,7 @@ const featureCards: { icon: IconName; title: string; body: string }[] = [
   {
     icon: "radio-tower",
     title: "Watch any forum tracker",
-    body: "Drop in a RuTracker, Kinozal, NNM-Club, LostFilm, Anidub, Anilibria, Toloka, or generic .torrent URL. Marauder logs in, scrapes the topic page, and detects when an uploader replaces the file.",
+    body: "Drop in a RuTracker, Kinozal, NNM-Club, LostFilm, Anidub, Anilibria, Toloka, or generic .torrent URL. Marauder scrapes the topic page and detects when an uploader replaces the file — logging in where the tracker requires it, or fetching anonymously where it does not.",
   },
   {
     icon: "globe",

--- a/site/src/pages/ru.astro
+++ b/site/src/pages/ru.astro
@@ -135,7 +135,9 @@ open http://localhost:34080`;
         <h3 class="text-lg font-semibold text-foreground">Любой форумный трекер</h3>
         <p class="mt-2 text-sm text-muted-foreground">
           Вставьте ссылку на тему RuTracker, Kinozal, NNM-Club, LostFilm или
-          другую — Marauder войдёт, разберёт страницу и поймает замену файла.
+          другую — Marauder разберёт страницу и поймает замену файла, входя
+          под учётной записью там, где это требуется, или скачивая анонимно
+          (например, NNM-Club).
         </p>
       </article>
       <article class="glass-card rounded-xl p-6">

--- a/site/src/pages/trackers.astro
+++ b/site/src/pages/trackers.astro
@@ -81,8 +81,9 @@ const indexers = trackers.filter((t) => t.category === "indexer");
       <h2 id="cat-forum" class="mb-2 text-2xl font-semibold tracking-tight">CIS forum trackers</h2>
       <p class="mb-6 text-muted-foreground">
         The Russian-speaking forum trackers that the *arr stack cannot reach.
-        Marauder logs in with your account, scrapes the topic page, and detects
-        when the uploader replaces the .torrent attachment.
+        Marauder scrapes the topic page and detects when the uploader replaces
+        the .torrent attachment — logging in with your account where required,
+        or fetching anonymously for public trackers (see the Auth column).
       </p>
       <div class="overflow-hidden rounded-xl border border-border/60">
         <table class="w-full text-sm">

--- a/site/src/pages/vs/flexget.astro
+++ b/site/src/pages/vs/flexget.astro
@@ -84,14 +84,15 @@ const matrix = [
       <p class="text-muted-foreground">
         FlexGet is built around <strong class="text-foreground">feeds</strong> — give it
         an RSS or HTML source and it filters and acts on entries. That's a great
-        fit for sources that publish a feed. Forum trackers like RuTracker,
-        LostFilm, NNM-Club, and Kinozal don't work that way: you log in with a
-        session cookie, browse a topic thread, and the same topic URL quietly gets
-        a <strong class="text-foreground">new <code>.torrent</code> attachment</strong> when a
+        fit for sources that publish a feed. Forum trackers like RuTracker, LostFilm, NNM-Club, and Kinozal don't work
+        that way: you browse to a topic thread — logging in where the tracker
+        requires it, or accessing anonymously where it does not (NNM-Club) — and
+        the same topic URL quietly gets a
+        <strong class="text-foreground">new <code>.torrent</code> attachment</strong> when a
         new episode drops. There's no per-episode feed item to catch.
       </p>
       <p class="mt-3 text-muted-foreground">
-        Marauder is built specifically for that pattern — log in, scrape the topic
+        Marauder is built specifically for that pattern — scrape the topic
         page, detect the in-place file swap, and hand the result to your client.
         It also speaks Torznab and Newznab, so the feed-shaped sources FlexGet
         excels at are reachable too.

--- a/site/src/pages/vs/sonarr.astro
+++ b/site/src/pages/vs/sonarr.astro
@@ -80,11 +80,12 @@ const matrix = [
         </p>
         <p class="mt-3 text-muted-foreground">
           If your tracker is a <strong class="text-foreground">forum thread</strong>
-          you log in to, scroll, and click — RuTracker, LostFilm, Kinozal,
-          NNM-Club, Anidub, Anilibria, Toloka, and so on — Sonarr cannot help
-          you. Forum trackers don't expose Torznab. Marauder is built specifically
-          to scrape these sites, and it speaks Torznab and Newznab too so a
-          single Marauder install reaches both worlds at once.
+          you browse to — RuTracker, LostFilm, Kinozal, NNM-Club, Anidub,
+          Anilibria, Toloka, and so on — Sonarr cannot help you. Forum trackers
+          don't expose Torznab. Marauder is built specifically to scrape these
+          sites (with account login where required, or anonymously where not),
+          and it speaks Torznab and Newznab too so a single Marauder install
+          reaches both worlds at once.
         </p>
       </div>
     </section>
@@ -105,10 +106,10 @@ const matrix = [
         What they share is:
       </p>
       <ul class="mt-4 space-y-2 text-muted-foreground">
-        <li>• Authentication by <strong class="text-foreground">session cookie</strong> obtained via an HTML login form</li>
         <li>• Content discovery by <strong class="text-foreground">browsing topic threads</strong>, not by querying an API</li>
         <li>• Updates <strong class="text-foreground">in place</strong> — the same topic URL gets a new <code>.torrent</code> attachment when a new episode drops</li>
-        <li>• <strong class="text-foreground">Cloudflare interstitials</strong> that need to be solved before you can even reach the login page</li>
+        <li>• Most require <strong class="text-foreground">account login</strong> via an HTML form (RuTracker, LostFilm, Kinozal…); some like NNM-Club work <strong class="text-foreground">anonymously</strong> via magnet links</li>
+        <li>• <strong class="text-foreground">Cloudflare interstitials</strong> that need to be solved before the page can be reached</li>
       </ul>
       <p class="mt-3 text-muted-foreground">
         Jackett bolts a Torznab shim onto these sites for the *arr stack, but


### PR DESCRIPTION
## Summary

Makes the NNM-Club tracker work **anonymously** and presents it honestly as an account-free tracker. NNM-Club's login is gated by a Cloudflare Turnstile that blocks automated sign-in, so authenticated support is deliberately not offered.

## Why

The existing `nnmclub` plugin was a stub that failed on real pages (`Check` looked for an "Info-Hash" text label that doesn't exist — the infohash is only in the magnet). Authenticated `.torrent` delivery was explored (cfsolver headless, patchright/Chromium, camoufox/Firefox headless + virtual display, all from a residential IP) and every automated path is blocked by Turnstile's pre-JS fingerprinting; in-app token relay is structurally impossible (origin-bound token + SOP + `X-Frame-Options: SAMEORIGIN`). A paid solver would work but was rejected for a free, self-hosted product. Decision: **anonymous-only**. See `docs/superpowers/specs/2026-06-23-nnmclub-anonymous-design.md`.

## Changes

**Backend**
- `nnmclub`: `Check` extracts the infohash from the topic-page magnet; `Download` returns the enriched magnet; new `WithMetadata` (real title + poster). Removed `WithCredentials` (Turnstile-gated login can't be automated).
- New `registry.WithAnonymousDownload` (RuTracker) → `/trackers/match` reports `credentials_optional` instead of `requires_credentials` for trackers whose download works without an account.
- `/system/info` now reports `supports_credentials` per tracker.

**Frontend**
- AddTopic: optional-credentials hint instead of "requires login" for anonymous-capable trackers.
- Add-account form: disclaimer + disabled inputs when a tracker has no credential support (e.g. NNM-Club).

**Docs + site**
- `CLAUDE.md`, `docs/trackers.md`, design spec/plan, and 8 marketing-site files updated to describe NNM-Club as anonymous-only.

## Testing

- Backend: `go build`/`vet`/`test -race ./...` — green.
- Frontend: `tsc --noEmit` + 46 tests + `vite build` — green (incl. new disclaimer + credentials-hint tests).
- Site: `astro check && astro build` — green.
- Live smoke against nnmclub.to confirmed anonymous infohash + magnet delivery end-to-end.

## Also included (unrelated frontend fixes)

Bundled in a separate commit (`fix(frontend): …`):
- nginx serves `index.html` with `Cache-Control: no-cache` so a deploy's new hashed bundles aren't masked by a stale cached index.
- `min-w-0` on `<main>` so long topic titles can't overflow the viewport.
- `background-attachment: fixed` pins the ambient background glow.
