### PR TITLE
fix(security): close tracker SSRF, fix CI security-scan blind spots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,10 +66,6 @@ updates:
       frontend-minor-patch:
         patterns: ["*"]
         update-types: [minor, patch]
-      frontend-types:
-        patterns:
-          - "@types/*"
-        update-types: [major, minor, patch]
     ignore:
       # Pin to React 19 / Vite 8 / Tailwind 4 majors per the
       # tech-stack lock in CHANGELOG. Dependabot will still propose

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,10 @@ jobs:
           push: false
           load: true
           tags: ${{ matrix.image.tag }}
+          # cfsolver builds fresh: its chromium layer carries security patches
+          # that a frozen GHA cache would mask, making the Trivy scan report
+          # phantom CVEs from a stale layer that the shipped image doesn't have.
+          no-cache: ${{ matrix.image.name == 'cfsolver' }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,10 @@ jobs:
             BUILD_DATE=${{ steps.bm.outputs.date }}
           provenance: true
           sbom: true
+          # cfsolver builds fresh so each release ships a chromium with the
+          # latest security patches rather than a frozen GHA cache layer that
+          # would silently go stale over weeks between releases.
+          no-cache: ${{ matrix.image.name == 'cfsolver' }}
           cache-from: type=gha,scope=release-${{ matrix.image.name }}
           cache-to: type=gha,scope=release-${{ matrix.image.name }},mode=max
 

--- a/backend/internal/api/middleware/middleware.go
+++ b/backend/internal/api/middleware/middleware.go
@@ -3,6 +3,7 @@ package middleware
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -38,6 +39,49 @@ func RequestID(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), CtxRequestID, id)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// realIPHeaders is the precedence order for proxy-supplied client IPs,
+// matching chi's historical middleware.RealIP.
+var realIPHeaders = []string{"True-Client-IP", "X-Real-IP", "X-Forwarded-For"}
+
+// RealIP rewrites r.RemoteAddr from the reverse proxy's forwarded-for headers
+// so downstream logging/audit see the originating client IP rather than the
+// gateway's.
+//
+// This replaces chi's middleware.RealIP, deprecated in chi v5.3 as spoofable
+// (GHSA-3fxj-6jh8-hvhx) because it trusts these headers unconditionally. The
+// same trust assumption is safe here: Marauder's backend is never exposed
+// directly — only the nginx gateway is published, and it sets X-Forwarded-For
+// — and RemoteAddr feeds only the access log and audit display, never an
+// authn/authz or rate-limit decision. It is deliberately not used as a
+// security control.
+func RealIP(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ip := realIP(r); ip != "" {
+			r.RemoteAddr = ip
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func realIP(r *http.Request) string {
+	for _, h := range realIPHeaders {
+		v := r.Header.Get(h)
+		if v == "" {
+			continue
+		}
+		if h == "X-Forwarded-For" {
+			if i := strings.Index(v, ","); i >= 0 {
+				v = v[:i]
+			}
+		}
+		v = strings.TrimSpace(v)
+		if net.ParseIP(v) != nil {
+			return v
+		}
+	}
+	return ""
 }
 
 // Logger wraps every request in a zerolog event AND records HTTP

--- a/backend/internal/api/middleware/realip_test.go
+++ b/backend/internal/api/middleware/realip_test.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRealIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		fallback string
+		want     string
+	}{
+		{"x-forwarded-for first hop", map[string]string{"X-Forwarded-For": "203.0.113.7, 10.0.0.1"}, "10.0.0.1:5000", "203.0.113.7"},
+		{"x-real-ip", map[string]string{"X-Real-IP": "203.0.113.8"}, "10.0.0.1:5000", "203.0.113.8"},
+		{"true-client-ip wins", map[string]string{"True-Client-IP": "203.0.113.9", "X-Real-IP": "198.51.100.1"}, "10.0.0.1:5000", "203.0.113.9"},
+		{"no headers keeps remoteaddr", nil, "10.0.0.1:5000", "10.0.0.1:5000"},
+		{"garbage header ignored", map[string]string{"X-Real-IP": "not-an-ip"}, "10.0.0.1:5000", "10.0.0.1:5000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			h := RealIP(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got = r.RemoteAddr
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.fallback
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			if got != tt.want {
+				t.Errorf("RemoteAddr = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -60,7 +60,7 @@ func NewRouter(d Deps) http.Handler {
 	r.Use(middleware.Logger(d.Log))
 	r.Use(middleware.Recover(d.Log, d.Cfg.PublicBaseURL))
 	r.Use(middleware.SecurityHeaders)
-	r.Use(chimw.RealIP)
+	r.Use(middleware.RealIP)
 	r.Use(chimw.Heartbeat("/health"))
 
 	// CORS

--- a/backend/internal/plugins/trackers/nnmclub/nnmclub.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub.go
@@ -154,7 +154,35 @@ func (p *plugin) ResolveMetadata(ctx context.Context, rawURL string, creds *doma
 	return meta, nil
 }
 
+// allowHost parses target and confirms it is an http(s) URL pointing at one
+// of NNM-Club's hosts (the configured domain, plus the known nnmclub.to /
+// nnmclub.me family and their www. forms). It is the SSRF barrier for every
+// outbound fetch: a topic URL is user-controlled, so anything off-site is
+// refused before a request is built.
+func (p *plugin) allowHost(target string) error {
+	u, err := url.Parse(strings.TrimSpace(target))
+	if err != nil {
+		return fmt.Errorf("nnm-club: invalid URL: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return fmt.Errorf("nnm-club: refusing URL scheme %q", u.Scheme)
+	}
+	host := strings.ToLower(u.Host)
+	bare := strings.TrimPrefix(host, "www.")
+	if bare == p.domain || bare == "nnmclub.to" || bare == "nnmclub.me" {
+		return nil
+	}
+	return fmt.Errorf("nnm-club: refusing to fetch off-site host %q", u.Host)
+}
+
 func (p *plugin) fetch(ctx context.Context, target string, creds *domain.TrackerCredential) ([]byte, error) {
+	// SSRF guard: `target` is a user-supplied topic URL, so confine the
+	// outbound request to NNM-Club's own hosts before dialing. Without this
+	// an attacker could register a topic whose URL points at an internal
+	// service (cloud metadata, localhost) and have the backend fetch it.
+	if err := p.allowHost(target); err != nil {
+		return nil, err
+	}
 	key := pluginName + ":nocreds"
 	if creds != nil {
 		key = forumcommon.SessionKey(pluginName, creds.UserID.String())

--- a/backend/internal/plugins/trackers/nnmclub/nnmclub_test.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub_test.go
@@ -121,6 +121,38 @@ func TestDownload(t *testing.T) {
 	}
 }
 
+func TestFetch_RejectsOffSiteHost(t *testing.T) {
+	p := newTestPlugin(t)
+	// A topic URL pointing somewhere other than NNM-Club must never be
+	// fetched (SSRF guard), even though the page would parse fine.
+	topic := &domain.Topic{URL: "http://169.254.169.254/latest/meta-data/"}
+	if _, err := p.Check(context.Background(), topic, nil); err == nil {
+		t.Fatal("Check should refuse an off-site host")
+	}
+	if _, err := p.ResolveMetadata(context.Background(), "http://localhost:6379/", nil); err == nil {
+		t.Fatal("ResolveMetadata should refuse an off-site host")
+	}
+}
+
+func TestAllowHost(t *testing.T) {
+	p := &plugin{domain: defaultDomain}
+	cases := map[string]bool{
+		"https://nnmclub.to/forum/viewtopic.php?t=1":     true,
+		"https://www.nnmclub.to/forum/viewtopic.php?t=1": true,
+		"https://nnmclub.me/forum/viewtopic.php?t=1":     true,
+		"http://nnmclub.to/forum/viewtopic.php?t=1":      true,
+		"https://nnmclub.to.evil.com/forum/":             false,
+		"https://evil.com/forum/viewtopic.php?t=1":       false,
+		"ftp://nnmclub.to/forum/":                        false,
+		"http://169.254.169.254/":                        false,
+	}
+	for u, want := range cases {
+		if got := p.allowHost(u) == nil; got != want {
+			t.Errorf("allowHost(%q) allowed=%v, want %v", u, got, want)
+		}
+	}
+}
+
 func TestResolveMetadata(t *testing.T) {
 	p := newTestPlugin(t)
 	meta, err := p.ResolveMetadata(context.Background(), "https://"+p.domain+"/forum/viewtopic.php?t=42", nil)

--- a/cfsolver/Dockerfile
+++ b/cfsolver/Dockerfile
@@ -23,7 +23,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
 # has reliable chromium packages and Alpine's chromium is hit-or-miss.
 FROM debian:13-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update \
+ && apt-get upgrade -y --no-install-recommends \
+ && apt-get install -y --no-install-recommends \
     chromium \
     ca-certificates \
     fonts-liberation \


### PR DESCRIPTION
Resolves the security/quality-scan and dependabot findings surfaced in a Security tab audit.

## Summary
- **fix(nnmclub): close CodeQL critical SSRF** — `go/request-forgery`. The user-supplied topic URL flowed into the outbound request in `fetch()` with no host check. Added `allowHost()` at the single fetch choke point (Check/Download/ResolveMetadata) confining requests to NNM-Club hosts. Closes the only *real* code-scanning alert.
- **refactor(api): replace deprecated chi `RealIP`** — chi v5.3 deprecates it (SA1019, GHSA-3fxj-6jh8-hvhx); the deprecation fails `golangci-lint` and blocks the chi dependency bump (#62). In-package `middleware.RealIP` restores behaviour with a documented trusted-gateway assumption.
- **ci(cfsolver): build the image fresh for scanning** — docker.yml reused a frozen GHA cache layer for the chromium install, so Trivy scanned a months-stale browser and reported ~18 *phantom* Chrome CVEs (36 alerts) the shipped image never had. `no-cache` for cfsolver in docker.yml **and** release.yml (so a future release can't ship stale-cache chromium) + `apt-get upgrade`. A fresh build scans **0 chromium / 0 fixable HIGH-CRITICAL**.
- **ci(deps): drop the redundant `frontend-types` dependabot group** — it only ever captured `@types/*` *majors*, contradicting the majors-are-manual policy and leaving `@types` major PRs stuck (#64).

## Test plan
- `go build ./...`, `go vet ./...`, full `go test ./...` — green
- `golangci-lint v2.12.2` (the exact CI version) on changed packages — **0 issues**
- `cfsolver/Dockerfile` fresh build + Trivy scan — **0 chromium / 0 fixable HIGH-CRIT**
- New tests: `allowHost`/off-site-host rejection (nnmclub), `RealIP` header precedence

## Notes
- The 36 Trivy alerts on the Security tab are **stale** (the shipped image is already clean); the docker.yml run after this merges will report the category empty and auto-close them.
- This PR is titled `fix(...)` so merging cuts a **patch release** (ships the SSRF fix). Retitle to `chore`/`ci` if you'd rather not release yet.