### PR TITLE
ci: decouple release publish from flaky SBOM asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,15 +246,41 @@ jobs:
             } >> release-notes.md
           fi
 
+      # Create/publish the release with notes ONLY — no asset uploads in this
+      # gating step. GitHub's release-asset API intermittently 404s on
+      # upload/metadata-update (eventual consistency); when that failed the
+      # combined step, the whole `release` job failed and the version-sync +
+      # issue-notify jobs (needs: [release]) were silently SKIPPED — which froze
+      # README and the marketing site at the previous version release after
+      # release. Keeping asset attachment out of the gating step makes the
+      # release reliable and the downstream sync run every time.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
           name: Marauder ${{ steps.changelog.outputs.tag }}
           body_path: release-notes.md
-          files: sboms/**/*.cdx.json
           draft: false
           prerelease: ${{ contains(steps.changelog.outputs.tag, '-rc') || contains(steps.changelog.outputs.tag, '-alpha') || contains(steps.changelog.outputs.tag, '-beta') }}
+
+      # Attach the SBOMs best-effort. `gh release upload --clobber` is idempotent
+      # (safe to re-run) and avoids the action's delete-then-reupload path that
+      # triggers the asset-API 404s. continue-on-error: a supply-chain-artifact
+      # hiccup must never fail the release or block the version sync below.
+      - name: Attach SBOMs (best-effort)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.changelog.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t sboms < <(find sboms -type f -name '*.cdx.json')
+          if [ "${#sboms[@]}" -eq 0 ]; then
+            echo "::warning::No SBOMs found to attach."
+            exit 0
+          fi
+          gh release upload "$TAG" "${sboms[@]}" --clobber --repo "$REPO"
 
   # --------------------------------------------------- notify linked issues
   # Comment on every issue the released PR was linked to (closing keywords in

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **A modern, self-hosted torrent topic monitor for the trackers the *arr stack can't reach.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release: v1.11.2](https://img.shields.io/badge/release-v1.11.2-success.svg)](CHANGELOG.md)
+[![Release: v1.12.0](https://img.shields.io/badge/release-v1.12.0-success.svg)](CHANGELOG.md)
 
 [![CI](https://github.com/artyomsv/marauder/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/artyomsv/marauder/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/codeql.yml)
@@ -84,7 +84,7 @@ Read the full rationale: [VISION.md](docs/VISION.md) ·
 
 ## Project status
 
-**v1.11.2** — latest release (v1.0.0 was the initial production cut;
+**v1.12.0** — latest release (v1.0.0 was the initial production cut;
 v1.0.1 was the first release to publish container images to GHCR).
 
 What works **today**:
@@ -149,7 +149,7 @@ docker compose -f docker-compose.ghcr.yml --env-file .env up -d
 ```
 
 Requires Docker Compose **v2.23.1+**. Pin the release with `MARAUDER_VERSION`
-in `.env` (defaults to `1.11.2`); `latest` also exists.
+in `.env` (defaults to `1.12.0`); `latest` also exists.
 
 ### Build from source (contributors)
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -27,7 +27,7 @@ MARAUDER_ADMIN_INITIAL_PASSWORD=pleasechangeme
 # Which published image tag to pull from ghcr.io/artyomsv/marauder-*.
 # Pin to a release for reproducible deploys; `latest` floats with every
 # release. Ignored by the build-from-source stack (docker-compose.yml).
-MARAUDER_VERSION=1.11.2
+MARAUDER_VERSION=1.12.0
 
 # --- Database -------------------------------------------------------
 POSTGRES_DB=marauder

--- a/deploy/docker-compose.ghcr.yml
+++ b/deploy/docker-compose.ghcr.yml
@@ -21,7 +21,7 @@
 #   - The GHCR packages must be public. If `docker compose pull` fails with
 #     "denied" / 403, the maintainer has not flipped package visibility yet.
 #
-# Pin the version with MARAUDER_VERSION in .env (defaults to 1.11.2 below).
+# Pin the version with MARAUDER_VERSION in .env (defaults to 1.12.0 below).
 # `latest` also exists but floats with every release — pin for reproducible
 # deployments.
 
@@ -56,7 +56,7 @@ services:
         max-file: "3"
 
   backend:
-    image: ghcr.io/artyomsv/marauder-backend:${MARAUDER_VERSION:-1.11.2}
+    image: ghcr.io/artyomsv/marauder-backend:${MARAUDER_VERSION:-1.12.0}
     restart: unless-stopped
     depends_on:
       db:
@@ -99,7 +99,7 @@ services:
         max-file: "3"
 
   frontend:
-    image: ghcr.io/artyomsv/marauder-frontend:${MARAUDER_VERSION:-1.11.2}
+    image: ghcr.io/artyomsv/marauder-frontend:${MARAUDER_VERSION:-1.12.0}
     restart: unless-stopped
     depends_on:
       - backend
@@ -118,7 +118,7 @@ services:
 
   cfsolver:
     profiles: ["cfsolver"]
-    image: ghcr.io/artyomsv/marauder-cfsolver:${MARAUDER_VERSION:-1.11.2}
+    image: ghcr.io/artyomsv/marauder-cfsolver:${MARAUDER_VERSION:-1.12.0}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9244/health"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -49,8 +49,8 @@ services:
       context: ../backend
       dockerfile: Dockerfile
       args:
-        VERSION: "1.11.2"
-    image: marauder-backend:1.11.2
+        VERSION: "1.12.0"
+    image: marauder-backend:1.12.0
     restart: unless-stopped
     depends_on:
       db:
@@ -96,7 +96,7 @@ services:
     build:
       context: ../frontend
       dockerfile: Dockerfile
-    image: marauder-frontend:1.11.2
+    image: marauder-frontend:1.12.0
     restart: unless-stopped
     depends_on:
       - backend
@@ -118,7 +118,7 @@ services:
     build:
       context: ../cfsolver
       dockerfile: Dockerfile
-    image: marauder-cfsolver:1.11.2
+    image: marauder-cfsolver:1.12.0
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9244/health"]

--- a/site/src/data/seo.ts
+++ b/site/src/data/seo.ts
@@ -34,7 +34,7 @@ export const SITE = {
    *  release.yml's bump-dev-version job (sed + commit) — do not hand-edit it
    *  except to correct drift. */
   software: {
-    version: "1.11.2",
+    version: "1.12.0",
     license: "MIT",
     operatingSystem: "Linux, Docker, macOS, Windows",
     applicationCategory: "Utility",

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -79,7 +79,7 @@ const cmdHealth = `curl -fsS http://localhost:34080/health
 
 curl -sS http://localhost:34080/api/v1/system/info | jq .version
 # {
-#   "version": "1.11.2",
+#   "version": "1.12.0",
 #   "commit":  "...",
 #   "buildDate": "..."
 # }`;
@@ -136,7 +136,7 @@ const cmdLogin = `curl -sS -X POST http://localhost:34080/api/v1/auth/login \\
       <p class="mt-3 text-muted-foreground">
         Then open <a href="http://localhost:34080" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">http://localhost:34080</a>.
         Pin the release with <code>MARAUDER_VERSION</code> in <code>.env</code>
-        (defaults to <code>1.11.2</code>); <code>latest</code> also exists.
+        (defaults to <code>1.12.0</code>); <code>latest</code> also exists.
       </p>
     </section>
 


### PR DESCRIPTION
## Permanent fix: release version-sync no longer held hostage by SBOM asset uploads

### The bug

`release.yml` bundled two things into one "Create GitHub Release" step:
publishing the release **and** attaching SBOM assets (`files: sboms/**/*.cdx.json`
via `softprops/action-gh-release`). GitHub's release-asset API intermittently
404s on upload/metadata-update (eventual consistency), which failed the whole
`release` job. Because **`bump-dev-version` (Sync version references)** and
**`notify-issues`** both declare `needs: [release]`, they were then silently
**skipped** — so `README.md` and the marketing site (`marauder.cc`) stayed frozen
at the previous version, release after release. This is what happened on v1.12.0.

### The fix (so it can't recur)

Split the gating step:

1. **Create/publish the release with notes only** — no asset uploads, so it's
   reliable and downstream jobs run every time.
2. **Attach SBOMs best-effort** in a separate `continue-on-error` step using
   `gh release upload --clobber` — idempotent (safe on re-run) and free of the
   action's delete-then-reupload path that triggers the 404s.

A supply-chain-artifact hiccup can no longer skip the version sync or the issue
notification.

### One-time catch-up

The v1.12.0 release already shipped, but its version references were never
stamped (the `bump-dev-version` job was skipped). This PR also runs
`.github/scripts/bump-version-refs.sh 1.12.0` to correct `README.md`, the deploy
compose defaults, `.env.example`, and the site (`seo.ts`, `install.astro`) to
1.12.0. On merge, `site.yml` redeploys marauder.cc with the corrected version.

### Notes

- Titled `ci:` so auto-release cuts no new version for this infra change.
- No behavior change to the images, signing, or SBOM generation — only *how* the
  release is published and assets are attached.
- Verified: `release.yml` is valid YAML; the Astro site builds with the new
  version refs; `bump-version-refs.sh` is unit-tested.
