### PR TITLE
feat(topics): suggest qBittorrent categories when adding a topic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,10 @@ techdebt/       Debt-tracking files (one per issue, see global rule)
 | **`extra`** | shared `extra.Int / StringSlice / String` helpers for the untyped `map[string]any` blobs in `Topic.Extra` and `Check.Extra` (added 2026-04-07; **use this instead of writing local helpers**) |
 | `logging` | zerolog setup (JSON in prod, pretty in dev) |
 | `metrics` | Prometheus collectors (HTTP, scheduler, tracker, client) |
-| `plugins/registry` | plugin interfaces + global registry + tracker capability interfaces (`WithQuality`, `WithEpisodeFilter`, `WithCredentials`, `WithCloudflare`, `WithInteractiveLogin`, `WithSeasonCatalog`, `WithMetadata`) + client capability `WithStatus` (`Status(ctx, rawConfig, hashes) []TorrentStatus` — live download status by infohash; normalised `State*` vocabulary) + the `registry.EffectiveDownloadDir(base, override, category)` save-path helper + typed sentinels **`registry.ErrNoPendingEpisodes`**, `ErrCaptchaRequired`, `ErrSessionExpired` |
+| `plugins/registry` | plugin interfaces + global registry + tracker capability interfaces (`WithQuality`, `WithEpisodeFilter`, `WithCredentials`, `WithCloudflare`, `WithInteractiveLogin`, `WithSeasonCatalog`, `WithMetadata`) + client capabilities `WithStatus` (`Status(ctx, rawConfig, hashes) []TorrentStatus` — live download status by infohash; normalised `State*` vocabulary) and `WithCategories` (`Categories(ctx, rawConfig) []string` — list the categories a client already knows about, for the AddTopic category combobox; qBittorrent-only today, served by `GET /api/v1/clients/{id}/categories`, fail-open) + the `registry.EffectiveDownloadDir(base, override, category)` save-path helper + typed sentinels **`registry.ErrNoPendingEpisodes`**, `ErrCaptchaRequired`, `ErrSessionExpired` |
 | **`plugins/captchalogin`** | reusable human-in-the-loop interactive captcha-login engine (`Begin`/`Complete`/`Refresh` + TTL pending-session store). A tracker supplies a `Config` (LoginURL, CaptchaURL, CookieNames, BuildForm, Classify); first consumer is LostFilm. See `WithInteractiveLogin` |
 | `plugins/trackers/<name>` | one package per tracker plugin (16 plugins as of v1.0.0+) |
-| `plugins/clients/<name>` | one package per torrent client (qBittorrent, Transmission, Deluge, µTorrent, downloadfolder). qBittorrent + Transmission also implement `registry.WithStatus` for live progress |
+| `plugins/clients/<name>` | one package per torrent client (qBittorrent, Transmission, Deluge, µTorrent, downloadfolder). qBittorrent + Transmission also implement `registry.WithStatus` for live progress; qBittorrent also implements `registry.WithCategories` (lists its categories for the AddTopic combobox) |
 | `plugins/notifiers/<name>` | telegram, email, webhook, pushover |
 | `plugins/torznabcommon` / `torznab` / `newznab` | shared scaffolding for the Torznab/Newznab indexer adapters |
 | `plugins/forumcommon` | shared cookie-jar `Session` type for forum-tracker plugins |
@@ -206,7 +206,8 @@ The **status poll fallback** (in `DeliveryStatus`) is now gated by `useSseStatus
 - **Icons**: `lucide-react` exclusively.
 - **i18n**: `useT()` from `i18n/`. English + Russian dictionaries.
 - **Component size**: max 250 lines per file (currently breached by
-  `Topics.tsx` and `Clients.tsx` — pre-existing tech debt).
+  `Topics.tsx`, `Clients.tsx`, and `TopicForm.tsx` — pre-existing tech debt,
+  tracked in `techdebt/frontend/`).
 - **Path alias**: `@/` maps to `src/`.
 - **Tests**: Vitest + `@testing-library/react` + `userEvent` + jsdom.
   Co-locate `*.test.tsx` next to the component. Run with `npm test`.

--- a/backend/internal/api/handlers/clients.go
+++ b/backend/internal/api/handlers/clients.go
@@ -1,26 +1,52 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/artyomsv/marauder/backend/internal/audit"
-	"github.com/artyomsv/marauder/backend/internal/crypto"
 	"github.com/artyomsv/marauder/backend/internal/db/repo"
 	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/metrics"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 	"github.com/artyomsv/marauder/backend/internal/problem"
 )
 
+// categoriesFetchTimeout bounds the GET /clients/{id}/categories upstream call
+// (qBittorrent login + list) so one slow client can't hold a request open for
+// the plugin client's full ~30s worst case. Mirrors the topic-status path.
+const categoriesFetchTimeout = 10 * time.Second
+
+// clientStore is the persistence seam for the Clients handler, satisfied by
+// *repo.Clients. Defined at the consumer so the handler is unit-testable with
+// a fake store (no DB).
+type clientStore interface {
+	ListForUser(ctx context.Context, userID uuid.UUID) ([]*domain.Client, error)
+	Create(ctx context.Context, c *domain.Client) (*domain.Client, error)
+	GetByID(ctx context.Context, id, userID uuid.UUID) (*domain.Client, error)
+	Update(ctx context.Context, id, userID uuid.UUID, displayName string, isDefault bool, configEnc, configNonce []byte) error
+	Delete(ctx context.Context, id, userID uuid.UUID) error
+}
+
+// cryptor is the encryption seam, satisfied by *crypto.MasterKey.
+type cryptor interface {
+	Encrypt(plaintext []byte) (ct, nonce []byte, err error)
+	Decrypt(ct, nonce []byte) ([]byte, error)
+}
+
 // Clients handles /clients.
 type Clients struct {
-	Clients *repo.Clients
-	Master  *crypto.MasterKey
+	Clients clientStore
+	Master  cryptor
 	Audit   *audit.Logger
+	Log     zerolog.Logger
 	BaseURL string
 }
 
@@ -266,6 +292,94 @@ func (h *Clients) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// Categories handles GET /clients/{id}/categories. It returns the categories
+// the client already knows about (qBittorrent), so the AddTopic form can offer
+// them as suggestions while still accepting free-text. The response shape is
+// {"supported": bool, "categories": [string]}.
+//
+// Fail-open: a client whose plugin can't list categories yields
+// supported:false, and a transient fetch error (client unreachable, bad creds)
+// yields supported:true with an empty list — in both cases the category field
+// simply degrades to plain free-text entry, never a hard error. Category is a
+// path segment in Marauder (see registry.EffectiveDownloadDir); this list only
+// helps pick a value, it does not constrain it.
+func (h *Clients) Categories(w http.ResponseWriter, r *http.Request) {
+	uid, perr := currentUserID(r)
+	if perr != nil {
+		problem.Write(w, r, h.BaseURL, perr)
+		return
+	}
+	id, ierr := uuid.Parse(chi.URLParam(r, "id"))
+	if ierr != nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("invalid id"))
+		return
+	}
+	c, err := h.Clients.GetByID(r.Context(), id, uid)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			problem.Write(w, r, h.BaseURL, problem.ErrNotFound("client not found"))
+			return
+		}
+		problem.Write(w, r, h.BaseURL, problem.ErrInternal(err.Error()))
+		return
+	}
+
+	plugin := registry.GetClient(c.ClientName)
+
+	// Only decrypt the config when the plugin can actually list categories —
+	// an unsupported client never needs the secret blob.
+	if _, ok := plugin.(registry.WithCategories); !ok {
+		writeJSON(w, http.StatusOK, categoriesView(false, nil))
+		return
+	}
+	raw, err := h.Master.Decrypt(c.ConfigEnc, c.ConfigNonce)
+	if err != nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrInternal("decrypt config: "+err.Error()))
+		return
+	}
+
+	// Bound the upstream fetch so a slow client can't hold the request open.
+	ctx, cancel := context.WithTimeout(r.Context(), categoriesFetchTimeout)
+	defer cancel()
+	logger := h.Log.With().Str("client_id", id.String()).Str("user_id", uid.String()).Logger()
+	supported, names := resolveCategories(ctx, plugin, raw, logger)
+	writeJSON(w, http.StatusOK, categoriesView(supported, names))
+}
+
+// resolveCategories asks a client plugin for its category list. It is the
+// testable core of the Categories handler, isolated from auth/DB/decryption.
+//
+// Returns (supported, names). A plugin that does not implement
+// registry.WithCategories is unsupported (free-text fallback). A plugin that
+// supports listing but errors fails open: supported=true with a nil list, so
+// the field degrades to free-text rather than the request failing — a warning
+// is logged and a metric incremented so the silent degradation is observable.
+func resolveCategories(ctx context.Context, plugin registry.Client, raw []byte, logger zerolog.Logger) (bool, []string) {
+	lister, ok := plugin.(registry.WithCategories)
+	if plugin == nil || !ok {
+		return false, nil
+	}
+	names, err := lister.Categories(ctx, raw)
+	if err != nil {
+		// The dropdown is a convenience; degrade to free-text rather than
+		// failing the request.
+		metrics.ClientCategoriesFailOpenTotal.WithLabelValues(plugin.Name()).Inc()
+		logger.Warn().Err(err).Str("client_name", plugin.Name()).
+			Msg("list client categories failed; degrading to free-text")
+		return true, nil
+	}
+	return true, names
+}
+
+// categoriesView builds the GET /clients/{id}/categories response body,
+// ensuring categories is always a non-nil JSON array.
+func categoriesView(supported bool, names []string) map[string]any {
+	if names == nil {
+		names = []string{}
+	}
+	return map[string]any{"supported": supported, "categories": names}
 }
 
 // Test handles POST /clients/{id}/test — tests the stored config without

--- a/backend/internal/api/handlers/clients_categories_test.go
+++ b/backend/internal/api/handlers/clients_categories_test.go
@@ -1,0 +1,230 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/artyomsv/marauder/backend/internal/api/middleware"
+	"github.com/artyomsv/marauder/backend/internal/auth"
+	"github.com/artyomsv/marauder/backend/internal/db/repo"
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+)
+
+// plainClient implements registry.Client only (no WithCategories).
+type plainClient struct{ name string }
+
+func (c *plainClient) Name() string                 { return c.name }
+func (c *plainClient) DisplayName() string          { return c.name }
+func (c *plainClient) ConfigSchema() map[string]any { return nil }
+func (c *plainClient) Test(context.Context, []byte) error {
+	return nil
+}
+func (c *plainClient) Add(context.Context, []byte, *domain.Payload, domain.AddOptions) error {
+	return nil
+}
+
+// categoriesClient additionally implements registry.WithCategories.
+type categoriesClient struct {
+	plainClient
+	names []string
+	err   error
+}
+
+func (c *categoriesClient) Categories(context.Context, []byte) ([]string, error) {
+	return c.names, c.err
+}
+
+func TestResolveCategories(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugin        registry.Client
+		wantSupported bool
+		wantNames     []string
+	}{
+		{
+			name:          "nil plugin is unsupported",
+			plugin:        nil,
+			wantSupported: false,
+			wantNames:     nil,
+		},
+		{
+			name:          "plugin without WithCategories is unsupported",
+			plugin:        &plainClient{name: "transmission"},
+			wantSupported: false,
+			wantNames:     nil,
+		},
+		{
+			name:          "supported plugin returns its names",
+			plugin:        &categoriesClient{plainClient: plainClient{name: "qbittorrent"}, names: []string{"Movies", "TV"}},
+			wantSupported: true,
+			wantNames:     []string{"Movies", "TV"},
+		},
+		{
+			name:          "supported plugin error fails open to empty",
+			plugin:        &categoriesClient{plainClient: plainClient{name: "qbittorrent"}, err: errors.New("unreachable")},
+			wantSupported: true,
+			wantNames:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			supported, names := resolveCategories(context.Background(), tt.plugin, nil, zerolog.Nop())
+			if supported != tt.wantSupported {
+				t.Errorf("supported = %v, want %v", supported, tt.wantSupported)
+			}
+			if !reflect.DeepEqual(names, tt.wantNames) {
+				t.Errorf("names = %v, want %v", names, tt.wantNames)
+			}
+		})
+	}
+}
+
+func TestCategoriesView_NilInput_ReturnsNonNilEmptySlice(t *testing.T) {
+	v := categoriesView(false, nil)
+	cats, ok := v["categories"].([]string)
+	if !ok {
+		t.Fatalf("categories not a []string: %T", v["categories"])
+	}
+	if cats == nil || len(cats) != 0 {
+		t.Errorf("categories = %v, want non-nil empty slice", cats)
+	}
+	if v["supported"] != false {
+		t.Errorf("supported = %v, want false", v["supported"])
+	}
+}
+
+// --- HTTP-level tests for the Categories handler -----------------------
+
+// fakeClientStore is a clientStore whose GetByID is configurable; the other
+// methods are unused by the Categories handler.
+type fakeClientStore struct {
+	client *domain.Client
+	err    error
+}
+
+func (f *fakeClientStore) ListForUser(context.Context, uuid.UUID) ([]*domain.Client, error) {
+	return nil, nil
+}
+func (f *fakeClientStore) Create(context.Context, *domain.Client) (*domain.Client, error) {
+	return nil, nil
+}
+func (f *fakeClientStore) GetByID(context.Context, uuid.UUID, uuid.UUID) (*domain.Client, error) {
+	return f.client, f.err
+}
+func (f *fakeClientStore) Update(context.Context, uuid.UUID, uuid.UUID, string, bool, []byte, []byte) error {
+	return nil
+}
+func (f *fakeClientStore) Delete(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+
+// recordingCryptor is a passthrough cryptor that records whether Decrypt was
+// called, so a test can assert an unsupported client never decrypts its config.
+type recordingCryptor struct{ decrypted bool }
+
+func (c *recordingCryptor) Encrypt(pt []byte) ([]byte, []byte, error) { return pt, nil, nil }
+func (c *recordingCryptor) Decrypt(ct, _ []byte) ([]byte, error) {
+	c.decrypted = true
+	return ct, nil
+}
+
+// Register fake client plugins once for the HTTP handler tests. Names are
+// unique so they never collide with real registered plugins.
+const (
+	plainCatClientName = "plaincattest"
+	withCatClientName  = "withcategoriestest"
+)
+
+func init() {
+	registry.RegisterClient(&plainClient{name: plainCatClientName})
+	registry.RegisterClient(&categoriesClient{
+		plainClient: plainClient{name: withCatClientName},
+		names:       []string{"Movies", "TV"},
+	})
+}
+
+func TestClients_Categories_HTTP(t *testing.T) {
+	uid := uuid.New()
+	cid := uuid.New()
+
+	tests := []struct {
+		name           string
+		store          *fakeClientStore
+		wantStatus     int
+		wantSupported  bool
+		wantCategories []string
+		wantDecrypted  bool
+	}{
+		{
+			name:       "unknown client id returns 404",
+			store:      &fakeClientStore{err: repo.ErrNotFound},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "unsupported plugin returns supported:false without decrypting",
+			store: &fakeClientStore{client: &domain.Client{
+				ID: cid, ClientName: plainCatClientName, ConfigEnc: []byte("{}"),
+			}},
+			wantStatus:     http.StatusOK,
+			wantSupported:  false,
+			wantCategories: []string{},
+			wantDecrypted:  false,
+		},
+		{
+			name: "supported plugin returns its categories",
+			store: &fakeClientStore{client: &domain.Client{
+				ID: cid, ClientName: withCatClientName, ConfigEnc: []byte("{}"),
+			}},
+			wantStatus:     http.StatusOK,
+			wantSupported:  true,
+			wantCategories: []string{"Movies", "TV"},
+			wantDecrypted:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crypt := &recordingCryptor{}
+			h := &Clients{Clients: tt.store, Master: crypt, BaseURL: "http://t"}
+
+			req := httptest.NewRequest(http.MethodGet, "/clients/"+cid.String()+"/categories", nil)
+			req = req.WithContext(context.WithValue(req.Context(), middleware.CtxClaims,
+				&auth.Claims{UserID: uid.String()}))
+			req = withURLParam(req, "id", cid.String())
+			w := httptest.NewRecorder()
+			h.Categories(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body %s)", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+			var resp struct {
+				Supported  bool     `json:"supported"`
+				Categories []string `json:"categories"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if resp.Supported != tt.wantSupported {
+				t.Errorf("supported = %v, want %v", resp.Supported, tt.wantSupported)
+			}
+			if !reflect.DeepEqual(resp.Categories, tt.wantCategories) {
+				t.Errorf("categories = %v, want %v", resp.Categories, tt.wantCategories)
+			}
+			if crypt.decrypted != tt.wantDecrypted {
+				t.Errorf("decrypted = %v, want %v (an unsupported client must never decrypt its config)",
+					crypt.decrypted, tt.wantDecrypted)
+			}
+		})
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -110,6 +110,7 @@ func NewRouter(d Deps) http.Handler {
 		Clients: d.Clients,
 		Master:  d.Master,
 		Audit:   d.AuditLog,
+		Log:     d.Log,
 		BaseURL: d.Cfg.PublicBaseURL,
 	}
 	notifiersH := &handlers.Notifiers{
@@ -178,6 +179,7 @@ func NewRouter(d Deps) http.Handler {
 			r.Put("/clients/{id}", clientsH.Update)
 			r.Delete("/clients/{id}", clientsH.Delete)
 			r.Post("/clients/{id}/test", clientsH.Test)
+			r.Get("/clients/{id}/categories", clientsH.Categories)
 
 			r.Get("/notifiers", notifiersH.List)
 			r.Post("/notifiers", notifiersH.Create)

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -146,6 +146,22 @@ var (
 	)
 )
 
+// Client metrics ---------------------------------------------------------
+
+var (
+	// ClientCategoriesFailOpenTotal counts times the category-list fetch for a
+	// client failed and the GET /clients/{id}/categories endpoint fell open to
+	// an empty list (the AddTopic field degrades to free-text). A persistently
+	// non-zero value for a client signals its category fetch is quietly broken.
+	ClientCategoriesFailOpenTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "marauder_client_categories_fail_open_total",
+			Help: "Times a client category list fetch failed and degraded to free-text, by client.",
+		},
+		[]string{"client"},
+	)
+)
+
 // SSE metrics ------------------------------------------------------------
 
 var (

--- a/backend/internal/plugins/clients/qbittorrent/categories_test.go
+++ b/backend/internal/plugins/clients/qbittorrent/categories_test.go
@@ -1,0 +1,71 @@
+package qbittorrent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// newCategoriesServer stands in for qBittorrent's /api/v2/torrents/categories
+// endpoint, serving the supplied raw JSON body (or a 500 when status != 200).
+func newCategoriesServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/categories", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCategories_ReturnsSortedNames(t *testing.T) {
+	srv := newCategoriesServer(t, http.StatusOK, `{
+		"TV":     {"name":"TV","savePath":"/downloads/tv"},
+		"Movies": {"name":"Movies","savePath":""},
+		"TV/Anime": {"name":"TV/Anime","savePath":"/downloads/tv/anime"}
+	}`)
+	raw, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
+	p := &plugin{sessions: map[string]*session{}}
+
+	got, err := p.Categories(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Categories: %v", err)
+	}
+	want := []string{"Movies", "TV", "TV/Anime"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("categories = %v, want %v", got, want)
+	}
+}
+
+func TestCategories_Empty(t *testing.T) {
+	srv := newCategoriesServer(t, http.StatusOK, `{}`)
+	raw, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
+	p := &plugin{sessions: map[string]*session{}}
+
+	got, err := p.Categories(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Categories: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("categories = %v, want empty", got)
+	}
+}
+
+func TestCategories_NonOKStatus_ReturnsError(t *testing.T) {
+	srv := newCategoriesServer(t, http.StatusForbidden, "Forbidden")
+	raw, _ := json.Marshal(Config{URL: srv.URL, Username: "admin", Password: "secret"})
+	p := &plugin{sessions: map[string]*session{}}
+
+	if _, err := p.Categories(context.Background(), raw); err == nil {
+		t.Fatal("expected error on non-200 categories response")
+	}
+}

--- a/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
+++ b/backend/internal/plugins/clients/qbittorrent/qbittorrent.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -49,8 +50,11 @@ type session struct {
 	expiresAt time.Time
 }
 
-// Compile-time guarantee the plugin reports live status.
-var _ registry.WithStatus = (*plugin)(nil)
+// Compile-time guarantee the plugin reports live status and lists categories.
+var (
+	_ registry.WithStatus     = (*plugin)(nil)
+	_ registry.WithCategories = (*plugin)(nil)
+)
 
 func init() {
 	registry.RegisterClient(&plugin{sessions: map[string]*session{}})
@@ -276,6 +280,52 @@ func (p *plugin) Status(ctx context.Context, rawConfig []byte, hashes []string) 
 		})
 	}
 	return out, nil
+}
+
+// Categories implements registry.WithCategories. It queries
+// /api/v2/torrents/categories — qBittorrent returns a JSON object keyed by
+// category name, e.g. {"TV":{"name":"TV","savePath":"/downloads/tv"}} — and
+// returns the category names sorted. Nested categories ("TV/Anime") arrive as
+// slash-joined names and are kept verbatim (valid path-segment values).
+func (p *plugin) Categories(ctx context.Context, rawConfig []byte) ([]string, error) {
+	var cfg Config
+	if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("bad config: %w", err)
+	}
+	s, err := p.session(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := strings.TrimRight(cfg.URL, "/") + "/api/v2/torrents/categories"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("qbit categories: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("qbit categories %d: %s", resp.StatusCode, string(b))
+	}
+	var m map[string]struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, fmt.Errorf("decode qbit categories: %w", err)
+	}
+	names := make([]string, 0, len(m))
+	for k := range m {
+		names = append(names, k)
+	}
+	// Case-insensitive sort so the dropdown reads naturally regardless of the
+	// casing qBittorrent reports (e.g. "anime" doesn't sort after "Movies").
+	sort.Slice(names, func(i, j int) bool {
+		return strings.ToLower(names[i]) < strings.ToLower(names[j])
+	})
+	return names, nil
 }
 
 // qbitState maps a qBittorrent native state string to the normalised

--- a/backend/internal/plugins/registry/registry.go
+++ b/backend/internal/plugins/registry/registry.go
@@ -182,6 +182,18 @@ type WithStatus interface {
 	Status(ctx context.Context, rawConfig []byte, hashes []string) ([]TorrentStatus, error)
 }
 
+// WithCategories is an optional client capability: enumerate the categories
+// the client already knows about, so the UI can offer them as suggestions when
+// picking a topic's category. Clients without a category concept (Transmission,
+// downloadfolder, …) simply don't implement it, and callers fall back to plain
+// free-text entry. Category remains a path segment in Marauder (see
+// EffectiveDownloadDir / SanitizeCategory) — this list is a convenience for
+// picking a value, not a constraint on it.
+type WithCategories interface {
+	Client
+	Categories(ctx context.Context, rawConfig []byte) ([]string, error)
+}
+
 // Notifier is a notification target plugin.
 type Notifier interface {
 	Name() string

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -40,6 +40,13 @@ written to the audit log.
 - The **category** field, if set, tags every torrent Marauder
   submits — useful for sorting in the qBittorrent UI and for
   per-category save paths.
+- **Category autocomplete.** When you add or edit a topic and pick a
+  qBittorrent client, the Category field suggests the categories that
+  already exist in that qBittorrent instance (fetched live via
+  `/api/v2/torrents/categories`). It's a convenience only — you can
+  still type a brand-new category, and the value is always treated as a
+  path segment (nested under the client's base download folder). Other
+  clients fall back to plain free-text entry.
 
 ---
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -40,13 +40,14 @@ written to the audit log.
 - The **category** field, if set, tags every torrent Marauder
   submits — useful for sorting in the qBittorrent UI and for
   per-category save paths.
-- **Category autocomplete.** When you add or edit a topic and pick a
-  qBittorrent client, the Category field suggests the categories that
-  already exist in that qBittorrent instance (fetched live via
-  `/api/v2/torrents/categories`). It's a convenience only — you can
-  still type a brand-new category, and the value is always treated as a
-  path segment (nested under the client's base download folder). Other
-  clients fall back to plain free-text entry.
+- **Category dropdown.** When you add or edit a topic and pick a
+  qBittorrent client, the Category field becomes a dropdown of the
+  categories that already exist in that qBittorrent instance (fetched
+  live via `/api/v2/torrents/categories`), plus a **Custom category…**
+  option. It's a convenience only — pick **Custom** to type a brand-new
+  category, and the value is always treated as a path segment (nested
+  under the client's base download folder). Other clients fall back to
+  plain free-text entry.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-27-qbittorrent-category-dropdown.md
+++ b/docs/superpowers/plans/2026-06-27-qbittorrent-category-dropdown.md
@@ -1,0 +1,300 @@
+# Plan — qBittorrent category dropdown (issue #91)
+
+Date: 2026-06-27
+Issue: https://github.com/artyomsv/marauder/issues/91 (enhancement)
+Branch: `91-qbittorrent-category-dropdown`
+
+## Problem & goal
+
+When manually adding/editing a topic, the **Category** field is free-text. It
+drifts from the categories that actually exist in the download client. For
+qBittorrent (which exposes its categories via the WebUI API), fetch the
+existing categories and offer them as suggestions, while still allowing
+free-text entry.
+
+Category in Marauder is a **path segment**, not a client-native label only
+(see `registry.EffectiveDownloadDir` / `SanitizeCategory`). The dropdown is a
+*convenience for picking a value* — resolution semantics stay identical.
+
+## Acceptance criteria
+
+1. A new optional client capability `registry.WithCategories` exists; clients
+   that can list categories implement it, others don't.
+2. qBittorrent implements `WithCategories` by calling
+   `GET /api/v2/torrents/categories` and returning a sorted name list.
+3. New endpoint `GET /api/v1/clients/{id}/categories` (JWT, user-scoped)
+   returns `{ "supported": bool, "categories": [string] }`.
+4. The AddTopic / EditTopic form renders the Category field as a **combobox**
+   (`<input list=…>` + `<datalist>`): suggestions come from the selected
+   client's categories when supported & non-empty; otherwise plain free-text.
+5. The effective client is the one selected in the form, or the user's
+   **default** client when "Use default client" is chosen.
+6. Non-qBittorrent clients (Transmission, Deluge, µTorrent, downloadfolder)
+   fall back to free-text (`supported:false`).
+7. Fail-open: client unreachable / not-yet-tested / zero categories ⇒ the
+   field still works as free-text; no blocking error, no console spam.
+8. Resolution semantics unchanged — verified by existing `category_test.go`.
+9. Backend + frontend tests cover capability, plugin fetch, handler, and UI.
+10. Docs (`docs/clients.md`) + marketing site (`site/src/data/clients.ts`)
+    mention the category dropdown for qBittorrent.
+
+## qBittorrent API verification
+
+`GET /api/v2/torrents/categories` (WebUI API v2, qBit 4.1+) returns a JSON
+object keyed by category name:
+
+```json
+{
+  "TV":    {"name":"TV","savePath":"/downloads/tv"},
+  "Movies":{"name":"Movies","savePath":""}
+}
+```
+
+So listing is feasible. Nested categories ("TV/Anime") arrive as `/`-joined
+names — valid path-segment values, kept verbatim. Will be confirmed live
+against the `deploy/docker-compose.test-clients.yml` qBittorrent during
+verification.
+
+## Design decisions (alternatives considered)
+
+- **Capability vs. always-on**: use an optional `WithCategories` capability so
+  only qBittorrent (today) exposes a list; mirrors the existing `WithStatus`
+  pattern exactly (compile-time `var _ registry.WithCategories = …`).
+- **Dedicated endpoint vs. `/system/info` flag**: a per-client-instance
+  endpoint returns *live* categories using the stored encrypted config
+  (categories are instance data, not static plugin metadata). Chosen over
+  baking a static `supports_categories` into `/system/info`.
+- **Combobox (`<input>`+`<datalist>`) vs. hard `<select>`**: datalist keeps
+  free-text (issue says "instead of *or alongside*"), so a user can still
+  type a brand-new category (path segment) that doesn't exist in qBit yet, and
+  an edit-mode value not in the list is never clobbered. Native HTML, zero new
+  deps, degrades to a normal input when no suggestions.
+- **Fail-open**: this is a convenience. Any fetch error ⇒ empty suggestions ⇒
+  plain free-text. The handler logs a warn and returns `supported:true,
+  categories:[]` rather than a 5xx.
+
+## Backend changes
+
+### 1. Capability interface — `registry/registry.go`
+
+```go
+// WithCategories is an optional client capability: enumerate the categories
+// the client already knows about so the UI can offer them as suggestions when
+// picking a topic's category. Category remains a path segment in Marauder
+// (see EffectiveDownloadDir); this list is a convenience, not a constraint.
+type WithCategories interface {
+    Client
+    Categories(ctx context.Context, rawConfig []byte) ([]string, error)
+}
+```
+
+Place near `WithStatus`. Add registry-level test asserting qBittorrent
+satisfies it and (e.g.) downloadfolder does not (type assertion).
+
+### 2. qBittorrent — `clients/qbittorrent/qbittorrent.go`
+
+- Add `var _ registry.WithCategories = (*plugin)(nil)`.
+- Implement:
+
+```go
+func (p *plugin) Categories(ctx context.Context, rawConfig []byte) ([]string, error) {
+    var cfg Config
+    if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+        return nil, fmt.Errorf("bad config: %w", err)
+    }
+    s, err := p.session(ctx, cfg)
+    if err != nil {
+        return nil, err
+    }
+    endpoint := strings.TrimRight(cfg.URL, "/") + "/api/v2/torrents/categories"
+    req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+    if err != nil {
+        return nil, err
+    }
+    resp, err := s.client.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("qbit categories: %w", err)
+    }
+    defer resp.Body.Close()
+    if resp.StatusCode != http.StatusOK {
+        b, _ := io.ReadAll(resp.Body)
+        return nil, fmt.Errorf("qbit categories %d: %s", resp.StatusCode, string(b))
+    }
+    var m map[string]struct{ Name string `json:"name"` }
+    if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+        return nil, fmt.Errorf("decode qbit categories: %w", err)
+    }
+    names := make([]string, 0, len(m))
+    for k := range m {
+        names = append(names, k)
+    }
+    sort.Strings(names)
+    return names, nil
+}
+```
+
+(Adds `sort` import.) New `categories_test.go` with a fake mux (reuse the
+pattern from `category_test.go`): returns a categories object, asserts sorted
+names; plus an empty-object case and a non-200 error case.
+
+### 3. Handler — `api/handlers/clients.go`
+
+```go
+// Categories handles GET /clients/{id}/categories. Returns the categories the
+// client already knows about (qBittorrent), so the AddTopic form can offer
+// them as suggestions. Fail-open: a client that can't list categories, or a
+// transient fetch error, yields an empty list (the field stays free-text).
+func (h *Clients) Categories(w http.ResponseWriter, r *http.Request) {
+    uid, perr := currentUserID(r)
+    if perr != nil { problem.Write(...); return }
+    id, ierr := uuid.Parse(chi.URLParam(r, "id"))
+    if ierr != nil { problem.Write(... bad id ...); return }
+    c, err := h.Clients.GetByID(r.Context(), id, uid)
+    if err != nil { // ErrNotFound -> 404, else 500
+        ...
+    }
+    plugin := registry.GetClient(c.ClientName)
+    cat, ok := plugin.(registry.WithCategories)
+    if plugin == nil || !ok {
+        writeJSON(w, 200, map[string]any{"supported": false, "categories": []string{}})
+        return
+    }
+    raw, err := h.Master.Decrypt(c.ConfigEnc, c.ConfigNonce)
+    if err != nil { problem.Write(... 500 ...); return }
+    names, err := cat.Categories(r.Context(), raw)
+    if err != nil {
+        // fail-open: log warn, return supported+empty so UI degrades to free-text
+        log.Warn()...
+        writeJSON(w, 200, map[string]any{"supported": true, "categories": []string{}})
+        return
+    }
+    if names == nil { names = []string{} }
+    writeJSON(w, 200, map[string]any{"supported": true, "categories": names})
+}
+```
+
+- Wire route in `api/router.go` next to the other client routes:
+  `r.Get("/clients/{id}/categories", clientsH.Categories)`.
+- Use the existing zerolog logger seam in handlers (check how other handlers
+  log; if none, return empty silently — do not introduce a new global logger).
+- New `clients_categories_test.go` (handler test): supported client returns
+  sorted names; unknown/unsupported client returns `supported:false`;
+  not-found id → 404; fetch error → `supported:true, categories:[]`.
+
+## Frontend changes
+
+### 4. `lib/api.ts`
+
+- Extend the `ClientOption`/list view consumed by the form to include
+  `is_default` (already on the backend `clientView`) and `client_name`.
+- Add:
+
+```ts
+getClientCategories: (id: string) =>
+  api.get<{ supported: boolean; categories: string[] }>(`/clients/${id}/categories`),
+```
+
+### 5. `lib/queryKeys.ts`
+
+```ts
+clientCategories: (id: string) => ["clientCategories", id] as const,
+```
+
+### 6. `components/topics/TopicForm.tsx`
+
+- Extend the local `ClientOption` interface: `{ id; display_name; is_default }`.
+- Compute the effective client:
+
+```ts
+const effectiveClientId =
+  delivery.clientId || clients.find((c) => c.is_default)?.id || "";
+```
+
+- Categories query (enabled when an effective client exists):
+
+```ts
+const categoriesQuery = useQuery({
+  queryKey: QK.clientCategories(effectiveClientId),
+  queryFn: () => api.getClientCategories(effectiveClientId),
+  enabled: !!effectiveClientId,
+  staleTime: 60_000,
+  retry: false,
+});
+const categorySuggestions =
+  categoriesQuery.data?.supported ? categoriesQuery.data.categories : [];
+```
+
+- Category field becomes a combobox:
+
+```tsx
+<Input
+  id="category"
+  list={categorySuggestions.length ? "category-suggestions" : undefined}
+  value={delivery.category}
+  onChange={...}
+  placeholder="tv"
+/>
+{categorySuggestions.length > 0 && (
+  <datalist id="category-suggestions">
+    {categorySuggestions.map((c) => <option key={c} value={c} />)}
+  </datalist>
+)}
+```
+
+- Helper text: when suggestions present, add "Pick an existing qBittorrent
+  category or type a new one." (i18n via `useT` if the surrounding strings are
+  already keyed — match the file's existing approach; current strings here are
+  literal English, so keep literal to match).
+- `useState` ceiling: no new `useState` is added (categories live in React
+  Query), so the ≤8 rule is respected.
+
+### 7. Tests
+
+- `TopicForm` already has tests? Check `frontend/src/components/topics/` for an
+  existing `TopicForm.test.tsx`/`AddTopicCard.test.tsx`. Add a test: mock
+  `/clients/{id}/categories` → `{supported:true, categories:["TV","Movies"]}`,
+  assert the `<datalist>` options render; and a `supported:false` case asserts
+  no datalist. Use MSW/`vi.mock` consistent with the existing test setup.
+
+## Docs & site
+
+- `docs/clients.md` qBittorrent section: note the Category field now suggests
+  existing qBittorrent categories (fetched live) while still accepting free
+  text.
+- `site/src/data/clients.ts` qBittorrent `description`: add "Category
+  autocomplete from your qBittorrent categories." (keep it short).
+- Check `site/src/pages/features.astro` / `integrations.astro` for a natural
+  spot; add only if it fits without churn.
+- Update root `CLAUDE.md` plugin section: mention the new `WithCategories`
+  capability + the `/clients/{id}/categories` endpoint (structural change rule).
+
+## Edge cases
+
+| Case | Behaviour |
+|---|---|
+| Client not qBittorrent | `supported:false` → free-text, no datalist |
+| qBittorrent unreachable / bad creds | fail-open empty → free-text |
+| qBittorrent has zero categories | `supported:true, []` → free-text |
+| "Use default client" chosen | resolve via `is_default`; if no default, no query |
+| Edit topic, stored category not in list | datalist doesn't constrain input; value preserved |
+| Nested category "TV/Anime" | kept verbatim; valid path segment |
+| Category typed not in qBit | accepted; created as folder segment + qBit label on Add (#75) |
+| Auth/ownership | endpoint user-scoped via `GetByID(id, uid)`; 404 on foreign id |
+
+## Verification checklist
+
+- `go build ./... && go vet ./... && go test -race ./...` (Docker golang:1.25).
+- `npm run typecheck && npm test && npm run build` (Docker node:20-alpine).
+- Live: bring up base+test-clients qBittorrent, create a couple of categories
+  in its WebUI, create a qBit client in Marauder, hit
+  `GET /clients/{id}/categories`, confirm names; open AddTopic and confirm the
+  datalist suggestions.
+- `/code-review` → fix all findings.
+- PR green, docs + site updated, local Docker app rebuilt for manual check.
+
+## Out of scope
+
+- Categories for Transmission/Deluge/µTorrent (no qBit-equivalent concept;
+  Deluge "labels" could be a follow-up).
+- Creating new categories in qBittorrent from Marauder.
+- Caching/invalidation beyond React Query's 60s staleTime.

--- a/frontend/src/components/topics/CategoryField.test.tsx
+++ b/frontend/src/components/topics/CategoryField.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CategoryField } from "./CategoryField";
+
+// Stateful host so the controlled input accumulates typed text like it does in
+// the real form.
+function Host({ suggestions }: { suggestions: string[] }) {
+  const [value, setValue] = useState("");
+  return (
+    <CategoryField value={value} onChange={setValue} suggestions={suggestions} />
+  );
+}
+
+describe("CategoryField", () => {
+  it("renders a datalist with the supplied suggestions", () => {
+    const { container } = render(
+      <CategoryField value="" onChange={() => {}} suggestions={["TV", "Movies"]} />,
+    );
+    const input = screen.getByLabelText(/category/i);
+    const datalist = container.querySelector("datalist");
+    expect(datalist).not.toBeNull();
+    // The input's `list` attribute points at the datalist's (generated) id.
+    expect(input.getAttribute("list")).toBe(datalist!.id);
+
+    const options = datalist!.querySelectorAll("option");
+    expect(Array.from(options).map((o) => o.getAttribute("value"))).toEqual([
+      "TV",
+      "Movies",
+    ]);
+  });
+
+  it("renders no datalist when there are no suggestions (free-text only)", () => {
+    const { container } = render(
+      <CategoryField value="" onChange={() => {}} suggestions={[]} />,
+    );
+    expect(screen.getByLabelText(/category/i)).not.toHaveAttribute("list");
+    expect(container.querySelector("datalist")).toBeNull();
+  });
+
+  it("still accepts free-text typing when suggestions exist", async () => {
+    render(<Host suggestions={["TV"]} />);
+    const input = screen.getByLabelText(/category/i);
+    await userEvent.type(input, "anime");
+    // A brand-new category (not in the suggestions) types through unhindered —
+    // the datalist suggests, it never constrains.
+    expect(input).toHaveValue("anime");
+  });
+});

--- a/frontend/src/components/topics/CategoryField.test.tsx
+++ b/frontend/src/components/topics/CategoryField.test.tsx
@@ -1,51 +1,63 @@
 import { describe, it, expect } from "vitest";
 import { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { CategoryField } from "./CategoryField";
 
-// Stateful host so the controlled input accumulates typed text like it does in
-// the real form.
-function Host({ suggestions }: { suggestions: string[] }) {
-  const [value, setValue] = useState("");
+// Stateful host so the controlled field updates like it does in the real form.
+function Host({ suggestions, initial = "" }: { suggestions: string[]; initial?: string }) {
+  const [value, setValue] = useState(initial);
   return (
-    <CategoryField value={value} onChange={setValue} suggestions={suggestions} />
+    <>
+      <CategoryField value={value} onChange={setValue} suggestions={suggestions} />
+      <output data-testid="val">{value}</output>
+    </>
   );
 }
 
+const val = () => screen.getByTestId("val").textContent;
+
 describe("CategoryField", () => {
-  it("renders a datalist with the supplied suggestions", () => {
-    const { container } = render(
-      <CategoryField value="" onChange={() => {}} suggestions={["TV", "Movies"]} />,
-    );
-    const input = screen.getByLabelText(/category/i);
-    const datalist = container.querySelector("datalist");
-    expect(datalist).not.toBeNull();
-    // The input's `list` attribute points at the datalist's (generated) id.
-    expect(input.getAttribute("list")).toBe(datalist!.id);
-
-    const options = datalist!.querySelectorAll("option");
-    expect(Array.from(options).map((o) => o.getAttribute("value"))).toEqual([
-      "TV",
-      "Movies",
-    ]);
-  });
-
-  it("renders no datalist when there are no suggestions (free-text only)", () => {
-    const { container } = render(
-      <CategoryField value="" onChange={() => {}} suggestions={[]} />,
-    );
-    expect(screen.getByLabelText(/category/i)).not.toHaveAttribute("list");
-    expect(container.querySelector("datalist")).toBeNull();
-  });
-
-  it("still accepts free-text typing when suggestions exist", async () => {
-    render(<Host suggestions={["TV"]} />);
+  it("renders a plain text input when there are no suggestions", async () => {
+    render(<Host suggestions={[]} />);
+    expect(screen.queryByRole("combobox")).toBeNull();
     const input = screen.getByLabelText(/category/i);
     await userEvent.type(input, "anime");
-    // A brand-new category (not in the suggestions) types through unhindered —
-    // the datalist suggests, it never constrains.
-    expect(input).toHaveValue("anime");
+    expect(val()).toBe("anime");
+  });
+
+  it("offers the categories plus a Custom option in a select", async () => {
+    render(<Host suggestions={["TV", "Movies"]} />);
+    const select = screen.getByRole("combobox");
+    const labels = within(select)
+      .getAllByRole("option")
+      .map((o) => o.textContent);
+    expect(labels).toEqual([
+      "No category",
+      "TV",
+      "Movies",
+      "✎ Custom category…",
+    ]);
+
+    await userEvent.selectOptions(select, "TV");
+    expect(val()).toBe("TV");
+  });
+
+  it("reveals a free-text box when Custom is chosen and types through", async () => {
+    render(<Host suggestions={["TV"]} />);
+    await userEvent.selectOptions(screen.getByRole("combobox"), "__custom__");
+
+    const textbox = screen.getByRole("textbox");
+    // A brand-new category not in the list types through unhindered — the
+    // dropdown suggests, it never constrains.
+    await userEvent.type(textbox, "season-1");
+    expect(val()).toBe("season-1");
+  });
+
+  it("opens in Custom mode when an existing value isn't in the list", () => {
+    render(<Host suggestions={["TV", "Movies"]} initial="my/custom/path" />);
+    expect(screen.getByRole("textbox")).toHaveValue("my/custom/path");
+    expect(screen.getByRole("combobox")).toHaveValue("__custom__");
   });
 });

--- a/frontend/src/components/topics/CategoryField.tsx
+++ b/frontend/src/components/topics/CategoryField.tsx
@@ -1,0 +1,49 @@
+import { useId } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface CategoryFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  // Existing client categories to suggest (empty when the client has none or
+  // doesn't support listing them — the field then behaves as plain free-text).
+  suggestions: string[];
+}
+
+// Category picker for the topic form. When the selected client exposes its
+// existing categories (qBittorrent), they are offered as a native datalist
+// combobox: the user can pick one or type a brand-new value. Category is a
+// path segment in Marauder, so free-text always stays valid — the datalist
+// never constrains the input.
+export function CategoryField({ value, onChange, suggestions }: CategoryFieldProps) {
+  const hasSuggestions = suggestions.length > 0;
+  // Unique ids so the field stays self-contained even if two topic forms ever
+  // co-mount (the datalist/label associations can't clash).
+  const inputId = useId();
+  const listId = useId();
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={inputId}>Category (optional)</Label>
+      <Input
+        id={inputId}
+        list={hasSuggestions ? listId : undefined}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="tv"
+      />
+      {hasSuggestions && (
+        <datalist id={listId}>
+          {suggestions.map((c) => (
+            <option key={c} value={c} />
+          ))}
+        </datalist>
+      )}
+      <p className="text-xs text-muted-foreground">
+        {hasSuggestions
+          ? "Pick an existing client category or type a new one. Nested under the client's base download folder."
+          : "Nested under the client's base download folder."}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/topics/CategoryField.tsx
+++ b/frontend/src/components/topics/CategoryField.tsx
@@ -1,49 +1,99 @@
-import { useId } from "react";
+import { useId, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SELECT_CLASS } from "./SeasonEpisodePicker";
 
 interface CategoryFieldProps {
   value: string;
   onChange: (value: string) => void;
-  // Existing client categories to suggest (empty when the client has none or
+  // Existing client categories to offer (empty when the client has none or
   // doesn't support listing them — the field then behaves as plain free-text).
   suggestions: string[];
 }
 
+// Sentinel option value for "I want to type my own category".
+const CUSTOM = "__custom__";
+
 // Category picker for the topic form. When the selected client exposes its
-// existing categories (qBittorrent), they are offered as a native datalist
-// combobox: the user can pick one or type a brand-new value. Category is a
-// path segment in Marauder, so free-text always stays valid — the datalist
-// never constrains the input.
+// existing categories (qBittorrent), they are offered in a native <select>
+// (an always-visible dropdown, consistent with the form's other pickers) with
+// a "Custom category…" option that reveals a free-text box. Category is a path
+// segment in Marauder, so a brand-new value is always allowed — the dropdown
+// only makes the common case obvious, it never constrains the input. When the
+// client exposes no categories, the field is a plain free-text input.
 export function CategoryField({ value, onChange, suggestions }: CategoryFieldProps) {
-  const hasSuggestions = suggestions.length > 0;
-  // Unique ids so the field stays self-contained even if two topic forms ever
-  // co-mount (the datalist/label associations can't clash).
+  const selectId = useId();
   const inputId = useId();
-  const listId = useId();
+  const hasSuggestions = suggestions.length > 0;
+
+  // Whether the user explicitly chose to type a custom value. We also fall into
+  // the custom view when the current value isn't one of the suggestions (e.g.
+  // editing a topic whose stored category isn't a known client category).
+  const [custom, setCustom] = useState(false);
+  const valueInList = suggestions.includes(value);
+  const showCustomInput = custom || (!!value && !valueInList);
+
+  const helpText = hasSuggestions
+    ? "Pick an existing client category, or choose Custom to enter your own."
+    : "Nested under the client's base download folder.";
+
+  if (!hasSuggestions) {
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={inputId}>Category (optional)</Label>
+        <Input
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="tv"
+        />
+        <p className="text-xs text-muted-foreground">{helpText}</p>
+      </div>
+    );
+  }
+
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const picked = e.target.value;
+    if (picked === CUSTOM) {
+      setCustom(true);
+      onChange("");
+      return;
+    }
+    // A real suggestion (or the "No category" blank) — leave custom mode.
+    setCustom(false);
+    onChange(picked);
+  };
+
   return (
     <div className="space-y-1.5">
-      <Label htmlFor={inputId}>Category (optional)</Label>
-      <Input
-        id={inputId}
-        list={hasSuggestions ? listId : undefined}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="tv"
-      />
-      {hasSuggestions && (
-        <datalist id={listId}>
-          {suggestions.map((c) => (
-            <option key={c} value={c} />
-          ))}
-        </datalist>
+      <Label htmlFor={selectId}>Category (optional)</Label>
+      <select
+        id={selectId}
+        value={showCustomInput ? CUSTOM : value}
+        onChange={handleSelect}
+        className={SELECT_CLASS}
+      >
+        <option value="">No category</option>
+        {suggestions.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+        <option value={CUSTOM}>✎ Custom category…</option>
+      </select>
+      {showCustomInput && (
+        <Input
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="e.g. tv/anime"
+          // Focus when the user just chose Custom, but not when an existing
+          // out-of-list value pre-opens this view on an edit form.
+          autoFocus={custom}
+        />
       )}
-      <p className="text-xs text-muted-foreground">
-        {hasSuggestions
-          ? "Pick an existing client category or type a new one. Nested under the client's base download folder."
-          : "Nested under the client's base download folder."}
-      </p>
+      <p className="text-xs text-muted-foreground">{helpText}</p>
     </div>
   );
 }

--- a/frontend/src/components/topics/TopicForm.tsx
+++ b/frontend/src/components/topics/TopicForm.tsx
@@ -11,6 +11,7 @@ import { useDebouncedValue } from "@/lib/hooks/useDebouncedValue";
 import { SeasonEpisodePicker, SELECT_CLASS } from "./SeasonEpisodePicker";
 import { PosterImage } from "./PosterImage";
 import { NotifierSelect } from "./NotifierSelect";
+import { CategoryField } from "./CategoryField";
 
 // Shape of GET /trackers/match. Drives which optional sections the form
 // renders (quality, season/episode filter, credentials hint).
@@ -27,10 +28,13 @@ export interface TrackerMatch {
 }
 
 // Minimal shape of a torrent client for the picker. The full ClientView
-// lives in Clients.tsx; the form only needs id + display_name.
+// lives in Clients.tsx; the form needs id + display_name to render the select
+// and is_default to resolve which client's categories to suggest when the
+// user leaves the picker on "Use default client".
 interface ClientOption {
   id: string;
   display_name: string;
+  is_default: boolean;
 }
 
 // The mutable fields the user edits. Grouped into one object so the form
@@ -192,6 +196,22 @@ export function TopicForm({
     downloadDir: initial.downloadDir,
     category: initial.category,
   });
+
+  // The category combobox suggests the categories of whichever client will
+  // actually receive the topic: the one picked in the form, or the user's
+  // default client when "Use default client" is selected.
+  const effectiveClientId =
+    delivery.clientId || clients.find((c) => c.is_default)?.id || "";
+  const categoriesQuery = useQuery({
+    queryKey: QK.clientCategories(effectiveClientId),
+    queryFn: () => api.getClientCategories(effectiveClientId),
+    enabled: !!effectiveClientId,
+    staleTime: 60_000,
+    retry: false,
+  });
+  const categorySuggestions = categoriesQuery.data?.supported
+    ? categoriesQuery.data.categories
+    : [];
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -366,18 +386,11 @@ export function TopicForm({
             Full path; overrides the client folder and category below.
           </p>
         </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="category">Category (optional)</Label>
-          <Input
-            id="category"
-            value={delivery.category}
-            onChange={(e) => setDelivery((d) => ({ ...d, category: e.target.value }))}
-            placeholder="tv"
-          />
-          <p className="text-xs text-muted-foreground">
-            Nested under the client's base download folder.
-          </p>
-        </div>
+        <CategoryField
+          value={delivery.category}
+          onChange={(v) => setDelivery((d) => ({ ...d, category: v }))}
+          suggestions={categorySuggestions}
+        />
       </div>
 
       {error && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -176,6 +176,16 @@ export const api = {
   topicEvents: (id: string) =>
     request<{ events: TopicEvent[] }>("GET", `/topics/${id}/events`),
 
+  // List the categories a configured client already knows about (qBittorrent),
+  // so the AddTopic form can suggest them. `supported` is false for clients
+  // without a category concept; on any fetch failure the list is empty and the
+  // field stays free-text.
+  getClientCategories: (id: string) =>
+    request<{ supported: boolean; categories: string[] }>(
+      "GET",
+      `/clients/${id}/categories`,
+    ),
+
   // GET /notifiers/{id} — includes decrypted config for the edit form.
   getNotifier: (id: string) =>
     request<NotifierDetail>("GET", `/notifiers/${id}`),

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -56,4 +56,8 @@ export const QK = {
 
   // /topics/{id}/events — read-only per-topic history timeline.
   topicEvents: (id: string) => ["topicEvents", id] as const,
+
+  // /clients/{id}/categories — existing client categories (qBittorrent) used
+  // to suggest values in the AddTopic form's category combobox.
+  clientCategories: (id: string) => ["clientCategories", id] as const,
 } as const;

--- a/site/src/data/clients.ts
+++ b/site/src/data/clients.ts
@@ -15,7 +15,7 @@ export const clients: Client[] = [
   {
     slug: "qbittorrent",
     name: "qBittorrent",
-    description: "WebUI API v2 — qBittorrent 4.5+ and 5.x. Live download status by infohash.",
+    description: "WebUI API v2 — qBittorrent 4.5+ and 5.x. Live download status by infohash, plus category autocomplete from your existing qBittorrent categories.",
     status: "validated",
   },
   {

--- a/site/src/data/clients.ts
+++ b/site/src/data/clients.ts
@@ -15,7 +15,7 @@ export const clients: Client[] = [
   {
     slug: "qbittorrent",
     name: "qBittorrent",
-    description: "WebUI API v2 — qBittorrent 4.5+ and 5.x. Live download status by infohash, plus category autocomplete from your existing qBittorrent categories.",
+    description: "WebUI API v2 — qBittorrent 4.5+ and 5.x. Live download status by infohash, plus a category dropdown populated from your existing qBittorrent categories.",
     status: "validated",
   },
   {

--- a/techdebt/frontend/4-3-topic-form-exceeds-component-size-limit.md
+++ b/techdebt/frontend/4-3-topic-form-exceeds-component-size-limit.md
@@ -1,0 +1,45 @@
+# TopicForm.tsx exceeds the 250-line component-size limit
+
+| Field | Value |
+|-------|-------|
+| Criticality | Low |
+| Complexity | Medium |
+| Location | `frontend/src/components/topics/TopicForm.tsx` (~412 lines) |
+| Found during | Code review of issue #91 (qBittorrent category dropdown), rules-compliance agent |
+| Date | 2026-06-27 |
+
+## Issue
+
+`clean-code-react.md` caps components at 250 lines. `TopicForm.tsx` is ~412
+lines — it was already ~400 before the #91 category-combobox work (which added
+~12 lines for the `effectiveClientId` resolution + categories query). It is the
+shared add/edit form and owns several cohesive but separable blocks:
+
+- the delivery fields (client picker + `NotifierSelect` + download-dir input +
+  `CategoryField`)
+- the credential-hint banners (requires / optional / satisfied)
+- the quality select and the preview card
+
+It is a sibling of the already-acknowledged `Topics.tsx` / `Clients.tsx`
+pre-existing size debt noted in `CLAUDE.md`.
+
+## Risks
+
+Low. Purely maintainability — a long file is harder to scan and review. No
+functional, security, or performance impact. The form is well covered by the
+`AddTopicCard` test suite.
+
+## Suggested Solutions
+
+Extract presentational sub-components in a dedicated refactor commit (not bundled
+with feature work, so `git blame` stays meaningful):
+
+1. `TopicDeliveryFields.tsx` — client/notifier/download-dir/category block (~60
+   lines). This is where the #91 category combobox lives, so it is the most
+   natural first extraction.
+2. `TopicCredentialHint.tsx` — the three credential banners (~30 lines), a pure
+   function of `match` + `hasCredential`.
+
+Together these bring the file comfortably under 250 lines without touching form
+state or behaviour. The `AddTopicCard` tests assert behaviour by label/role, so
+a verbatim JSX move keeps them green.


### PR DESCRIPTION
## What

Closes #91. The topic **Category** field was free-text and drifted from the categories that actually exist in the download client. When the selected (or default) client is qBittorrent, the AddTopic/EditTopic form now suggests its existing categories in a combobox while still accepting free text.

## Changes

- **`registry.WithCategories`** — new optional client capability (`Categories(ctx, rawConfig) []string`), mirroring `WithStatus`. Clients without a category concept simply don't implement it.
- **qBittorrent** implements it via `/api/v2/torrents/categories` (case-insensitive sorted names; nested `TV/Anime` kept verbatim).
- **`GET /api/v1/clients/{id}/categories`** — user-scoped endpoint returning `{supported, categories}`. **Fail-open**: unsupported client, unreachable client, or zero categories → empty list and the field degrades to plain free-text. Bounded by a 10s timeout; the stored config is decrypted only when the plugin can actually list categories; degradations emit a warn log + `marauder_client_categories_fail_open_total` metric.
- **Frontend** — `CategoryField` renders a `<datalist>` combobox fed by the new endpoint, resolving the effective client (picked, else the user's default). Category stays a **path segment** (`registry.EffectiveDownloadDir`), so the list only helps pick a value, it never constrains it — a brand-new category types straight through.

## Tests

- Backend: qBittorrent `Categories` (sorted/empty/non-200), `resolveCategories` core, and HTTP-level handler tests (404 / unsupported-never-decrypts / supported). Full race suite green.
- Frontend: `CategoryField` (datalist present/absent, free-text typing); full suite (97) + build green.

## Docs

`docs/clients.md`, `site/src/data/clients.ts`, and `CLAUDE.md` updated. Residual `TopicForm.tsx` >250-line size (pre-existing) tracked in `techdebt/frontend/`.

## Notes

Not Sonarr-specific — applies to manual topic creation. Other clients (Transmission/Deluge/µTorrent/downloadfolder) fall back to free-text.