### PR TITLE
refactor: dedupe kinozal topic-id parse; tighten Update test matcher

### DIFF
--- a/backend/internal/db/repo/topics_test.go
+++ b/backend/internal/db/repo/topics_test.go
@@ -401,7 +401,9 @@ func TestTopics_Update_HappyPath(t *testing.T) {
 
 	rows := pgxmock.NewRows(topicColumnsAll).AddRow(row...)
 
-	mock.ExpectQuery(`UPDATE topics SET`).
+	// Pattern asserts the lock-on-rename clause is present (not just any UPDATE),
+	// so an accidental removal of the CASE expression is caught at unit level.
+	mock.ExpectQuery(`UPDATE topics SET[\s\S]*display_name_is_placeholder = CASE WHEN display_name <> \$3`).
 		WithArgs(
 			id, userID,
 			"Updated Name",    // $3 display_name

--- a/backend/internal/plugins/trackers/kinozal/kinozal.go
+++ b/backend/internal/plugins/trackers/kinozal/kinozal.go
@@ -178,18 +178,29 @@ func extractImageURL(body []byte, host string) string {
 	}
 }
 
+// parseTopicID extracts the numeric Kinozal topic id from the "id" query
+// parameter of rawURL. Shared by canonicalDetailsURL and fetchInfohash so the
+// url.Parse → id logic lives in exactly one place.
+func parseTopicID(rawURL string) (int, error) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return 0, fmt.Errorf("kinozal: parse url: %w", err)
+	}
+	id, err := strconv.Atoi(u.Query().Get("id"))
+	if err != nil {
+		return 0, fmt.Errorf("kinozal: topic id: %w", err)
+	}
+	return id, nil
+}
+
 // canonicalDetailsURL rebuilds the details URL from the trusted host (p.domain)
 // + the numeric id parsed from rawURL — never the raw user URL. Avoids request
 // forgery (CodeQL go/request-forgery) and pins the request to p.domain so
 // Check's title matches ResolveMetadata's (issue #90).
 func (p *plugin) canonicalDetailsURL(rawURL string) (string, error) {
-	u, err := url.Parse(strings.TrimSpace(rawURL))
+	id, err := parseTopicID(rawURL)
 	if err != nil {
-		return "", fmt.Errorf("kinozal: parse url: %w", err)
-	}
-	id, err := strconv.Atoi(u.Query().Get("id"))
-	if err != nil {
-		return "", fmt.Errorf("kinozal: topic id: %w", err)
+		return "", err
 	}
 	return fmt.Sprintf("https://%s/details.php?id=%d", p.domain, id), nil
 }
@@ -228,13 +239,9 @@ func (p *plugin) Check(ctx context.Context, topic *domain.Topic, creds *domain.T
 // rebuilt from the trusted domain + numeric id (never the raw user URL) to
 // avoid request forgery (CodeQL go/request-forgery), mirroring Download.
 func (p *plugin) fetchInfohash(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (string, error) {
-	u, err := url.Parse(strings.TrimSpace(rawURL))
+	id, err := parseTopicID(rawURL)
 	if err != nil {
-		return "", fmt.Errorf("kinozal: parse url: %w", err)
-	}
-	id, err := strconv.Atoi(u.Query().Get("id"))
-	if err != nil {
-		return "", fmt.Errorf("kinozal: topic id: %w", err)
+		return "", err
 	}
 	srvURL := fmt.Sprintf("https://%s/get_srv_details.php?id=%d&action=2", p.domain, id)
 	body, err := p.fetch(ctx, srvURL, creds)


### PR DESCRIPTION
Non-functional follow-ups from the #90 whole-branch review (PR #94). No behaviour change; `refactor:` so no release is cut.

## Changes

1. **DRY the Kinozal id parse.** `canonicalDetailsURL` and `fetchInfohash` each carried an identical `url.Parse` → `strconv.Atoi(query "id")` block. Extracted into a single `parseTopicID(rawURL) (int, error)` helper used by both. Error messages unchanged.
2. **Tighten the `Update` repo test matcher.** `TestTopics_Update_HappyPath` previously matched the prefix `UPDATE topics SET`, which did **not** constrain the new `display_name_is_placeholder = CASE WHEN display_name <> $3` lock-on-rename clause. The matcher now asserts that clause, so an accidental removal of the lock-on-rename behaviour is caught at unit level.

## Tests

Full backend suite green with `-race` (gofmt clean, build + vet OK). The tightened matcher passing confirms the `CASE` clause is present in the live SQL.

Follow-up to #90.