### PR TITLE
refactor(nnmclub): constant host allowlist for SSRF barrier

### DIFF
--- a/backend/internal/plugins/trackers/nnmclub/nnmclub.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub.go
@@ -28,24 +28,21 @@ import (
 )
 
 const (
-	pluginName    = "nnmclub"
-	displayName   = "NNM-Club.to"
-	defaultDomain = "nnmclub.to"
-	userAgent     = "Marauder/0.3 (+https://marauder.cc)"
+	pluginName  = "nnmclub"
+	displayName = "NNM-Club.to"
+	userAgent   = "Marauder/0.3 (+https://marauder.cc)"
 )
 
 var urlPattern = regexp.MustCompile(`^https?://(?:www\.)?nnmclub\.(?:to|me)/forum/viewtopic\.php\?t=(\d+)`)
 
 type plugin struct {
 	sessions  *forumcommon.SessionStore
-	domain    string
 	transport http.RoundTripper
 }
 
 func init() {
 	registry.RegisterTracker(&plugin{
 		sessions: forumcommon.New(),
-		domain:   defaultDomain,
 	})
 }
 
@@ -167,12 +164,12 @@ func (p *plugin) fetch(ctx context.Context, target string, creds *domain.Tracker
 	if u.Scheme != "https" && u.Scheme != "http" {
 		return nil, fmt.Errorf("nnm-club: refusing URL scheme %q", u.Scheme)
 	}
-	allowed := p.domain
-	if i := strings.LastIndex(allowed, ":"); i >= 0 {
-		allowed = allowed[:i] // strip the port the httptest server appends
-	}
-	switch strings.TrimPrefix(strings.ToLower(u.Hostname()), "www.") {
-	case allowed, "nnmclub.to", "nnmclub.me":
+	// Allowlist the host against compile-time constants only (url.Parse has
+	// already lower-cased it). Checking u.Hostname() against literal hosts is
+	// the form CodeQL recognises as a request-forgery barrier, so the
+	// u.String() dialed below is treated as sanitised.
+	switch u.Hostname() {
+	case "nnmclub.to", "www.nnmclub.to", "nnmclub.me", "www.nnmclub.me":
 		// a permitted NNM-Club host — fall through and fetch
 	default:
 		return nil, fmt.Errorf("nnm-club: refusing to fetch off-site host %q", u.Hostname())

--- a/backend/internal/plugins/trackers/nnmclub/nnmclub_e2e_test.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub_e2e_test.go
@@ -35,7 +35,6 @@ func TestE2E(t *testing.T) {
 			testHost := strings.TrimPrefix(srv.URL, "http://")
 			p := &plugin{
 				sessions: forumcommon.New(),
-				domain:   "nnmclub.to",
 				transport: &e2etest.HostRewriteTransport{
 					From: "nnmclub.to",
 					To:   testHost,

--- a/backend/internal/plugins/trackers/nnmclub/nnmclub_test.go
+++ b/backend/internal/plugins/trackers/nnmclub/nnmclub_test.go
@@ -21,6 +21,10 @@ const fixtureViewtopicHTML = `<html><head>
 <a href="download.php?id=379398" rel="nofollow">Скачать</a>
 </body></html>`
 
+// testTopicURL is a real NNM-Club host so it passes the fetch() SSRF
+// allowlist; hostRewrite redirects the actual connection to the test server.
+const testTopicURL = "https://nnmclub.to/forum/viewtopic.php?t=42"
+
 func newTestPlugin(t *testing.T) *plugin {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,20 +38,19 @@ func newTestPlugin(t *testing.T) *plugin {
 	}))
 	t.Cleanup(srv.Close)
 
-	host := strings.TrimPrefix(srv.URL, "http://")
 	return &plugin{
 		sessions:  forumcommon.New(),
-		domain:    host,
-		transport: &schemeRewrite{},
+		transport: &hostRewrite{host: strings.TrimPrefix(srv.URL, "http://")},
 	}
 }
 
-type schemeRewrite struct{}
+// hostRewrite reroutes every request to the test server while leaving the
+// request's declared URL (a real nnmclub.to host) intact for the SSRF guard.
+type hostRewrite struct{ host string }
 
-func (s *schemeRewrite) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.URL.Scheme == "https" {
-		req.URL.Scheme = "http"
-	}
+func (h *hostRewrite) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = h.host
 	return http.DefaultTransport.RoundTrip(req)
 }
 
@@ -87,7 +90,7 @@ func TestParse(t *testing.T) {
 
 func TestCheck(t *testing.T) {
 	p := newTestPlugin(t)
-	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=42"}
+	topic := &domain.Topic{URL: testTopicURL}
 	check, err := p.Check(context.Background(), topic, nil)
 	if err != nil {
 		t.Fatalf("Check: %v", err)
@@ -105,7 +108,7 @@ func TestCheck(t *testing.T) {
 
 func TestDownload(t *testing.T) {
 	p := newTestPlugin(t)
-	topic := &domain.Topic{URL: "https://" + p.domain + "/forum/viewtopic.php?t=42"}
+	topic := &domain.Topic{URL: testTopicURL}
 	payload, err := p.Download(context.Background(), topic, nil, nil)
 	if err != nil {
 		t.Fatalf("Download: %v", err)
@@ -123,9 +126,8 @@ func TestDownload(t *testing.T) {
 
 func TestFetch_RejectsOffSiteHost(t *testing.T) {
 	// The SSRF guard must refuse any topic URL that is not an NNM-Club host,
-	// before a request is ever dialed. defaultDomain so no test server is
-	// needed — these are rejected up front.
-	p := &plugin{sessions: forumcommon.New(), domain: defaultDomain}
+	// before a request is ever dialed — so no test server is needed here.
+	p := &plugin{sessions: forumcommon.New()}
 	bad := []string{
 		"http://169.254.169.254/latest/meta-data/",
 		"http://localhost:6379/",
@@ -146,7 +148,7 @@ func TestFetch_RejectsOffSiteHost(t *testing.T) {
 
 func TestResolveMetadata(t *testing.T) {
 	p := newTestPlugin(t)
-	meta, err := p.ResolveMetadata(context.Background(), "https://"+p.domain+"/forum/viewtopic.php?t=42", nil)
+	meta, err := p.ResolveMetadata(context.Background(), testTopicURL, nil)
 	if err != nil {
 		t.Fatalf("ResolveMetadata: %v", err)
 	}


### PR DESCRIPTION
Follow-up to #103. CodeQL still flagged `go/request-forgery` because the prior guard switched on a **transformed** hostname (`ToLower`/`TrimPrefix`) and included a **non-constant** case (the configured domain) — so it wasn't recognised as a host-allowlist barrier, and the `u.String()` dial stayed tainted.

## Change
- Switch `u.Hostname()` **directly** against the four literal NNM-Club hosts (`url.Parse` already lower-cases the host) — the canonical form CodeQL models as a sanitiser.
- Unit test now uses a real `nnmclub.to` URL + a host-rewriting transport (same approach as the existing `nnmclub_e2e_test.go`), so the dynamic test host no longer forces a variable case. The now-vestigial `domain` field is removed.
- **Behaviour unchanged.**

## Test plan
- `go build`, `go vet`, `go test`, `golangci-lint v2.12.2` — all green, 0 issues
- `TestFetch_RejectsOffSiteHost` still covers metadata endpoint / localhost / look-alike / bad scheme / malformed

`refactor` → no release. Once merged, the next CodeQL run on main should close the last open alert. If CodeQL still doesn't recognise this canonical pattern, the remaining step is a documented dismissal — I'll flag that for you rather than decide it.