### PR TITLE
feat: in-app tracker search to add topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **In-app tracker search** (#129): the AddTopic card gains a **Search
+  trackers** tab — type a title, get live results from every searchable
+  tracker (Rutor public, RuTracker with a stored account), click one to
+  prefill the topic URL into the normal add flow. New optional
+  `registry.WithSearch` plugin capability, `GET /api/v1/trackers/search`
+  (concurrent per-tracker fan-out, fail-open, per-user single-flight
+  guard), `supports_search` in `/system/info`, and a
+  `marauder_tracker_search_total{tracker,result}` metric. Cyrillic
+  RuTracker queries are cp1251-encoded (`forumcommon.EncodeWindows1251Query`)
+  so they actually match.
+
 ## [1.12.0] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **In-app tracker search** (#129): the AddTopic card gains a **Search
   trackers** tab — type a title, get live results from every searchable
-  tracker (Rutor public, RuTracker with a stored account, LostFilm's
-  public series catalog), click one to prefill the topic URL into the
+  tracker (Rutor, Kinozal, LostFilm, and Anilibria anonymously; RuTracker
+  with a stored account), click one to prefill the topic URL into the
   normal add flow. New optional
   `registry.WithSearch` plugin capability, `GET /api/v1/trackers/search`
   (concurrent per-tracker fan-out, fail-open, per-user single-flight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **In-app tracker search** (#129): the AddTopic card gains a **Search
   trackers** tab — type a title, get live results from every searchable
-  tracker (Rutor public, RuTracker with a stored account), click one to
-  prefill the topic URL into the normal add flow. New optional
+  tracker (Rutor public, RuTracker with a stored account, LostFilm's
+  public series catalog), click one to prefill the topic URL into the
+  normal add flow. New optional
   `registry.WithSearch` plugin capability, `GET /api/v1/trackers/search`
   (concurrent per-tracker fan-out, fail-open, per-user single-flight
   guard), `supports_search` in `/system/info`, and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,12 +455,18 @@ public `/series/<slug>/seasons` page, reuses the episode parser); the
 AddTopic form uses it to constrain the "start from" season/episode
 selectors to released values.
 
-`WithSearch` (Rutor, RuTracker, LostFilm; issue #129) searches the tracker
-by free-text query and returns candidate topics (`SearchResult{Title, URL,
-Size, Seeders, Category}` — URL in canonical form so it feeds the normal
-match→parse→create pipeline). LostFilm searches its public JSON endpoint
-(`/ajaxik.php?act=common&type=search`) and returns series pages
-(Seeders -1, Category "Series") — subscribing, not grabbing a release. `GET /api/v1/trackers/search?q=&trackers=`
+`WithSearch` (Rutor, RuTracker, LostFilm, Kinozal, Anilibria; issue #129)
+searches the tracker by free-text query and returns candidate topics
+(`SearchResult{Title, URL, Size, Seeders, Category}` — URL in canonical
+form so it feeds the normal match→parse→create pipeline). LostFilm
+searches its public JSON endpoint (`/ajaxik.php?act=common&type=search`)
+and returns series pages (Seeders -1, Category "Series") — subscribing,
+not grabbing a release; Anilibria reuses the AniLiberty v1
+`/app/search/releases` endpoint the check path already depends on and
+returns aniliberty.top release pages; Kinozal scrapes public `browse.php`
+(cp1251 query, mixed attribute quoting in live markup — regexes tolerate
+single/double/no quotes, and the size cell is identified by looking like
+a size, not by position). `GET /api/v1/trackers/search?q=&trackers=`
 fans out to all `WithSearch` trackers concurrently (15s per tracker,
 fail-open per tracker into an `errors` array, per-user single-flight →
 429, metric `marauder_tracker_search_total{tracker,result}`); for a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,10 +455,12 @@ public `/series/<slug>/seasons` page, reuses the episode parser); the
 AddTopic form uses it to constrain the "start from" season/episode
 selectors to released values.
 
-`WithSearch` (Rutor, RuTracker; issue #129) searches the tracker by
-free-text query and returns candidate topics (`SearchResult{Title, URL,
+`WithSearch` (Rutor, RuTracker, LostFilm; issue #129) searches the tracker
+by free-text query and returns candidate topics (`SearchResult{Title, URL,
 Size, Seeders, Category}` — URL in canonical form so it feeds the normal
-match→parse→create pipeline). `GET /api/v1/trackers/search?q=&trackers=`
+match→parse→create pipeline). LostFilm searches its public JSON endpoint
+(`/ajaxik.php?act=common&type=search`) and returns series pages
+(Seeders -1, Category "Series") — subscribing, not grabbing a release. `GET /api/v1/trackers/search?q=&trackers=`
 fans out to all `WithSearch` trackers concurrently (15s per tracker,
 fail-open per tracker into an `errors` array, per-user single-flight →
 429, metric `marauder_tracker_search_total{tracker,result}`); for a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ unit test plus an e2e test using `plugins/e2etest.HostRewriteTransport`.
 
 Optional capability interfaces: `WithQuality`, `WithEpisodeFilter`,
 `WithCredentials`, `WithAnonymousDownload`, `WithCloudflare`, `WithInteractiveLogin`,
-`WithSeasonCatalog`, `WithMetadata`, `WithAuthorComment`. `WithAnonymousDownload` (RuTracker)
+`WithSeasonCatalog`, `WithMetadata`, `WithAuthorComment`, `WithSearch`. `WithAnonymousDownload` (RuTracker)
 marks a `WithCredentials` tracker whose download also works without an account, so
 `/trackers/match` reports `credentials_optional` (not `requires_credentials`) and the
 AddTopic form shows an optional hint instead of a "requires login" warning. The
@@ -454,6 +454,24 @@ seasons/episodes from `GET /api/v1/trackers/seasons?url=` (fetches the
 public `/series/<slug>/seasons` page, reuses the episode parser); the
 AddTopic form uses it to constrain the "start from" season/episode
 selectors to released values.
+
+`WithSearch` (Rutor, RuTracker; issue #129) searches the tracker by
+free-text query and returns candidate topics (`SearchResult{Title, URL,
+Size, Seeders, Category}` — URL in canonical form so it feeds the normal
+match→parse→create pipeline). `GET /api/v1/trackers/search?q=&trackers=`
+fans out to all `WithSearch` trackers concurrently (15s per tracker,
+fail-open per tracker into an `errors` array, per-user single-flight →
+429, metric `marauder_tracker_search_total{tracker,result}`); for a
+`WithCredentials` searcher it loads+decrypts the user's credential and
+warms the session Verify-first/Login-on-miss, degrading to nil creds on
+any failure (RuTracker then returns the
+`registry.ErrSearchRequiresCredentials` sentinel → "needs an account"
+notice). RuTracker's `nm=` query must be cp1251-percent-encoded —
+`forumcommon.EncodeWindows1251Query`. `supports_search` is surfaced per
+tracker in `/system/info`. Frontend: `AddTopicCard` hosts a By-URL /
+Search mode toggle; `components/topics/TrackerSearch` renders the
+explicit-submit search UI and hands the picked URL back via key-remount
+of `TopicForm` (TopicForm itself untouched).
 
 `WithMetadata` (RuTracker, LostFilm, Kinozal, NNM-Club) resolves a real title + poster image
 from a topic URL. It is called best-effort (fail-open, short timeout) at add

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ What works **today**:
 - 16 tracker plugins, 5 torrent-client plugins, 4 notifier plugins.
 - In-app cross-tracker search: type a title in the Add-topic form,
   pick a result, monitor it — no browser trip to find the topic URL
-  (Rutor public, RuTracker with a stored account).
+  (Rutor + LostFilm public, RuTracker with a stored account).
 - Generic-magnet → qBittorrent end-to-end pipeline validated against
   a real qBittorrent docker container — see
   [`docs/test-e2e-magnet.md`](docs/test-e2e-magnet.md).

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ What works **today**:
 - OIDC sign-in via Keycloak (or any OIDC provider). Bring up the
   bundled Keycloak realm with the `sso` compose profile.
 - 16 tracker plugins, 5 torrent-client plugins, 4 notifier plugins.
+- In-app cross-tracker search: type a title in the Add-topic form,
+  pick a result, monitor it — no browser trip to find the topic URL
+  (Rutor public, RuTracker with a stored account).
 - Generic-magnet → qBittorrent end-to-end pipeline validated against
   a real qBittorrent docker container — see
   [`docs/test-e2e-magnet.md`](docs/test-e2e-magnet.md).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ What works **today**:
 - 16 tracker plugins, 5 torrent-client plugins, 4 notifier plugins.
 - In-app cross-tracker search: type a title in the Add-topic form,
   pick a result, monitor it — no browser trip to find the topic URL
-  (Rutor + LostFilm public, RuTracker with a stored account).
+  (Rutor, Kinozal, LostFilm, Anilibria public; RuTracker with a
+  stored account).
 - Generic-magnet → qBittorrent end-to-end pipeline validated against
   a real qBittorrent docker container — see
   [`docs/test-e2e-magnet.md`](docs/test-e2e-magnet.md).

--- a/backend/internal/api/handlers/system.go
+++ b/backend/internal/api/handlers/system.go
@@ -103,11 +103,13 @@ func listTrackerInfos(items []registry.Tracker) []map[string]any {
 	for _, t := range items {
 		_, interactive := t.(registry.WithInteractiveLogin)
 		_, hasCreds := t.(registry.WithCredentials)
+		_, hasSearch := t.(registry.WithSearch)
 		out = append(out, map[string]any{
 			"name":                       t.Name(),
 			"display_name":               t.DisplayName(),
 			"supports_interactive_login": interactive,
 			"supports_credentials":       hasCreds,
+			"supports_search":            hasSearch,
 		})
 	}
 	return out

--- a/backend/internal/api/handlers/trackers.go
+++ b/backend/internal/api/handlers/trackers.go
@@ -20,8 +20,12 @@ type Trackers struct {
 	BaseURL string
 	Creds   credentialStore   // nil-safe: login-gated search degrades to anonymous when absent
 	Master  *crypto.MasterKey // decrypts stored credentials for login-gated search
+	// SearchBudget overrides the per-tracker search timeout (tests); zero
+	// means the 15s default.
+	SearchBudget time.Duration
 
 	searchInFlight sync.Map // userID -> struct{}; per-user single-flight search gate
+	searchLast     sync.Map // userID -> time.Time; sequential-search cooldown gate
 }
 
 // trackerMatch is the response shape for GET /api/v1/trackers/match.

--- a/backend/internal/api/handlers/trackers.go
+++ b/backend/internal/api/handlers/trackers.go
@@ -4,18 +4,24 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/artyomsv/marauder/backend/internal/crypto"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 	"github.com/artyomsv/marauder/backend/internal/problem"
 )
 
 // Trackers handles /trackers/* — capability discovery for the AddTopic
-// form. The frontend pastes a URL, debounces, then calls /match to
-// learn what optional fields the tracker supports (quality picker,
-// episode filter, credentials requirement, etc.).
+// form (the frontend pastes a URL, debounces, then calls /match to learn
+// what optional fields the tracker supports) plus the cross-tracker
+// release search (issue #129).
 type Trackers struct {
 	BaseURL string
+	Creds   credentialStore   // nil-safe: login-gated search degrades to anonymous when absent
+	Master  *crypto.MasterKey // decrypts stored credentials for login-gated search
+
+	searchInFlight sync.Map // userID -> struct{}; per-user single-flight search gate
 }
 
 // trackerMatch is the response shape for GET /api/v1/trackers/match.

--- a/backend/internal/api/handlers/trackers_search.go
+++ b/backend/internal/api/handlers/trackers_search.go
@@ -119,7 +119,12 @@ func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
 		problem.Write(w, r, h.BaseURL, problem.ErrTooManyRequests("searching too fast; wait a moment"))
 		return
 	}
-	h.searchLast.Store(uid, time.Now())
+	// Stamp at completion, not admission: a search that itself takes longer
+	// than the cooldown would otherwise leave no cooldown at all. Must be a
+	// closure — a plain `defer Store(uid, time.Now())` evaluates time.Now()
+	// at the defer statement (admission time again). Registered only after
+	// the gate passes so rejected attempts can't keep extending the window.
+	defer func() { h.searchLast.Store(uid, time.Now()) }()
 
 	var searchers []registry.WithSearch
 	for _, t := range registry.ListTrackers() {

--- a/backend/internal/api/handlers/trackers_search.go
+++ b/backend/internal/api/handlers/trackers_search.go
@@ -1,0 +1,195 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/metrics"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/problem"
+)
+
+const (
+	searchQueryMaxRunes    = 200
+	searchPerTrackerBudget = 15 * time.Second
+)
+
+// searchResultView is one row of GET /trackers/search — a registry result
+// plus which tracker produced it.
+type searchResultView struct {
+	TrackerName        string `json:"tracker_name"`
+	TrackerDisplayName string `json:"tracker_display_name"`
+	registry.SearchResult
+}
+
+// searchErrorView reports one tracker's failure without failing the whole
+// search (per-tracker fail-open).
+type searchErrorView struct {
+	TrackerName string `json:"tracker_name"`
+	Error       string `json:"error"`
+}
+
+// Search handles GET /api/v1/trackers/search?q=<query>&trackers=<csv>.
+// Fans out to every WithSearch tracker concurrently; per-tracker failures
+// degrade to entries in `errors` (fail-open) — only a bad request shape
+// produces a non-200. A per-user single-flight gate returns 429 on
+// concurrent searches: every call triggers real scraping requests, and a
+// runaway loop could get the instance's IP banned by trackers.
+//
+// Deliberate non-behaviour: search failures do NOT feed
+// domains.Store.ReportFailure — domain rotation stays scheduler-driven so
+// an interactive search hitting a cold mirror can't spin the ring the
+// scheduler depends on.
+func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
+	uid, perr := currentUserID(r)
+	if perr != nil {
+		problem.Write(w, r, h.BaseURL, perr)
+		return
+	}
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+	if q == "" {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("q query parameter is required"))
+		return
+	}
+	if utf8.RuneCountInString(q) > searchQueryMaxRunes {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("query too long (max 200 characters)"))
+		return
+	}
+	var filter map[string]bool
+	if raw := strings.TrimSpace(r.URL.Query().Get("trackers")); raw != "" {
+		filter = map[string]bool{}
+		for _, n := range strings.Split(raw, ",") {
+			if n = strings.TrimSpace(n); n != "" {
+				filter[n] = true
+			}
+		}
+	}
+	if _, busy := h.searchInFlight.LoadOrStore(uid, struct{}{}); busy {
+		problem.Write(w, r, h.BaseURL, problem.ErrTooManyRequests("a search is already running; wait for it to finish"))
+		return
+	}
+	defer h.searchInFlight.Delete(uid)
+
+	var searchers []registry.WithSearch
+	for _, t := range registry.ListTrackers() {
+		ws, ok := t.(registry.WithSearch)
+		if !ok || (filter != nil && !filter[t.Name()]) {
+			continue
+		}
+		searchers = append(searchers, ws)
+	}
+
+	type outcome struct {
+		results []searchResultView
+		errView *searchErrorView
+	}
+	outcomes := make([]outcome, len(searchers))
+	done := make(chan struct{})
+	for i, ws := range searchers {
+		go func(i int, ws registry.WithSearch) {
+			defer func() { done <- struct{}{} }()
+			ctx, cancel := context.WithTimeout(r.Context(), searchPerTrackerBudget)
+			defer cancel()
+			name := ws.Name()
+			creds := h.searchCredentials(ctx, uid, ws)
+			results, err := ws.Search(ctx, q, creds)
+			switch {
+			case errors.Is(err, registry.ErrSearchRequiresCredentials):
+				metrics.TrackerSearchTotal.WithLabelValues(name, "no_credentials").Inc()
+				outcomes[i] = outcome{errView: &searchErrorView{TrackerName: name, Error: "search requires credentials"}}
+			case err != nil:
+				metrics.TrackerSearchTotal.WithLabelValues(name, "error").Inc()
+				log.Warn().Str("tracker", name).Err(err).Msg("tracker search failed")
+				outcomes[i] = outcome{errView: &searchErrorView{TrackerName: name, Error: err.Error()}}
+			default:
+				metrics.TrackerSearchTotal.WithLabelValues(name, "ok").Inc()
+				views := make([]searchResultView, 0, len(results))
+				for _, res := range results {
+					views = append(views, searchResultView{
+						TrackerName:        name,
+						TrackerDisplayName: ws.DisplayName(),
+						SearchResult:       res,
+					})
+				}
+				outcomes[i] = outcome{results: views}
+			}
+		}(i, ws)
+	}
+	for range searchers {
+		<-done
+	}
+
+	results := []searchResultView{}
+	errViews := []searchErrorView{}
+	for _, o := range outcomes {
+		results = append(results, o.results...)
+		if o.errView != nil {
+			errViews = append(errViews, *o.errView)
+		}
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Seeders != results[j].Seeders {
+			return results[i].Seeders > results[j].Seeders // unknown (-1) sorts last
+		}
+		return results[i].TrackerName < results[j].TrackerName
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results, "errors": errViews})
+}
+
+// searchCredentials loads, decrypts, and warms the user's credential for a
+// login-gated searchable tracker. Every failure degrades to nil (the plugin
+// then reports ErrSearchRequiresCredentials) — search must never hard-fail
+// on credential trouble. Ordering is Verify-first, Login-on-miss: on a warm
+// in-process session Verify is one cheap GET; only a cold/dead session pays
+// the Login round-trip. (Deliberately neither loginAndVerify — Login→Verify
+// always, right for validating fresh credentials, wasteful per search — nor
+// the scheduler's Login-only loadCredentials.)
+func (h *Trackers) searchCredentials(ctx context.Context, uid uuid.UUID, t registry.Tracker) *domain.TrackerCredential {
+	wc, needsCreds := t.(registry.WithCredentials)
+	if !needsCreds || h.Creds == nil || h.Master == nil {
+		return nil
+	}
+	stored, err := h.Creds.GetForTracker(ctx, uid, t.Name())
+	if err != nil || stored == nil {
+		return nil
+	}
+	// Decrypt secret + session like Credentials.Test does — session-cookie
+	// trackers validate the session blob, not the password.
+	plain, err := h.Master.Decrypt(stored.SecretEnc, stored.SecretNonce)
+	if err != nil {
+		log.Warn().Str("tracker", t.Name()).Err(err).Msg("search credential decrypt failed; searching anonymously")
+		return nil
+	}
+	transient := &domain.TrackerCredential{
+		ID:          stored.ID,
+		UserID:      uid,
+		TrackerName: stored.TrackerName,
+		Username:    stored.Username,
+		SecretEnc:   plain,
+	}
+	if len(stored.SessionEnc) > 0 {
+		sess, derr := h.Master.Decrypt(stored.SessionEnc, stored.SessionNonce)
+		if derr != nil {
+			log.Warn().Str("tracker", t.Name()).Err(derr).Msg("search session decrypt failed; searching anonymously")
+			return nil
+		}
+		transient.SessionEnc = sess
+	}
+	if ok, verr := wc.Verify(ctx, transient); verr == nil && ok {
+		return transient
+	}
+	if lerr := wc.Login(ctx, transient); lerr != nil {
+		log.Debug().Str("tracker", t.Name()).Err(lerr).Msg("search credential login failed; searching anonymously")
+		return nil
+	}
+	return transient
+}

--- a/backend/internal/api/handlers/trackers_search.go
+++ b/backend/internal/api/handlers/trackers_search.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -19,9 +21,29 @@ import (
 )
 
 const (
-	searchQueryMaxRunes    = 200
-	searchPerTrackerBudget = 15 * time.Second
+	searchQueryMaxRunes           = 200
+	defaultSearchPerTrackerBudget = 15 * time.Second
+	searchCooldown                = 2 * time.Second
 )
+
+// Stable per-tracker error codes for the search response. The frontend
+// switches on these; the human-readable text is a canned message, never a
+// raw Go error chain — transport errors embed admin-configured mirror
+// hosts, resolved IPs, and proxy topology that non-admin users must not
+// see (the raw error is server-logged instead).
+const (
+	searchErrNoCredentials = "no_credentials"
+	searchErrLoginFailed   = "login_failed"
+	searchErrTimeout       = "timeout"
+	searchErrFailed        = "failed"
+)
+
+var searchErrMessages = map[string]string{
+	searchErrNoCredentials: "search requires credentials",
+	searchErrLoginFailed:   "tracker login failed",
+	searchErrTimeout:       "search timed out",
+	searchErrFailed:        "search failed",
+}
 
 // searchResultView is one row of GET /trackers/search — a registry result
 // plus which tracker produced it.
@@ -32,18 +54,32 @@ type searchResultView struct {
 }
 
 // searchErrorView reports one tracker's failure without failing the whole
-// search (per-tracker fail-open).
+// search (per-tracker fail-open). Code is one of the searchErr* constants;
+// Error is the matching canned message (kept for display fallback).
 type searchErrorView struct {
-	TrackerName string `json:"tracker_name"`
-	Error       string `json:"error"`
+	TrackerName        string `json:"tracker_name"`
+	TrackerDisplayName string `json:"tracker_display_name"`
+	Code               string `json:"code"`
+	Error              string `json:"error"`
+}
+
+func newSearchErrorView(ws registry.WithSearch, code string) *searchErrorView {
+	return &searchErrorView{
+		TrackerName:        ws.Name(),
+		TrackerDisplayName: ws.DisplayName(),
+		Code:               code,
+		Error:              searchErrMessages[code],
+	}
 }
 
 // Search handles GET /api/v1/trackers/search?q=<query>&trackers=<csv>.
 // Fans out to every WithSearch tracker concurrently; per-tracker failures
 // degrade to entries in `errors` (fail-open) — only a bad request shape
-// produces a non-200. A per-user single-flight gate returns 429 on
-// concurrent searches: every call triggers real scraping requests, and a
-// runaway loop could get the instance's IP banned by trackers.
+// produces a non-200. Two abuse gates protect the trackers (every call
+// triggers real scraping requests, and hammering them is how instances
+// get IP-banned — and a dead session means each search replays a real
+// login): a per-user single-flight (concurrent search → 429) and a short
+// per-user cooldown between sequential searches (→ 429).
 //
 // Deliberate non-behaviour: search failures do NOT feed
 // domains.Store.ReportFailure — domain rotation stays scheduler-driven so
@@ -61,7 +97,8 @@ func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if utf8.RuneCountInString(q) > searchQueryMaxRunes {
-		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("query too long (max 200 characters)"))
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest(
+			fmt.Sprintf("query too long (max %d characters)", searchQueryMaxRunes)))
 		return
 	}
 	var filter map[string]bool
@@ -78,6 +115,11 @@ func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer h.searchInFlight.Delete(uid)
+	if last, ok := h.searchLast.Load(uid); ok && time.Since(last.(time.Time)) < searchCooldown {
+		problem.Write(w, r, h.BaseURL, problem.ErrTooManyRequests("searching too fast; wait a moment"))
+		return
+	}
+	h.searchLast.Store(uid, time.Now())
 
 	var searchers []registry.WithSearch
 	for _, t := range registry.ListTrackers() {
@@ -93,23 +135,44 @@ func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
 		errView *searchErrorView
 	}
 	outcomes := make([]outcome, len(searchers))
-	done := make(chan struct{})
+	var wg sync.WaitGroup
 	for i, ws := range searchers {
+		wg.Add(1)
 		go func(i int, ws registry.WithSearch) {
-			defer func() { done <- struct{}{} }()
-			ctx, cancel := context.WithTimeout(r.Context(), searchPerTrackerBudget)
+			defer wg.Done()
+			// A panic in a plugin's Search must not kill the process: chi's
+			// Recoverer only covers the handler goroutine, not these children.
+			defer func() {
+				if rec := recover(); rec != nil {
+					log.Error().Str("tracker", ws.Name()).Any("panic", rec).
+						Msg("tracker search panicked")
+					metrics.TrackerSearchTotal.WithLabelValues(ws.Name(), "error").Inc()
+					outcomes[i] = outcome{errView: newSearchErrorView(ws, searchErrFailed)}
+				}
+			}()
+			ctx, cancel := context.WithTimeout(r.Context(), h.perTrackerBudget())
 			defer cancel()
 			name := ws.Name()
-			creds := h.searchCredentials(ctx, uid, ws)
+			creds, loginFailed := h.searchCredentials(ctx, uid, ws)
 			results, err := ws.Search(ctx, q, creds)
 			switch {
 			case errors.Is(err, registry.ErrSearchRequiresCredentials):
-				metrics.TrackerSearchTotal.WithLabelValues(name, "no_credentials").Inc()
-				outcomes[i] = outcome{errView: &searchErrorView{TrackerName: name, Error: "search requires credentials"}}
+				// A stored-but-unusable credential is a different user story
+				// ("your login broke") than a missing one ("add an account").
+				code := searchErrNoCredentials
+				if loginFailed {
+					code = searchErrLoginFailed
+				}
+				metrics.TrackerSearchTotal.WithLabelValues(name, code).Inc()
+				outcomes[i] = outcome{errView: newSearchErrorView(ws, code)}
 			case err != nil:
+				code := searchErrFailed
+				if errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+					code = searchErrTimeout
+				}
 				metrics.TrackerSearchTotal.WithLabelValues(name, "error").Inc()
 				log.Warn().Str("tracker", name).Err(err).Msg("tracker search failed")
-				outcomes[i] = outcome{errView: &searchErrorView{TrackerName: name, Error: err.Error()}}
+				outcomes[i] = outcome{errView: newSearchErrorView(ws, code)}
 			default:
 				metrics.TrackerSearchTotal.WithLabelValues(name, "ok").Inc()
 				views := make([]searchResultView, 0, len(results))
@@ -124,9 +187,7 @@ func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
 			}
 		}(i, ws)
 	}
-	for range searchers {
-		<-done
-	}
+	wg.Wait()
 
 	results := []searchResultView{}
 	errViews := []searchErrorView{}
@@ -145,29 +206,43 @@ func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"results": results, "errors": errViews})
 }
 
+// perTrackerBudget returns the per-tracker search timeout — the test seam
+// SearchBudget overrides the 15s default.
+func (h *Trackers) perTrackerBudget() time.Duration {
+	if h.SearchBudget > 0 {
+		return h.SearchBudget
+	}
+	return defaultSearchPerTrackerBudget
+}
+
 // searchCredentials loads, decrypts, and warms the user's credential for a
-// login-gated searchable tracker. Every failure degrades to nil (the plugin
-// then reports ErrSearchRequiresCredentials) — search must never hard-fail
-// on credential trouble. Ordering is Verify-first, Login-on-miss: on a warm
-// in-process session Verify is one cheap GET; only a cold/dead session pays
-// the Login round-trip. (Deliberately neither loginAndVerify — Login→Verify
-// always, right for validating fresh credentials, wasteful per search — nor
-// the scheduler's Login-only loadCredentials.)
-func (h *Trackers) searchCredentials(ctx context.Context, uid uuid.UUID, t registry.Tracker) *domain.TrackerCredential {
+// login-gated searchable tracker. Every failure degrades to nil creds
+// (the plugin then reports ErrSearchRequiresCredentials) — search must
+// never hard-fail on credential trouble. The second return distinguishes
+// "no stored credential" (false) from "stored credential exists but could
+// not be warmed" (true) so the caller can report login_failed instead of
+// telling a user with an account to go add one.
+//
+// Ordering is Verify-first, Login-on-miss: on a warm in-process session
+// Verify is one cheap GET; only a cold/dead session pays the Login round-
+// trip. (Deliberately neither loginAndVerify — Login→Verify always, right
+// for validating fresh credentials, wasteful per search — nor the
+// scheduler's Login-only loadCredentials.)
+func (h *Trackers) searchCredentials(ctx context.Context, uid uuid.UUID, t registry.Tracker) (creds *domain.TrackerCredential, loginFailed bool) {
 	wc, needsCreds := t.(registry.WithCredentials)
 	if !needsCreds || h.Creds == nil || h.Master == nil {
-		return nil
+		return nil, false
 	}
 	stored, err := h.Creds.GetForTracker(ctx, uid, t.Name())
 	if err != nil || stored == nil {
-		return nil
+		return nil, false
 	}
 	// Decrypt secret + session like Credentials.Test does — session-cookie
 	// trackers validate the session blob, not the password.
 	plain, err := h.Master.Decrypt(stored.SecretEnc, stored.SecretNonce)
 	if err != nil {
 		log.Warn().Str("tracker", t.Name()).Err(err).Msg("search credential decrypt failed; searching anonymously")
-		return nil
+		return nil, true
 	}
 	transient := &domain.TrackerCredential{
 		ID:          stored.ID,
@@ -180,16 +255,16 @@ func (h *Trackers) searchCredentials(ctx context.Context, uid uuid.UUID, t regis
 		sess, derr := h.Master.Decrypt(stored.SessionEnc, stored.SessionNonce)
 		if derr != nil {
 			log.Warn().Str("tracker", t.Name()).Err(derr).Msg("search session decrypt failed; searching anonymously")
-			return nil
+			return nil, true
 		}
 		transient.SessionEnc = sess
 	}
 	if ok, verr := wc.Verify(ctx, transient); verr == nil && ok {
-		return transient
+		return transient, false
 	}
 	if lerr := wc.Login(ctx, transient); lerr != nil {
 		log.Debug().Str("tracker", t.Name()).Err(lerr).Msg("search credential login failed; searching anonymously")
-		return nil
+		return nil, true
 	}
-	return transient
+	return transient, false
 }

--- a/backend/internal/api/handlers/trackers_search_test.go
+++ b/backend/internal/api/handlers/trackers_search_test.go
@@ -26,9 +26,9 @@ type fakeSearchTracker struct {
 	err     error
 }
 
-func (f *fakeSearchTracker) Name() string                                  { return f.name }
-func (f *fakeSearchTracker) DisplayName() string                           { return "Fake Search " + f.name }
-func (f *fakeSearchTracker) CanParse(string) bool                          { return false }
+func (f *fakeSearchTracker) Name() string                                         { return f.name }
+func (f *fakeSearchTracker) DisplayName() string                                  { return "Fake Search " + f.name }
+func (f *fakeSearchTracker) CanParse(string) bool                                 { return false }
 func (f *fakeSearchTracker) Parse(context.Context, string) (*domain.Topic, error) { return nil, nil }
 func (f *fakeSearchTracker) Check(context.Context, *domain.Topic, *domain.TrackerCredential) (*domain.Check, error) {
 	return nil, nil

--- a/backend/internal/api/handlers/trackers_search_test.go
+++ b/backend/internal/api/handlers/trackers_search_test.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/artyomsv/marauder/backend/internal/api/middleware"
 	"github.com/artyomsv/marauder/backend/internal/auth"
+	"github.com/artyomsv/marauder/backend/internal/crypto"
 	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 )
@@ -114,8 +117,10 @@ type searchResponse struct {
 		Seeders     int    `json:"seeders"`
 	} `json:"results"`
 	Errors []struct {
-		TrackerName string `json:"tracker_name"`
-		Error       string `json:"error"`
+		TrackerName        string `json:"tracker_name"`
+		TrackerDisplayName string `json:"tracker_display_name"`
+		Code               string `json:"code"`
+		Error              string `json:"error"`
 	} `json:"errors"`
 }
 
@@ -204,8 +209,8 @@ func TestSearch_CredsTrackerWithoutCredential_ReportsError(t *testing.T) {
 		t.Fatalf("results = %+v, want only 'public'", resp.Results)
 	}
 	if len(resp.Errors) != 1 || resp.Errors[0].TrackerName != "fake-search-gated" ||
-		resp.Errors[0].Error != "search requires credentials" {
-		t.Fatalf("errors = %+v, want gated needs-credentials entry", resp.Errors)
+		resp.Errors[0].Code != "no_credentials" {
+		t.Fatalf("errors = %+v, want gated no_credentials entry", resp.Errors)
 	}
 }
 
@@ -257,5 +262,205 @@ func TestListTrackerInfos_SupportsSearchFlag(t *testing.T) {
 	}
 	if infos[1]["supports_search"] != false {
 		t.Errorf("plain tracker: supports_search = %v, want false", infos[1]["supports_search"])
+	}
+}
+
+// fakeErrSearchTracker always fails with a generic (non-sentinel) error.
+type fakeErrSearchTracker struct{ fakeSearchTracker }
+
+func (f *fakeErrSearchTracker) Search(context.Context, string, *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	return nil, errors.New("GET https://secret-mirror.internal:3128 -> 503")
+}
+
+// fakeHangSearchTracker blocks until its context expires and returns the
+// context error, for the per-tracker timeout test.
+type fakeHangSearchTracker struct{ fakeSearchTracker }
+
+func (f *fakeHangSearchTracker) Search(ctx context.Context, _ string, _ *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// fakeWarmTracker is WithCredentials + WithSearch and records the creds the
+// handler warmed for it, for the searchCredentials branch tests.
+type fakeWarmTracker struct {
+	fakeSearchTracker
+	verifyOK bool
+	loginErr error
+	gotCreds *domain.TrackerCredential
+}
+
+func (f *fakeWarmTracker) Login(context.Context, *domain.TrackerCredential) error { return f.loginErr }
+func (f *fakeWarmTracker) Verify(context.Context, *domain.TrackerCredential) (bool, error) {
+	return f.verifyOK, nil
+}
+func (f *fakeWarmTracker) Search(_ context.Context, _ string, creds *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	f.gotCreds = creds
+	if creds == nil {
+		return nil, registry.ErrSearchRequiresCredentials
+	}
+	return []registry.SearchResult{{Title: "authed", URL: "https://warm.test/1", Seeders: 1}}, nil
+}
+
+func testMasterKey(t *testing.T) *crypto.MasterKey {
+	t.Helper()
+	mk, err := crypto.LoadMasterKey(base64.StdEncoding.EncodeToString([]byte(strings.Repeat("k", 32))))
+	if err != nil {
+		t.Fatalf("load master key: %v", err)
+	}
+	return mk
+}
+
+func encryptedCred(t *testing.T, mk *crypto.MasterKey, tracker string) *domain.TrackerCredential {
+	t.Helper()
+	enc, nonce, err := mk.Encrypt([]byte("hunter2"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	return &domain.TrackerCredential{
+		ID: uuid.New(), UserID: uuid.New(), TrackerName: tracker,
+		Username: "user", SecretEnc: enc, SecretNonce: nonce,
+	}
+}
+
+func TestSearch_TrackerError_ClassifiedNotLeaked(t *testing.T) {
+	registry.RegisterTracker(&fakeErrSearchTracker{fakeSearchTracker{name: "fake-search-err"}})
+
+	h := &Trackers{BaseURL: "http://test"}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, uuid.New(), "q=test&trackers=fake-search-err"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Errors) != 1 {
+		t.Fatalf("errors = %+v, want 1", resp.Errors)
+	}
+	if resp.Errors[0].Code != "failed" {
+		t.Errorf("code = %q, want failed", resp.Errors[0].Code)
+	}
+	// The raw transport error (internal hostnames) must never reach the client.
+	if strings.Contains(w.Body.String(), "secret-mirror.internal") {
+		t.Error("raw error text leaked into the response body")
+	}
+}
+
+func TestSearch_HungTracker_TimesOutOthersStillReturn(t *testing.T) {
+	registry.RegisterTracker(&fakeHangSearchTracker{fakeSearchTracker{name: "fake-search-hang"}})
+	registry.RegisterTracker(&fakeSearchTracker{name: "fake-search-fast", results: []registry.SearchResult{
+		{Title: "quick", URL: "https://fast.test/1", Seeders: 4},
+	}})
+
+	h := &Trackers{BaseURL: "http://test", SearchBudget: 50 * time.Millisecond}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, uuid.New(), "q=test&trackers=fake-search-hang,fake-search-fast"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].Title != "quick" {
+		t.Fatalf("results = %+v, want quick only", resp.Results)
+	}
+	if len(resp.Errors) != 1 || resp.Errors[0].Code != "timeout" {
+		t.Fatalf("errors = %+v, want one timeout", resp.Errors)
+	}
+}
+
+func TestSearch_SequentialTooFast_TooManyRequests(t *testing.T) {
+	registry.RegisterTracker(&fakeSearchTracker{name: "fake-search-cooldown"})
+
+	h := &Trackers{BaseURL: "http://test"}
+	uid := uuid.New()
+	w1 := httptest.NewRecorder()
+	h.Search(w1, searchRequest(t, uid, "q=test&trackers=fake-search-cooldown"))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first search status = %d, want 200", w1.Code)
+	}
+	w2 := httptest.NewRecorder()
+	h.Search(w2, searchRequest(t, uid, "q=test&trackers=fake-search-cooldown"))
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("immediate second search status = %d, want 429", w2.Code)
+	}
+}
+
+func TestSearchCredentials_VerifyOK_UsesStoredCredential(t *testing.T) {
+	mk := testMasterKey(t)
+	cred := encryptedCred(t, mk, "fake-warm-verify")
+	warm := &fakeWarmTracker{fakeSearchTracker: fakeSearchTracker{name: "fake-warm-verify"}, verifyOK: true}
+	registry.RegisterTracker(warm)
+
+	h := &Trackers{BaseURL: "http://test", Creds: &fakeSearchCredStore{cred: cred}, Master: mk}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, cred.UserID, "q=test&trackers=fake-warm-verify"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].Title != "authed" {
+		t.Fatalf("results = %+v, want authed", resp.Results)
+	}
+	if warm.gotCreds == nil || string(warm.gotCreds.SecretEnc) != "hunter2" {
+		t.Fatalf("plugin creds = %+v, want decrypted secret", warm.gotCreds)
+	}
+}
+
+func TestSearchCredentials_VerifyFailLoginOK_UsesStoredCredential(t *testing.T) {
+	mk := testMasterKey(t)
+	cred := encryptedCred(t, mk, "fake-warm-login")
+	warm := &fakeWarmTracker{fakeSearchTracker: fakeSearchTracker{name: "fake-warm-login"}, verifyOK: false}
+	registry.RegisterTracker(warm)
+
+	h := &Trackers{BaseURL: "http://test", Creds: &fakeSearchCredStore{cred: cred}, Master: mk}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, cred.UserID, "q=test&trackers=fake-warm-login"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("results = %+v, want 1 (login path should warm creds)", resp.Results)
+	}
+}
+
+func TestSearchCredentials_LoginFails_ReportsLoginFailed(t *testing.T) {
+	mk := testMasterKey(t)
+	cred := encryptedCred(t, mk, "fake-warm-dead")
+	warm := &fakeWarmTracker{
+		fakeSearchTracker: fakeSearchTracker{name: "fake-warm-dead"},
+		verifyOK:          false,
+		loginErr:          errors.New("bad password"),
+	}
+	registry.RegisterTracker(warm)
+
+	h := &Trackers{BaseURL: "http://test", Creds: &fakeSearchCredStore{cred: cred}, Master: mk}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, cred.UserID, "q=test&trackers=fake-warm-dead"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Errors) != 1 || resp.Errors[0].Code != "login_failed" {
+		t.Fatalf("errors = %+v, want login_failed (stored account, dead login)", resp.Errors)
+	}
+}
+
+func TestSearchCredentials_DecryptFails_ReportsLoginFailed(t *testing.T) {
+	mk := testMasterKey(t)
+	cred := &domain.TrackerCredential{
+		ID: uuid.New(), UserID: uuid.New(), TrackerName: "fake-warm-garbled",
+		Username: "user", SecretEnc: []byte("not-ciphertext"), SecretNonce: []byte("bad"),
+	}
+	warm := &fakeWarmTracker{fakeSearchTracker: fakeSearchTracker{name: "fake-warm-garbled"}, verifyOK: true}
+	registry.RegisterTracker(warm)
+
+	h := &Trackers{BaseURL: "http://test", Creds: &fakeSearchCredStore{cred: cred}, Master: mk}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, cred.UserID, "q=test&trackers=fake-warm-garbled"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Errors) != 1 || resp.Errors[0].Code != "login_failed" {
+		t.Fatalf("errors = %+v, want login_failed (undecryptable stored secret)", resp.Errors)
 	}
 }

--- a/backend/internal/api/handlers/trackers_search_test.go
+++ b/backend/internal/api/handlers/trackers_search_test.go
@@ -1,0 +1,261 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/artyomsv/marauder/backend/internal/api/middleware"
+	"github.com/artyomsv/marauder/backend/internal/auth"
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+)
+
+// fakeSearchTracker implements registry.Tracker + registry.WithSearch with a
+// canned public result set.
+type fakeSearchTracker struct {
+	name    string
+	results []registry.SearchResult
+	err     error
+}
+
+func (f *fakeSearchTracker) Name() string                                  { return f.name }
+func (f *fakeSearchTracker) DisplayName() string                           { return "Fake Search " + f.name }
+func (f *fakeSearchTracker) CanParse(string) bool                          { return false }
+func (f *fakeSearchTracker) Parse(context.Context, string) (*domain.Topic, error) { return nil, nil }
+func (f *fakeSearchTracker) Check(context.Context, *domain.Topic, *domain.TrackerCredential) (*domain.Check, error) {
+	return nil, nil
+}
+func (f *fakeSearchTracker) Download(context.Context, *domain.Topic, *domain.Check, *domain.TrackerCredential) (*domain.Payload, error) {
+	return nil, nil
+}
+func (f *fakeSearchTracker) Search(context.Context, string, *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	return f.results, f.err
+}
+
+// fakeCredsSearchTracker is login-gated: WithCredentials + WithSearch, and
+// Search demands a credential.
+type fakeCredsSearchTracker struct{ fakeSearchTracker }
+
+func (f *fakeCredsSearchTracker) Login(context.Context, *domain.TrackerCredential) error {
+	return nil
+}
+func (f *fakeCredsSearchTracker) Verify(context.Context, *domain.TrackerCredential) (bool, error) {
+	return true, nil
+}
+func (f *fakeCredsSearchTracker) Search(_ context.Context, _ string, creds *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	if creds == nil {
+		return nil, registry.ErrSearchRequiresCredentials
+	}
+	return f.results, nil
+}
+
+// fakeSlowSearchTracker blocks until released, for the single-flight test.
+type fakeSlowSearchTracker struct {
+	fakeSearchTracker
+	started chan struct{}
+	release chan struct{}
+}
+
+func (f *fakeSlowSearchTracker) Search(ctx context.Context, _ string, _ *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	close(f.started)
+	select {
+	case <-f.release:
+	case <-ctx.Done():
+	}
+	return nil, nil
+}
+
+// fakeSearchCredStore satisfies credentialStore; only GetForTracker matters here.
+type fakeSearchCredStore struct{ cred *domain.TrackerCredential }
+
+func (s *fakeSearchCredStore) Create(context.Context, *domain.TrackerCredential) (*domain.TrackerCredential, error) {
+	return nil, nil
+}
+func (s *fakeSearchCredStore) GetByID(context.Context, uuid.UUID, uuid.UUID) (*domain.TrackerCredential, error) {
+	return nil, nil
+}
+func (s *fakeSearchCredStore) GetForTracker(context.Context, uuid.UUID, string) (*domain.TrackerCredential, error) {
+	if s.cred == nil {
+		return nil, context.Canceled // any error means "no credential"
+	}
+	return s.cred, nil
+}
+func (s *fakeSearchCredStore) ListForUser(context.Context, uuid.UUID) ([]*domain.TrackerCredential, error) {
+	return nil, nil
+}
+func (s *fakeSearchCredStore) Update(context.Context, uuid.UUID, uuid.UUID, string, []byte, []byte) error {
+	return nil
+}
+func (s *fakeSearchCredStore) SetSession(context.Context, uuid.UUID, uuid.UUID, []byte, []byte) error {
+	return nil
+}
+func (s *fakeSearchCredStore) Delete(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+
+func searchRequest(t *testing.T, uid uuid.UUID, rawQuery string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/trackers/search?"+rawQuery, nil)
+	return req.WithContext(context.WithValue(req.Context(), middleware.CtxClaims,
+		&auth.Claims{UserID: uid.String()}))
+}
+
+type searchResponse struct {
+	Results []struct {
+		TrackerName string `json:"tracker_name"`
+		Title       string `json:"title"`
+		URL         string `json:"url"`
+		Seeders     int    `json:"seeders"`
+	} `json:"results"`
+	Errors []struct {
+		TrackerName string `json:"tracker_name"`
+		Error       string `json:"error"`
+	} `json:"errors"`
+}
+
+func TestSearch_MissingQuery_BadRequest(t *testing.T) {
+	h := &Trackers{BaseURL: "http://test"}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, uuid.New(), ""))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestSearch_QueryTooLong_BadRequest(t *testing.T) {
+	h := &Trackers{BaseURL: "http://test"}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, uuid.New(), "q="+strings.Repeat("x", 201)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestSearch_AggregatesAndSortsBySeeders(t *testing.T) {
+	registry.RegisterTracker(&fakeSearchTracker{name: "fake-search-a", results: []registry.SearchResult{
+		{Title: "low", URL: "https://a.test/1", Seeders: 5},
+		{Title: "unknown", URL: "https://a.test/2", Seeders: -1},
+	}})
+	registry.RegisterTracker(&fakeSearchTracker{name: "fake-search-b", results: []registry.SearchResult{
+		{Title: "high", URL: "https://b.test/1", Seeders: 12},
+	}})
+
+	h := &Trackers{BaseURL: "http://test"}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, uuid.New(), "q=test&trackers=fake-search-a,fake-search-b"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("results = %d, want 3", len(resp.Results))
+	}
+	if resp.Results[0].Title != "high" || resp.Results[1].Title != "low" || resp.Results[2].Title != "unknown" {
+		t.Errorf("sort order = %s,%s,%s", resp.Results[0].Title, resp.Results[1].Title, resp.Results[2].Title)
+	}
+	if len(resp.Errors) != 0 {
+		t.Errorf("errors = %+v, want none", resp.Errors)
+	}
+}
+
+func TestSearch_TrackerFilter_Restricts(t *testing.T) {
+	registry.RegisterTracker(&fakeSearchTracker{name: "fake-search-only", results: []registry.SearchResult{
+		{Title: "kept", URL: "https://only.test/1", Seeders: 1},
+	}})
+	registry.RegisterTracker(&fakeSearchTracker{name: "fake-search-excluded", results: []registry.SearchResult{
+		{Title: "dropped", URL: "https://ex.test/1", Seeders: 9},
+	}})
+
+	h := &Trackers{BaseURL: "http://test"}
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, uuid.New(), "q=test&trackers=fake-search-only"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].Title != "kept" {
+		t.Fatalf("results = %+v, want only 'kept'", resp.Results)
+	}
+}
+
+func TestSearch_CredsTrackerWithoutCredential_ReportsError(t *testing.T) {
+	registry.RegisterTracker(&fakeCredsSearchTracker{fakeSearchTracker{name: "fake-search-gated"}})
+	registry.RegisterTracker(&fakeSearchTracker{name: "fake-search-open", results: []registry.SearchResult{
+		{Title: "public", URL: "https://open.test/1", Seeders: 3},
+	}})
+
+	h := &Trackers{BaseURL: "http://test", Creds: &fakeSearchCredStore{}} // store has no credential
+	w := httptest.NewRecorder()
+	h.Search(w, searchRequest(t, uuid.New(), "q=test&trackers=fake-search-gated,fake-search-open"))
+	var resp searchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].Title != "public" {
+		t.Fatalf("results = %+v, want only 'public'", resp.Results)
+	}
+	if len(resp.Errors) != 1 || resp.Errors[0].TrackerName != "fake-search-gated" ||
+		resp.Errors[0].Error != "search requires credentials" {
+		t.Fatalf("errors = %+v, want gated needs-credentials entry", resp.Errors)
+	}
+}
+
+func TestSearch_SecondConcurrentRequest_TooManyRequests(t *testing.T) {
+	slow := &fakeSlowSearchTracker{
+		fakeSearchTracker: fakeSearchTracker{name: "fake-search-slow"},
+		started:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	registry.RegisterTracker(slow)
+
+	h := &Trackers{BaseURL: "http://test"}
+	uid := uuid.New()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w := httptest.NewRecorder()
+		h.Search(w, searchRequest(t, uid, "q=test&trackers=fake-search-slow"))
+	}()
+
+	select {
+	case <-slow.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("slow search never started")
+	}
+
+	w2 := httptest.NewRecorder()
+	h.Search(w2, searchRequest(t, uid, "q=test&trackers=fake-search-slow"))
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("concurrent search status = %d, want 429", w2.Code)
+	}
+
+	close(slow.release)
+	wg.Wait()
+}
+
+func TestListTrackerInfos_SupportsSearchFlag(t *testing.T) {
+	infos := listTrackerInfos([]registry.Tracker{
+		&fakeSearchTracker{name: "fake-info-search"},
+		&fakeNoSeasonTracker{name: "fake-info-plain"},
+	})
+	if len(infos) != 2 {
+		t.Fatalf("infos = %d, want 2", len(infos))
+	}
+	if infos[0]["supports_search"] != true {
+		t.Errorf("search-capable tracker: supports_search = %v, want true", infos[0]["supports_search"])
+	}
+	if infos[1]["supports_search"] != false {
+		t.Errorf("plain tracker: supports_search = %v, want false", infos[1]["supports_search"])
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -129,7 +129,7 @@ func NewRouter(d Deps) http.Handler {
 		Timeout:   10 * time.Second,
 		BaseURL:   d.Cfg.PublicBaseURL,
 	}
-	trackersH := &handlers.Trackers{BaseURL: d.Cfg.PublicBaseURL}
+	trackersH := &handlers.Trackers{BaseURL: d.Cfg.PublicBaseURL, Creds: d.Creds, Master: d.Master}
 	trackerDomainsH := &handlers.TrackerDomains{
 		Store:   d.TrackerSettings,
 		Probe:   handlers.DefaultDomainProbe,
@@ -170,6 +170,7 @@ func NewRouter(d Deps) http.Handler {
 			r.Get("/trackers/match", trackersH.Match)
 			r.Get("/trackers/seasons", trackersH.Seasons)
 			r.Get("/trackers/preview", trackersH.Preview)
+			r.Get("/trackers/search", trackersH.Search)
 
 			r.Get("/topics", topicsH.List)
 			r.Post("/topics", topicsH.Create)

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -70,7 +70,7 @@ var (
 			Name: "marauder_tracker_search_total",
 			Help: "Number of tracker search attempts, partitioned by tracker and result.",
 		},
-		[]string{"tracker", "result"}, // "ok" | "error" | "no_credentials"
+		[]string{"tracker", "result"}, // "ok" | "error" | "no_credentials" | "login_failed"
 	)
 
 	TrackerUpdatesTotal = promauto.NewCounterVec(

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -63,6 +63,16 @@ var (
 		[]string{"tracker"},
 	)
 
+	// TrackerSearchTotal counts interactive tracker searches (issue #129),
+	// partitioned by tracker and outcome.
+	TrackerSearchTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "marauder_tracker_search_total",
+			Help: "Number of tracker search attempts, partitioned by tracker and result.",
+		},
+		[]string{"tracker", "result"}, // "ok" | "error" | "no_credentials"
+	)
+
 	TrackerUpdatesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "marauder_tracker_updates_total",

--- a/backend/internal/plugins/registry/errors.go
+++ b/backend/internal/plugins/registry/errors.go
@@ -25,3 +25,9 @@ var ErrCaptchaRequired = errors.New("tracker requires a captcha")
 // no stored session exists or the stored session no longer authenticates.
 // The user must re-run the interactive (captcha) login flow.
 var ErrSessionExpired = errors.New("tracker session expired")
+
+// ErrSearchRequiresCredentials is returned by a WithSearch tracker whose
+// search page is login-gated (RuTracker's tracker.php) when no credential —
+// or no longer-valid session — is available. The search handler surfaces it
+// as a per-tracker "needs an account" notice instead of a hard failure.
+var ErrSearchRequiresCredentials = errors.New("search requires credentials")

--- a/backend/internal/plugins/registry/registry.go
+++ b/backend/internal/plugins/registry/registry.go
@@ -147,6 +147,32 @@ type WithAuthorComment interface {
 	AuthorComment(ctx context.Context, rawURL string, creds *domain.TrackerCredential) (string, error)
 }
 
+// SearchResult is one release found by a tracker search (issue #129). URL is
+// the topic page in the tracker's canonical form — exactly what a user would
+// paste into the AddTopic form, so every result feeds the existing
+// match → parse → create pipeline unchanged. Size and Category are
+// display-only strings exactly as scraped (no byte parsing — a mis-parsed
+// size would render as a confident wrong number). Seeders is -1 when the
+// tracker doesn't expose a count.
+type SearchResult struct {
+	Title    string `json:"title"`
+	URL      string `json:"url"`
+	Size     string `json:"size,omitempty"`
+	Seeders  int    `json:"seeders"`
+	Category string `json:"category,omitempty"`
+}
+
+// WithSearch is an optional tracker capability: search the tracker by free-
+// text query and return candidate topics to monitor. creds may be nil; a
+// tracker whose search page is login-gated returns
+// ErrSearchRequiresCredentials so callers can distinguish "needs an
+// account" from "found nothing". Implementations cap results at the first
+// page (≤50) and never treat an empty result set as an error.
+type WithSearch interface {
+	Tracker
+	Search(ctx context.Context, query string, creds *domain.TrackerCredential) ([]SearchResult, error)
+}
+
 // --- Client & Notifier interfaces ---------------------------------------
 
 // Client is a torrent client plugin.

--- a/backend/internal/plugins/trackers/anilibria/search.go
+++ b/backend/internal/plugins/trackers/anilibria/search.go
@@ -1,0 +1,60 @@
+package anilibria
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+)
+
+var _ registry.WithSearch = (*plugin)(nil)
+
+// Search implements registry.WithSearch (issue #129). It reuses the same
+// AniLiberty v1 endpoint the check path already depends on
+// (/app/search/releases — see findAniLibertyRelease), but with the user's
+// free-text query instead of an exact alias. Results are release pages in
+// the canonical aniliberty.top form aniLibertyAlias/CanParse accept, so
+// picking one subscribes to the release. Anonymous API; Seeders is -1 —
+// the API reports releases, not swarm state.
+func (p *plugin) Search(ctx context.Context, query string, _ *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	qv := url.Values{}
+	qv.Set("query", q)
+	qv.Set("include", "id,alias,name.main")
+	endpoint := strings.TrimRight(p.aniLibertyBase(), "/") + "/app/search/releases?" + qv.Encode()
+	body, err := p.fetch(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("anilibria search: %w", err)
+	}
+	releases, err := decodeAniLibertyReleases(body)
+	if err != nil {
+		return nil, fmt.Errorf("anilibria search: %w", err)
+	}
+	var out []registry.SearchResult
+	for _, rel := range releases {
+		alias := strings.TrimSpace(rel.Alias)
+		if rel.ID <= 0 || alias == "" {
+			continue
+		}
+		title := strings.TrimSpace(rel.Name.Main)
+		if title == "" {
+			title = alias
+		}
+		out = append(out, registry.SearchResult{
+			Title:    title,
+			URL:      "https://aniliberty.top/anime/releases/release/" + url.PathEscape(alias) + "/",
+			Seeders:  -1,
+			Category: "Anime",
+		})
+		if len(out) == 50 {
+			break
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/plugins/trackers/anilibria/search_test.go
+++ b/backend/internal/plugins/trackers/anilibria/search_test.go
@@ -1,0 +1,83 @@
+package anilibria
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// searchFixtureJSON mirrors the live /app/search/releases response shape
+// (verified 2026-07-23): a plain JSON array of releases.
+const searchFixtureJSON = `[
+	{"id":10290,"alias":"one-piece","name":{"main":"Ван-Пис"}},
+	{"id":420,"alias":"","name":{"main":"Без алиаса — пропустить"}},
+	{"id":777,"alias":"no-title","name":{"main":""}}
+]`
+
+func newSearchTestPlugin(t *testing.T, handler http.HandlerFunc) *plugin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &plugin{
+		httpClient:        srv.Client(),
+		aniLibertyAPIBase: srv.URL,
+	}
+}
+
+func TestSearch_MapsReleasesToCanonicalURLs(t *testing.T) {
+	var gotPath, gotQuery string
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("query")
+		_, _ = w.Write([]byte(searchFixtureJSON))
+	})
+	results, err := p.Search(context.Background(), "ван пис", nil)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if gotPath != "/app/search/releases" || gotQuery != "ван пис" {
+		t.Errorf("request = %s?query=%s, want /app/search/releases?query=ван пис", gotPath, gotQuery)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2 (empty-alias entry skipped)", len(results))
+	}
+	if results[0].Title != "Ван-Пис" {
+		t.Errorf("Title = %q", results[0].Title)
+	}
+	if results[0].URL != "https://aniliberty.top/anime/releases/release/one-piece/" {
+		t.Errorf("URL = %q", results[0].URL)
+	}
+	if results[0].Seeders != -1 || results[0].Category != "Anime" {
+		t.Errorf("meta = %+v", results[0])
+	}
+	// Missing name.main falls back to the alias, never an empty title.
+	if results[1].Title != "no-title" {
+		t.Errorf("fallback Title = %q", results[1].Title)
+	}
+	// The emitted URL must round-trip through the plugin's own CanParse.
+	if !p.CanParse(results[0].URL) {
+		t.Errorf("CanParse rejects emitted URL %q", results[0].URL)
+	}
+}
+
+func TestSearch_EmptyQuery_NoRequest(t *testing.T) {
+	called := false
+	p := newSearchTestPlugin(t, func(http.ResponseWriter, *http.Request) { called = true })
+	results, err := p.Search(context.Background(), "  ", nil)
+	if err != nil || results != nil {
+		t.Fatalf("empty query: results=%v err=%v, want nil,nil", results, err)
+	}
+	if called {
+		t.Error("empty query must not hit the API")
+	}
+}
+
+func TestSearch_NonJSONResponse_Errors(t *testing.T) {
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html>cf challenge</html>"))
+	})
+	if _, err := p.Search(context.Background(), "anything", nil); err == nil {
+		t.Fatal("non-JSON body must error, not silently return zero results")
+	}
+}

--- a/backend/internal/plugins/trackers/forumcommon/text.go
+++ b/backend/internal/plugins/trackers/forumcommon/text.go
@@ -1,9 +1,11 @@
 package forumcommon
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 
+	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
 )
 
@@ -31,4 +33,30 @@ func DecodeWindows1251(s string) string {
 func CleanTitle(raw, siteSuffix string) string {
 	t := strings.TrimSpace(DecodeWindows1251(raw))
 	return strings.TrimSuffix(t, siteSuffix)
+}
+
+// EncodeWindows1251Query percent-escapes s for use as a query parameter on a
+// cp1251 site (RuTracker's tracker.php?nm=). Go's url.Values.Encode emits
+// UTF-8 percent-encoding, which cp1251 backends read as mojibake — every
+// Cyrillic search would return zero results. So: transcode to cp1251 first
+// (unmappable runes become the encoder's substitute byte rather than failing
+// the whole query), then percent-escape everything outside RFC-3986
+// unreserved.
+func EncodeWindows1251Query(s string) string {
+	enc, err := encoding.ReplaceUnsupported(charmap.Windows1251.NewEncoder()).String(s)
+	if err != nil {
+		enc = s // fall back to UTF-8 bytes; a degraded search beats an error
+	}
+	var b strings.Builder
+	for i := 0; i < len(enc); i++ {
+		c := enc[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			c == '-', c == '.', c == '_', c == '~':
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
 }

--- a/backend/internal/plugins/trackers/forumcommon/text_test.go
+++ b/backend/internal/plugins/trackers/forumcommon/text_test.go
@@ -22,3 +22,21 @@ func TestDecodeWindows1251_AlreadyUTF8_Unchanged(t *testing.T) {
 		t.Errorf("DecodeWindows1251 = %q, want %q", got, in)
 	}
 }
+
+func TestEncodeWindows1251Query(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{"ascii passthrough", "dune", "dune"},
+		{"space escaped", "dune part", "dune%20part"},
+		// Д=0xC4 ю=0xFE н=0xED а=0xE0 in cp1251.
+		{"cyrillic cp1251 bytes", "Дюна", "%C4%FE%ED%E0"},
+		{"mixed", "Дюна 2", "%C4%FE%ED%E0%202"},
+		{"unreserved kept", "a-b_c.d~e", "a-b_c.d~e"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EncodeWindows1251Query(tt.in); got != tt.want {
+				t.Errorf("EncodeWindows1251Query(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/plugins/trackers/kinozal/search.go
+++ b/backend/internal/plugins/trackers/kinozal/search.go
@@ -1,0 +1,72 @@
+package kinozal
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+var _ registry.WithSearch = (*plugin)(nil)
+
+// Kinozal's browse.php mixes attribute quoting styles in one page
+// (class="nam", class='s', class=bg — captured live 2026-07-23), so every
+// cell regex tolerates single, double, or no quotes. The size cell is not
+// positional: browse rows carry several class='s' cells (comments count,
+// size, date) — the size is the one whose text looks like a size, i.e.
+// number + cp1251-decoded unit (КБ/МБ/ГБ/ТБ).
+var (
+	searchRowRe   = regexp.MustCompile(`(?s)<tr[^>]*>(.*?)</tr>`)
+	searchLinkRe  = regexp.MustCompile(`(?s)<td class=['"]?nam['"]?><a href="/details\.php\?id=(\d+)[^"]*"[^>]*>(.*?)</a>`)
+	searchSizeRe  = regexp.MustCompile(`<td class=['"]?s['"]?>([\d.,]+\s*[КМГТ]Б)</td>`)
+	searchSeedsRe = regexp.MustCompile(`<td class=['"]?sl_s['"]?>(\d+)</td>`)
+)
+
+// Search implements registry.WithSearch (issue #129). Kinozal's search is
+// anonymous-friendly (browse.php serves results without login — verified
+// live on kinozal.me 2026-07-23); creds are accepted only to reuse a warm
+// session jar. The query must be cp1251-percent-encoded like RuTracker's.
+func (p *plugin) Search(ctx context.Context, query string, creds *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	target := fmt.Sprintf("https://%s/browse.php?s=%s",
+		p.effectiveDomain(), forumcommon.EncodeWindows1251Query(q))
+	body, err := p.fetch(ctx, target, creds)
+	if err != nil {
+		return nil, fmt.Errorf("kinozal search: %w", err)
+	}
+	page := forumcommon.DecodeWindows1251(string(body))
+	var out []registry.SearchResult
+	for _, row := range searchRowRe.FindAllStringSubmatch(page, -1) {
+		cell := row[1]
+		link := searchLinkRe.FindStringSubmatch(cell)
+		if link == nil {
+			continue // header/pagination rows
+		}
+		r := registry.SearchResult{
+			Title:   strings.TrimSpace(forumcommon.HTMLToText(link[2])),
+			URL:     fmt.Sprintf("https://%s/details.php?id=%s", p.effectiveDomain(), link[1]),
+			Seeders: -1,
+		}
+		if m := searchSizeRe.FindStringSubmatch(cell); m != nil {
+			r.Size = strings.TrimSpace(m[1])
+		}
+		if m := searchSeedsRe.FindStringSubmatch(cell); m != nil {
+			if n, cerr := strconv.Atoi(m[1]); cerr == nil {
+				r.Seeders = n
+			}
+		}
+		out = append(out, r)
+		if len(out) == 50 {
+			break
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/plugins/trackers/kinozal/search_test.go
+++ b/backend/internal/plugins/trackers/kinozal/search_test.go
@@ -1,0 +1,109 @@
+package kinozal
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/encoding/charmap"
+
+	"github.com/artyomsv/marauder/backend/internal/plugins/e2etest"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+// searchFixtureHTML reproduces live kinozal.me browse.php markup (captured
+// 2026-07-23): mixed attribute quoting (class="nam" / class='s' /
+// class=bg), unclosed nam cells, and multiple class='s' cells per row of
+// which only one is the size.
+const searchFixtureHTML = `<html><body><table>
+<tr class="mn"><td>header</td></tr>
+<tr class='first bg'><td class="bt"><img src="/pic/cat/25.gif"></td><td class="nam"><a href="/details.php?id=2147332" class="r0">Планета Дюна / Planet Dune / 2021 / ПМ, СТ / WEB-DL (1080p)</a><td class='s'>2</td> <td class='s'>2.54 ГБ</td> <td class='sl_s'>5</td> <td class='sl_p'>0</td> <td class='s'>15.07.2026 в 15:55</td></tr>
+<tr class=bg><td class="bt"><img src="/pic/cat/46.gif"></td><td class="nam"><a href="/details.php?id=2063569" class="r1">Дюна: Пророчество (1 сезон: 1-6 серии из 6) / Dune: Prophecy / 2024 / ДБ / WEB-DL (1080p)</a><td class='s'>14</td> <td class='s'>11.4 ГБ</td> <td class='sl_s'>29</td> <td class='sl_p'>1</td> <td class='s'>10.01.2025 в 09:12</td></tr>
+</table></body></html>`
+
+func newSearchTestPlugin(t *testing.T, handler http.HandlerFunc) *plugin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &plugin{
+		sessions: forumcommon.New(),
+		domain:   defaultDomain,
+		transport: &e2etest.HostRewriteTransport{
+			From: defaultDomain,
+			To:   strings.TrimPrefix(srv.URL, "http://"),
+		},
+	}
+}
+
+func writeCP1251Search(t *testing.T, w http.ResponseWriter, utf8HTML string) {
+	t.Helper()
+	enc, err := charmap.Windows1251.NewEncoder().String(utf8HTML)
+	if err != nil {
+		t.Fatalf("encode fixture to cp1251: %v", err)
+	}
+	_, _ = w.Write([]byte(enc))
+}
+
+func TestSearch_ParsesLiveShapedRows(t *testing.T) {
+	var gotRawQuery string
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		writeCP1251Search(t, w, searchFixtureHTML)
+	})
+	results, err := p.Search(context.Background(), "Дюна", nil)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// Д=0xC4 ю=0xFE н=0xED а=0xE0 — the query must go out cp1251-encoded.
+	if gotRawQuery != "s=%C4%FE%ED%E0" {
+		t.Errorf("raw query = %q, want s=%%C4%%FE%%ED%%E0", gotRawQuery)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	first := results[0]
+	if first.Title != "Планета Дюна / Planet Dune / 2021 / ПМ, СТ / WEB-DL (1080p)" {
+		t.Errorf("Title = %q", first.Title)
+	}
+	if first.URL != "https://kinozal.tv/details.php?id=2147332" {
+		t.Errorf("URL = %q", first.URL)
+	}
+	// The size is the s-cell that looks like a size — not the comments
+	// count ("2") and not the date cell.
+	if first.Size != "2.54 ГБ" {
+		t.Errorf("Size = %q", first.Size)
+	}
+	if first.Seeders != 5 {
+		t.Errorf("Seeders = %d", first.Seeders)
+	}
+	if results[1].Seeders != 29 || results[1].Size != "11.4 ГБ" {
+		t.Errorf("second result = %+v", results[1])
+	}
+}
+
+func TestSearch_EmptyQuery_NoRequest(t *testing.T) {
+	called := false
+	p := newSearchTestPlugin(t, func(http.ResponseWriter, *http.Request) { called = true })
+	results, err := p.Search(context.Background(), "  ", nil)
+	if err != nil || results != nil {
+		t.Fatalf("empty query: results=%v err=%v, want nil,nil", results, err)
+	}
+	if called {
+		t.Error("empty query must not hit the tracker")
+	}
+}
+
+func TestSearch_NoResultRows_EmptyNotError(t *testing.T) {
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeCP1251Search(t, w, `<html><body>Ничего не найдено</body></html>`)
+	})
+	results, err := p.Search(context.Background(), "nothing", nil)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("results = %d, want 0", len(results))
+	}
+}

--- a/backend/internal/plugins/trackers/lostfilm/lostfilm_search.go
+++ b/backend/internal/plugins/trackers/lostfilm/lostfilm_search.go
@@ -1,0 +1,75 @@
+package lostfilm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+)
+
+var _ registry.WithSearch = (*plugin)(nil)
+
+// searchSeriesEntry is one series row in the /ajaxik.php search response.
+// The endpoint also returns a "names" (actors) list which is irrelevant
+// here — only data.series entries become results.
+type searchSeriesEntry struct {
+	Title     string `json:"title"`
+	TitleOrig string `json:"title_orig"`
+	Link      string `json:"link"` // "/series/<slug>"
+}
+
+// Search implements registry.WithSearch (issue #129). LostFilm's search is
+// the public JSON endpoint the site's own search box uses
+// (GET /ajaxik.php?act=common&type=search&val=<q> — verified live
+// 2026-07-23); no login needed, creds are accepted only to reuse a warm
+// session jar. Results are series pages, not individual releases — the
+// emitted URL is the canonical /series/<slug>/ form the plugin's CanParse
+// accepts, so picking one subscribes to the series like pasting its URL
+// would. Seeders is always -1: a series subscription has no swarm count.
+func (p *plugin) Search(ctx context.Context, query string, creds *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	target := "https://" + p.effectiveDomain() + "/ajaxik.php?" + url.Values{
+		"act":  {"common"},
+		"type": {"search"},
+		"val":  {q},
+	}.Encode()
+	body, err := p.fetch(ctx, target, creds)
+	if err != nil {
+		return nil, fmt.Errorf("lostfilm search: %w", err)
+	}
+	var resp struct {
+		Data struct {
+			Series []searchSeriesEntry `json:"series"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("lostfilm search: decode response: %w", err)
+	}
+	var out []registry.SearchResult
+	for _, s := range resp.Data.Series {
+		if !strings.HasPrefix(s.Link, "/series/") {
+			continue // defensive: never emit a URL CanParse would reject
+		}
+		title := strings.TrimSpace(s.Title)
+		if orig := strings.TrimSpace(s.TitleOrig); orig != "" && orig != title {
+			title = title + " / " + orig
+		}
+		out = append(out, registry.SearchResult{
+			Title:    title,
+			URL:      "https://" + p.effectiveDomain() + s.Link + "/",
+			Seeders:  -1,
+			Category: "Series",
+		})
+		if len(out) == 50 {
+			break
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/plugins/trackers/lostfilm/lostfilm_search_test.go
+++ b/backend/internal/plugins/trackers/lostfilm/lostfilm_search_test.go
@@ -1,0 +1,86 @@
+package lostfilm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/artyomsv/marauder/backend/internal/plugins/e2etest"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+// searchFixtureJSON mirrors the live /ajaxik.php response shape (verified
+// 2026-07-23): data.series is what matters; data.names (actors) must be
+// ignored.
+const searchFixtureJSON = `{"data":{"series":[` +
+	`{"id":"1146","icon":"/Static/Images/1146/Posters/icon.jpg","title":"Лаки","title_orig":"Lucky","link":"/series/Lucky"},` +
+	`{"id":"999","icon":"/i.jpg","title":"Одинаковое","title_orig":"Одинаковое","link":"/series/Same_Title"},` +
+	`{"id":"666","icon":"/i.jpg","title":"Мимо","title_orig":"Off-site","link":"/persons/Not_A_Series"}` +
+	`],"names":[{"id":"57135","title":"Лаки Джонсон","title_orig":"Lucky Johnson","link":"/persons/Lucky_Johnson"}]}}`
+
+func newSearchTestPlugin(t *testing.T, handler http.HandlerFunc) *plugin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	return &plugin{
+		sessions:  forumcommon.New(),
+		domain:    "www.lostfilm.tv",
+		transport: &e2etest.HostRewriteTransport{From: "www.lostfilm.tv", To: host},
+	}
+}
+
+func TestSearch_ParsesSeriesEntries(t *testing.T) {
+	var gotQuery url.Values
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte(searchFixtureJSON))
+	})
+	results, err := p.Search(context.Background(), "Лаки", nil)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if gotQuery.Get("act") != "common" || gotQuery.Get("type") != "search" || gotQuery.Get("val") != "Лаки" {
+		t.Errorf("query = %v, want act=common type=search val=Лаки", gotQuery)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2 (persons link filtered out)", len(results))
+	}
+	if results[0].Title != "Лаки / Lucky" {
+		t.Errorf("Title = %q, want combined ru/orig", results[0].Title)
+	}
+	if results[0].URL != "https://www.lostfilm.tv/series/Lucky/" {
+		t.Errorf("URL = %q", results[0].URL)
+	}
+	if results[0].Seeders != -1 || results[0].Category != "Series" {
+		t.Errorf("result meta = %+v", results[0])
+	}
+	// Identical ru/orig titles must not duplicate ("X / X").
+	if results[1].Title != "Одинаковое" {
+		t.Errorf("second Title = %q, want no duplicated orig", results[1].Title)
+	}
+}
+
+func TestSearch_EmptyQuery_NoRequest(t *testing.T) {
+	called := false
+	p := newSearchTestPlugin(t, func(http.ResponseWriter, *http.Request) { called = true })
+	results, err := p.Search(context.Background(), "  ", nil)
+	if err != nil || results != nil {
+		t.Fatalf("empty query: results=%v err=%v, want nil,nil", results, err)
+	}
+	if called {
+		t.Error("empty query must not hit the tracker")
+	}
+}
+
+func TestSearch_NonJSONResponse_Errors(t *testing.T) {
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html>maintenance</html>"))
+	})
+	if _, err := p.Search(context.Background(), "anything", nil); err == nil {
+		t.Fatal("non-JSON body must error, not silently return zero results")
+	}
+}

--- a/backend/internal/plugins/trackers/rutor/rutor.go
+++ b/backend/internal/plugins/trackers/rutor/rutor.go
@@ -16,11 +16,13 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/artyomsv/marauder/backend/internal/domain"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
 )
 
 const (
@@ -144,6 +146,59 @@ func (p *plugin) Download(ctx context.Context, topic *domain.Topic, _ *domain.Ch
 		return &domain.Payload{MagnetURI: string(m)}, nil
 	}
 	return nil, errors.New("rutor: no magnet link")
+}
+
+// --- WithSearch ---------------------------------------------------------
+
+var _ registry.WithSearch = (*plugin)(nil)
+
+var (
+	searchRowRe   = regexp.MustCompile(`(?s)<tr[^>]*>(.*?)</tr>`)
+	searchLinkRe  = regexp.MustCompile(`(?s)<a href="/torrent/(\d+)[^"]*">(.*?)</a>`)
+	searchSizeRe  = regexp.MustCompile(`<td align="right">([^<]+)</td>`)
+	searchSeedsRe = regexp.MustCompile(`<span class="green">[^0-9]*(\d+)`)
+)
+
+// Search implements registry.WithSearch (issue #129). Rutor's search is
+// public; the query is a path segment (page 0, category 0, filter 000,
+// sort 0), so it needs url.PathEscape — QueryEscape's `+` for space is
+// wrong inside a path.
+func (p *plugin) Search(ctx context.Context, query string, _ *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	target := fmt.Sprintf("https://%s/search/0/0/000/0/%s", p.effectiveDomain(), url.PathEscape(q))
+	body, err := p.fetch(ctx, target)
+	if err != nil {
+		return nil, fmt.Errorf("rutor search: %w", err)
+	}
+	var out []registry.SearchResult
+	for _, row := range searchRowRe.FindAllSubmatch(body, -1) {
+		cell := row[1]
+		link := searchLinkRe.FindSubmatch(cell)
+		if link == nil {
+			continue // header/spacer row without a torrent link
+		}
+		r := registry.SearchResult{
+			Title:   forumcommon.HTMLToText(string(link[2])),
+			URL:     fmt.Sprintf("https://%s/torrent/%s", p.effectiveDomain(), link[1]),
+			Seeders: -1,
+		}
+		if m := searchSizeRe.FindSubmatch(cell); m != nil {
+			r.Size = forumcommon.HTMLToText(string(m[1]))
+		}
+		if m := searchSeedsRe.FindSubmatch(cell); m != nil {
+			if n, cerr := strconv.Atoi(string(m[1])); cerr == nil {
+				r.Seeders = n
+			}
+		}
+		out = append(out, r)
+		if len(out) == 50 {
+			break
+		}
+	}
+	return out, nil
 }
 
 func (p *plugin) fetch(ctx context.Context, target string) ([]byte, error) {

--- a/backend/internal/plugins/trackers/rutor/rutor_test.go
+++ b/backend/internal/plugins/trackers/rutor/rutor_test.go
@@ -2,6 +2,7 @@ package rutor
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -298,5 +299,34 @@ func TestSearch_NoRows_EmptyNotError(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Errorf("results = %d, want 0", len(results))
+	}
+}
+
+func TestSearch_FetchError_Propagates(t *testing.T) {
+	p, _ := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	if _, err := p.Search(context.Background(), "anything", nil); err == nil {
+		t.Fatal("Search on a 503 must return an error")
+	}
+}
+
+func TestSearch_CapsAtFiftyResults(t *testing.T) {
+	var rows strings.Builder
+	for i := 0; i < 60; i++ {
+		fmt.Fprintf(&rows,
+			`<tr class="gai"><td>d</td><td><a href="/torrent/%d/slug">Release %d</a></td>`+
+				`<td align="right">1 GB</td><td align="center"><span class="green">1</span></td></tr>`, i, i)
+	}
+	page := "<html><body><table>" + rows.String() + "</table></body></html>"
+	p, _ := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(page))
+	})
+	results, err := p.Search(context.Background(), "many", nil)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 50 {
+		t.Errorf("results = %d, want capped at 50", len(results))
 	}
 }

--- a/backend/internal/plugins/trackers/rutor/rutor_test.go
+++ b/backend/internal/plugins/trackers/rutor/rutor_test.go
@@ -207,3 +207,96 @@ func TestFetch_RejectsOffSiteHost(t *testing.T) {
 		}
 	}
 }
+
+const searchFixtureHTML = `<html><body><table>
+<tr><td>Header row without link</td></tr>
+<tr class="gai"><td>22&nbsp;&#1048;&#1102;&#1083;&nbsp;26</td><td>
+<a class="downgif" href="/download/975045"><img src="/s/i/d.gif" alt="D"></a>
+<a href="magnet:?xt=urn:btih:aaaabbbbccccddddeeeeffff0000111122223333"><img src="/s/i/m.gif" alt="M"></a>
+<a href="/torrent/975045/test-release-1080p">Test release <b>1080p</b></a></td>
+<td align="right">1.4&nbsp;GB</td>
+<td align="center"><span class="green">&nbsp;17&nbsp;</span>&nbsp;<span class="red">3</span></td></tr>
+<tr class="tum"><td>21&nbsp;&#1048;&#1102;&#1083;&nbsp;26</td><td>
+<a class="downgif" href="/download/975001"><img src="/s/i/d.gif" alt="D"></a>
+<a href="/torrent/975001/another-release">Another release</a></td>
+<td align="right">804.9&nbsp;MB</td>
+<td align="center"><span class="green">2</span></td></tr>
+</table></body></html>`
+
+func newSearchTestPlugin(t *testing.T, handler http.HandlerFunc) (*plugin, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	p := &plugin{httpClient: &http.Client{
+		Transport: &e2eHostRewrite{to: strings.TrimPrefix(srv.URL, "http://")},
+	}}
+	return p, srv
+}
+
+// e2eHostRewrite forces rutor.org -> test server (scheme https -> http).
+type e2eHostRewrite struct{ to string }
+
+func (h *e2eHostRewrite) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = h.to
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestSearch_ParsesResultsFromFixture(t *testing.T) {
+	var gotPath string
+	p, _ := newSearchTestPlugin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		_, _ = w.Write([]byte(searchFixtureHTML))
+	})
+	results, err := p.Search(context.Background(), "test query", nil)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if gotPath != "/search/0/0/000/0/test%20query" {
+		t.Errorf("request path = %q, want /search/0/0/000/0/test%%20query", gotPath)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	first := results[0]
+	if first.Title != "Test release 1080p" {
+		t.Errorf("Title = %q", first.Title)
+	}
+	if first.URL != "https://rutor.org/torrent/975045" {
+		t.Errorf("URL = %q", first.URL)
+	}
+	if first.Size != "1.4 GB" {
+		t.Errorf("Size = %q", first.Size)
+	}
+	if first.Seeders != 17 {
+		t.Errorf("Seeders = %d", first.Seeders)
+	}
+	if results[1].Seeders != 2 {
+		t.Errorf("second Seeders = %d", results[1].Seeders)
+	}
+}
+
+func TestSearch_EmptyQuery_NoRequest(t *testing.T) {
+	called := false
+	p, _ := newSearchTestPlugin(t, func(http.ResponseWriter, *http.Request) { called = true })
+	results, err := p.Search(context.Background(), "   ", nil)
+	if err != nil || results != nil {
+		t.Fatalf("empty query: results=%v err=%v, want nil,nil", results, err)
+	}
+	if called {
+		t.Error("empty query must not hit the tracker")
+	}
+}
+
+func TestSearch_NoRows_EmptyNotError(t *testing.T) {
+	p, _ := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html><body>no matches</body></html>`))
+	})
+	results, err := p.Search(context.Background(), "nothing", nil)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("results = %d, want 0", len(results))
+	}
+}

--- a/backend/internal/plugins/trackers/rutracker/rutracker.go
+++ b/backend/internal/plugins/trackers/rutracker/rutracker.go
@@ -381,6 +381,22 @@ func (p *plugin) fetchTopicPage(ctx context.Context, topic *domain.Topic, creds 
 }
 
 func (p *plugin) fetchBytes(ctx context.Context, _ *domain.Topic, creds *domain.TrackerCredential, target string) ([]byte, error) {
+	// SSRF guard: every caller builds target from p.effectiveDomain(), but
+	// fetchBytes is the last line of defense before dialing — refuse any
+	// host that isn't the resolved effective domain (covers the test-
+	// injected p.domain) or a known/admin-configured rutracker domain, and
+	// any non-HTTP scheme (mirrors the rutor fetch guard).
+	u, err := url.Parse(strings.TrimSpace(target))
+	if err != nil {
+		return nil, fmt.Errorf("rutracker: invalid URL: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return nil, fmt.Errorf("rutracker: refusing URL scheme %q", u.Scheme)
+	}
+	if u.Host != p.effectiveDomain() && !registry.DomainAllowed(pluginName, u.Hostname(), knownDomains) {
+		return nil, fmt.Errorf("rutracker: refusing to fetch off-site host %q", u.Hostname())
+	}
+
 	key := pluginName + ":nocreds"
 	if creds != nil {
 		key = forumcommon.SessionKey(pluginName, creds.UserID.String())

--- a/backend/internal/plugins/trackers/rutracker/search.go
+++ b/backend/internal/plugins/trackers/rutracker/search.go
@@ -1,0 +1,84 @@
+package rutracker
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+var _ registry.WithSearch = (*plugin)(nil)
+
+var (
+	searchRowRe   = regexp.MustCompile(`(?s)<tr class="[^"]*tCenter[^"]*"[^>]*>(.*?)</tr>`)
+	searchLinkRe  = regexp.MustCompile(`(?s)<a[^>]*class="[^"]*tLink[^"]*"[^>]*>(.*?)</a>`)
+	searchTIDRe   = regexp.MustCompile(`viewtopic\.php\?t=(\d+)`)
+	searchSizeRe  = regexp.MustCompile(`(?s)<td[^>]*class="[^"]*tor-size[^"]*"[^>]*>(.*?)</td>`)
+	searchSeedsRe = regexp.MustCompile(`<b class="seedmed">\s*(\d+)`)
+	searchForumRe = regexp.MustCompile(`(?s)<a[^>]*href="tracker\.php\?f=\d+[^"]*"[^>]*>(.*?)</a>`)
+)
+
+// Search implements registry.WithSearch (issue #129). RuTracker's
+// tracker.php is login-gated: with no credential (or a dead session the
+// handler layer could not revive) it returns ErrSearchRequiresCredentials.
+// The nm param must be cp1251-percent-encoded — UTF-8 encoding reads as
+// mojibake server-side and returns zero results for Cyrillic queries.
+func (p *plugin) Search(ctx context.Context, query string, creds *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	if creds == nil {
+		return nil, registry.ErrSearchRequiresCredentials
+	}
+	target := fmt.Sprintf("https://%s/forum/tracker.php?nm=%s",
+		p.effectiveDomain(), forumcommon.EncodeWindows1251Query(q))
+	body, err := p.fetchBytes(ctx, nil, creds, target)
+	if err != nil {
+		return nil, fmt.Errorf("rutracker search: %w", err)
+	}
+	page := forumcommon.DecodeWindows1251(string(body))
+	if !strings.Contains(page, `id="logged-in-username"`) {
+		// tracker.php served the anonymous login shell — session is dead.
+		return nil, registry.ErrSearchRequiresCredentials
+	}
+	var out []registry.SearchResult
+	for _, row := range searchRowRe.FindAllStringSubmatch(page, -1) {
+		cell := row[1]
+		linkM := searchLinkRe.FindStringSubmatchIndex(cell)
+		if linkM == nil {
+			continue
+		}
+		anchor := cell[linkM[0]:linkM[1]]
+		tid := searchTIDRe.FindStringSubmatch(anchor)
+		if tid == nil {
+			continue
+		}
+		r := registry.SearchResult{
+			Title:   forumcommon.HTMLToText(cell[linkM[2]:linkM[3]]),
+			URL:     fmt.Sprintf("https://%s/forum/viewtopic.php?t=%s", p.effectiveDomain(), tid[1]),
+			Seeders: -1,
+		}
+		if m := searchSizeRe.FindStringSubmatch(cell); m != nil {
+			r.Size = forumcommon.HTMLToText(m[1])
+		}
+		if m := searchSeedsRe.FindStringSubmatch(cell); m != nil {
+			if n, cerr := strconv.Atoi(m[1]); cerr == nil {
+				r.Seeders = n
+			}
+		}
+		if m := searchForumRe.FindStringSubmatch(cell); m != nil {
+			r.Category = forumcommon.HTMLToText(m[1])
+		}
+		out = append(out, r)
+		if len(out) == 50 {
+			break
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/plugins/trackers/rutracker/search.go
+++ b/backend/internal/plugins/trackers/rutracker/search.go
@@ -15,7 +15,11 @@ import (
 var _ registry.WithSearch = (*plugin)(nil)
 
 var (
-	searchRowRe   = regexp.MustCompile(`(?s)<tr class="[^"]*tCenter[^"]*"[^>]*>(.*?)</tr>`)
+	// Attribute-order-agnostic: live rows are
+	// <tr id="trs-tr-N" class="tCenter hl-tr" data-topic_id="N"> — id comes
+	// BEFORE class, so anchoring the class to the tag name silently matches
+	// nothing (the bug that shipped zero rutracker results on 2026-07-23).
+	searchRowRe   = regexp.MustCompile(`(?s)<tr[^>]*class="[^"]*tCenter[^"]*"[^>]*>(.*?)</tr>`)
 	searchLinkRe  = regexp.MustCompile(`(?s)<a[^>]*class="[^"]*tLink[^"]*"[^>]*>(.*?)</a>`)
 	searchTIDRe   = regexp.MustCompile(`viewtopic\.php\?t=(\d+)`)
 	searchSizeRe  = regexp.MustCompile(`(?s)<td[^>]*class="[^"]*tor-size[^"]*"[^>]*>(.*?)</td>`)
@@ -65,7 +69,8 @@ func (p *plugin) Search(ctx context.Context, query string, creds *domain.Tracker
 			Seeders: -1,
 		}
 		if m := searchSizeRe.FindStringSubmatch(cell); m != nil {
-			r.Size = forumcommon.HTMLToText(m[1])
+			// Live size cells end with a download-arrow glyph ("1.4 GB ↓").
+			r.Size = strings.TrimSpace(strings.TrimSuffix(forumcommon.HTMLToText(m[1]), "↓"))
 		}
 		if m := searchSeedsRe.FindStringSubmatch(cell); m != nil {
 			if n, cerr := strconv.Atoi(m[1]); cerr == nil {

--- a/backend/internal/plugins/trackers/rutracker/search_test.go
+++ b/backend/internal/plugins/trackers/rutracker/search_test.go
@@ -139,3 +139,24 @@ func TestSearch_AnonymousShell_ErrSearchRequiresCredentials(t *testing.T) {
 		t.Fatalf("err = %v, want ErrSearchRequiresCredentials", err)
 	}
 }
+
+func TestSearch_EmptyQuery_NoRequestNoCredsCheck(t *testing.T) {
+	called := false
+	p := newSearchTestPlugin(t, func(http.ResponseWriter, *http.Request) { called = true })
+	results, err := p.Search(context.Background(), "   ", nil)
+	if err != nil || results != nil {
+		t.Fatalf("empty query: results=%v err=%v, want nil,nil", results, err)
+	}
+	if called {
+		t.Error("empty query must not hit the tracker")
+	}
+}
+
+func TestSearch_FetchError_Propagates(t *testing.T) {
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	if _, err := p.Search(context.Background(), "anything", testCreds()); err == nil {
+		t.Fatal("Search on a 503 must return an error")
+	}
+}

--- a/backend/internal/plugins/trackers/rutracker/search_test.go
+++ b/backend/internal/plugins/trackers/rutracker/search_test.go
@@ -1,0 +1,141 @@
+package rutracker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"golang.org/x/text/encoding/charmap"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/e2etest"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+// searchFixtureHTML is a representative tracker.php result page (selectors
+// verified against live markup 2026-07-23): an authenticated shell with two
+// tCenter result rows. Encoded to cp1251 by the test server to exercise the
+// decode path.
+const searchFixtureHTML = `<html><body><span id="logged-in-username">user</span>
+<table id="tor-tbl">
+<tr class="tCenter hl-tr">
+<td class="row1 t-ico"></td>
+<td class="row1 f-name-col"><div class="f-name"><a class="gen f ts-text" href="tracker.php?f=313">Зарубежное кино</a></div></td>
+<td class="row4 med tLeft t-title-col"><div class="t-title"><a data-topic_id="100" class="med tLink tt-text ts-text hl-tags bold" href="viewtopic.php?t=100">Дюна <span class="brackets-pair">[2026]</span></a></div></td>
+<td class="row1 t-author-col"></td>
+<td class="row4 med tor-size" data-ts_text="1500000000"><a class="small tr-dl dl-stub" href="dl.php?t=100">1.4&nbsp;GB</a></td>
+<td class="row4 nowrap" data-ts_text="17"><b class="seedmed">17</b></td>
+<td class="row4 leechmed bold">3</td><td class="row4 small nowrap">22-Июл-26</td>
+</tr>
+<tr class="tCenter hl-tr">
+<td class="row1 t-ico"></td>
+<td class="row1 f-name-col"><div class="f-name"><a class="gen f ts-text" href="tracker.php?f=7">Сериалы</a></div></td>
+<td class="row4 med tLeft t-title-col"><div class="t-title"><a data-topic_id="200" class="med tLink tt-text ts-text hl-tags bold" href="viewtopic.php?t=200">Другой релиз</a></div></td>
+<td class="row1 t-author-col"></td>
+<td class="row4 med tor-size" data-ts_text="800000000"><a class="small tr-dl dl-stub" href="dl.php?t=200">804&nbsp;MB</a></td>
+<td class="row4 nowrap" data-ts_text="2"><b class="seedmed">2</b></td>
+<td class="row4 leechmed bold">1</td><td class="row4 small nowrap">21-Июл-26</td>
+</tr>
+</table></body></html>`
+
+const searchLoginShellHTML = `<html><body><form id="login-form">login required</form></body></html>`
+
+func newSearchTestPlugin(t *testing.T, handler http.HandlerFunc) *plugin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &plugin{
+		sessions: forumcommon.New(),
+		domain:   defaultDomain,
+		transport: &e2etest.HostRewriteTransport{
+			From: defaultDomain,
+			To:   strings.TrimPrefix(srv.URL, "http://"),
+		},
+	}
+}
+
+func testCreds() *domain.TrackerCredential {
+	return &domain.TrackerCredential{UserID: uuid.New(), Username: "user"}
+}
+
+func writeCP1251(t *testing.T, w http.ResponseWriter, utf8HTML string) {
+	t.Helper()
+	enc, err := charmap.Windows1251.NewEncoder().String(utf8HTML)
+	if err != nil {
+		t.Fatalf("encode fixture to cp1251: %v", err)
+	}
+	_, _ = w.Write([]byte(enc))
+}
+
+func TestSearch_NilCreds_ErrSearchRequiresCredentials(t *testing.T) {
+	called := false
+	p := newSearchTestPlugin(t, func(http.ResponseWriter, *http.Request) { called = true })
+	_, err := p.Search(context.Background(), "anything", nil)
+	if !errors.Is(err, registry.ErrSearchRequiresCredentials) {
+		t.Fatalf("err = %v, want ErrSearchRequiresCredentials", err)
+	}
+	if called {
+		t.Error("nil creds must not hit the tracker")
+	}
+}
+
+func TestSearch_ParsesAuthenticatedResults(t *testing.T) {
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, r *http.Request) {
+		writeCP1251(t, w, searchFixtureHTML)
+	})
+	results, err := p.Search(context.Background(), "Дюна", testCreds())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	first := results[0]
+	if first.Title != "Дюна [2026]" {
+		t.Errorf("Title = %q", first.Title)
+	}
+	if first.URL != "https://rutracker.org/forum/viewtopic.php?t=100" {
+		t.Errorf("URL = %q", first.URL)
+	}
+	if first.Size != "1.4 GB" {
+		t.Errorf("Size = %q", first.Size)
+	}
+	if first.Seeders != 17 {
+		t.Errorf("Seeders = %d", first.Seeders)
+	}
+	if first.Category != "Зарубежное кино" {
+		t.Errorf("Category = %q", first.Category)
+	}
+	if results[1].Title != "Другой релиз" || results[1].Seeders != 2 {
+		t.Errorf("second result = %+v", results[1])
+	}
+}
+
+func TestSearch_CyrillicQuery_CP1251Encoded(t *testing.T) {
+	var gotRawQuery string
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		writeCP1251(t, w, searchFixtureHTML)
+	})
+	if _, err := p.Search(context.Background(), "Дюна", testCreds()); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if gotRawQuery != "nm=%C4%FE%ED%E0" {
+		t.Errorf("raw query = %q, want nm=%%C4%%FE%%ED%%E0", gotRawQuery)
+	}
+}
+
+func TestSearch_AnonymousShell_ErrSearchRequiresCredentials(t *testing.T) {
+	p := newSearchTestPlugin(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(searchLoginShellHTML))
+	})
+	_, err := p.Search(context.Background(), "query", testCreds())
+	if !errors.Is(err, registry.ErrSearchRequiresCredentials) {
+		t.Fatalf("err = %v, want ErrSearchRequiresCredentials", err)
+	}
+}

--- a/backend/internal/plugins/trackers/rutracker/search_test.go
+++ b/backend/internal/plugins/trackers/rutracker/search_test.go
@@ -23,16 +23,16 @@ import (
 // decode path.
 const searchFixtureHTML = `<html><body><span id="logged-in-username">user</span>
 <table id="tor-tbl">
-<tr class="tCenter hl-tr">
+<tr id="trs-tr-100" class="tCenter hl-tr" data-topic_id="100">
 <td class="row1 t-ico"></td>
 <td class="row1 f-name-col"><div class="f-name"><a class="gen f ts-text" href="tracker.php?f=313">Зарубежное кино</a></div></td>
 <td class="row4 med tLeft t-title-col"><div class="t-title"><a data-topic_id="100" class="med tLink tt-text ts-text hl-tags bold" href="viewtopic.php?t=100">Дюна <span class="brackets-pair">[2026]</span></a></div></td>
 <td class="row1 t-author-col"></td>
-<td class="row4 med tor-size" data-ts_text="1500000000"><a class="small tr-dl dl-stub" href="dl.php?t=100">1.4&nbsp;GB</a></td>
+<td class="row4 med tor-size" data-ts_text="1500000000"><a class="small tr-dl dl-stub" href="dl.php?t=100">1.4&nbsp;GB &darr;</a></td>
 <td class="row4 nowrap" data-ts_text="17"><b class="seedmed">17</b></td>
 <td class="row4 leechmed bold">3</td><td class="row4 small nowrap">22-Июл-26</td>
 </tr>
-<tr class="tCenter hl-tr">
+<tr id="trs-tr-200" class="tCenter hl-tr" data-topic_id="200">
 <td class="row1 t-ico"></td>
 <td class="row1 f-name-col"><div class="f-name"><a class="gen f ts-text" href="tracker.php?f=7">Сериалы</a></div></td>
 <td class="row4 med tLeft t-title-col"><div class="t-title"><a data-topic_id="200" class="med tLink tt-text ts-text hl-tags bold" href="viewtopic.php?t=200">Другой релиз</a></div></td>

--- a/backend/internal/problem/problem.go
+++ b/backend/internal/problem/problem.go
@@ -65,6 +65,9 @@ var (
 	ErrBadGateway = func(detail string) *Error {
 		return New(http.StatusBadGateway, "bad-gateway", "Bad Gateway", detail)
 	}
+	ErrTooManyRequests = func(detail string) *Error {
+		return New(http.StatusTooManyRequests, "too-many-requests", "Too Many Requests", detail)
+	}
 )
 
 // Write renders an error as a JSON RFC 7807 response.

--- a/docs/superpowers/plans/2026-07-23-tracker-search-spec.md
+++ b/docs/superpowers/plans/2026-07-23-tracker-search-spec.md
@@ -1,0 +1,315 @@
+# Tracker Search — Specification
+
+Date: 2026-07-23
+Status: verified (subagent review 2026-07-23 — 1 blocker + 2 majors + 7 minors
+found, all folded into this revision)
+Origin: web-research sprint 2026-07-23 — in-app search was the single
+feature-gap converged on by all four research tracks (Prowlarr's core UX,
+monitorrent #316, RuTracker's own Telegram bot, qBittorrent search-plugins
+6.4k★). Scoped here as *search-as-entry-point-to-monitoring*, not
+search-as-product: results exist only to become monitored topics.
+
+## Problem
+
+Adding a topic today requires the user to already have the topic URL — which
+means visiting the tracker in a browser, fighting Cloudflare/mirrors/login,
+finding the release, and copy-pasting the URL back into Marauder. That is the
+single biggest onboarding friction. The AddTopic form should let the user type
+a title, see matching releases across their configured trackers, and click one
+to monitor it.
+
+## Goals
+
+1. A user can type a query in the AddTopic flow, get live results from every
+   searchable tracker, and one click pre-fills the topic URL — from there the
+   existing match → preview → quality → create pipeline takes over unchanged.
+2. Search works with zero configuration on public trackers (Rutor) and uses
+   the user's stored credentials on login-gated trackers (RuTracker).
+3. Per-tracker failures degrade gracefully: one broken/slow/unauthenticated
+   tracker never blocks results from the others.
+
+## Non-goals (explicitly deferred)
+
+- **Prowlarr/Jackett-backed search** (consume their Torznab API as a search
+  source). Good future add-on; kept out to limit scope.
+- **Torznab search *output*** (`t=search` endpoint on Marauder's API).
+- **NNM-Club search** — its search sits behind Cloudflare; the cfsolver round
+  trip makes interactive search latency unacceptable. Revisit later.
+- **Kinozal search** — deferred on scope, not plumbing: the plugin already
+  has full `WithCredentials` + `forumcommon` session handling identical to
+  RuTracker's, but its search page behaviour (login gating, selectors)
+  could not be verified live from this session. Phase 2 is mostly
+  copy-the-RuTracker-pattern once verified.
+- Search-result caching, pagination beyond the first page, sort options.
+- Telegram-bot search, Jellyseerr intake (both depend on this seam and come
+  later).
+
+## Design
+
+### 1. Registry capability — `registry.WithSearch`
+
+```go
+// SearchResult is one release found by a tracker search. URL is the topic
+// page URL in the tracker's canonical form — exactly what a user would paste
+// into the AddTopic form, so every result feeds the existing
+// match → parse → create pipeline unchanged.
+type SearchResult struct {
+    Title    string `json:"title"`
+    URL      string `json:"url"`
+    Size     string `json:"size,omitempty"`     // human-readable, as scraped ("1.4 GB")
+    Seeders  int    `json:"seeders"`            // -1 = unknown
+    Category string `json:"category,omitempty"` // tracker's own category label, as scraped
+}
+
+// WithSearch is an optional tracker capability: search the tracker by free-
+// text query and return candidate topics to monitor. creds may be nil; a
+// tracker whose search requires login returns ErrSearchRequiresCredentials
+// so callers can distinguish "needs account" from "found nothing".
+type WithSearch interface {
+    Tracker
+    Search(ctx context.Context, query string, creds *domain.TrackerCredential) ([]SearchResult, error)
+}
+```
+
+New sentinel in `registry/errors.go`:
+
+```go
+// ErrSearchRequiresCredentials — the tracker's search page is login-gated
+// and no (valid) credential was supplied.
+var ErrSearchRequiresCredentials = errors.New("search requires credentials")
+```
+
+Design notes:
+
+- `Size`/`Category` stay **strings as scraped** — no byte parsing, no
+  normalization. They are display hints only; inventing a parse layer
+  invites per-tracker drift bugs and violates the no-synthetic-data rule
+  (a mis-parsed size would render as a confident wrong number).
+- `Seeders` is the one numeric field because the UI sorts by it; `-1`
+  (unknown) sorts last and renders as "—".
+- Result count is capped at 50 per tracker inside each plugin (first result
+  page only) to bound payload size.
+
+### 2. Plugin implementations (phase 1: two trackers)
+
+**Rutor** (public, no auth — the zero-config path):
+- `GET https://<effectiveDomain>/search/0/0/000/0/<path-escaped query>`
+  (rutor's positional search path: page 0, category 0, filter 000, sort 0).
+  The query is a **path segment** — use `url.PathEscape` (escapes `/`,
+  encodes space as `%20`), NOT `url.QueryEscape` (whose `+` for space is
+  wrong inside a path). Rutor is UTF-8; no transcoding needed.
+- Parse the results table: rows contain `href="/torrent/<id>/<slug>"` (the
+  topic link + title text), a size cell, and `<span class="green">N</span>`
+  seeders. Same regex-scanning style as the existing plugin (no new HTML
+  dep). Result URL is rebuilt as
+  `https://<effectiveDomain>/torrent/<id>` — canonical form the plugin's own
+  `CanParse` accepts.
+- Same SSRF guard as `fetch`: the built URL host is `effectiveDomain()`,
+  which is already allowlist-resolved.
+
+**RuTracker** (login-gated search):
+- `GET https://<effectiveDomain>/forum/tracker.php?nm=<query>` using the
+  user's `forumcommon` session (same session store as Check/Download —
+  search reuses an already-warm session).
+- **BLOCKER-grade encoding requirement:** RuTracker expects the `nm`
+  param **cp1251-encoded, then percent-escaped** — Go's
+  `url.Values.Encode()` emits UTF-8 percent-encoding, which turns every
+  Cyrillic query (the primary use case) into mojibake and returns zero
+  results. Add an `EncodeWindows1251` counterpart next to the existing
+  `forumcommon.DecodeWindows1251` (`x/text/encoding/charmap` is already a
+  dependency) and percent-escape the resulting bytes manually. Unit test
+  with a Cyrillic query is mandatory.
+- With `creds == nil` → return `ErrSearchRequiresCredentials` (RuTracker's
+  tracker.php redirects anonymous requests to login).
+- Parse result rows: `viewtopic.php?t=<id>` links with class `tLink` (title),
+  `tor-size` cell (size, cp1251-decoded via `forumcommon`), `seedmed` cell
+  (seeders), forum-name cell (category). Result URL rebuilt canonical:
+  `https://<effectiveDomain>/forum/viewtopic.php?t=<id>`.
+- cp1251 decoding is mandatory for title/category (same reason as
+  `cleanTitle` — undecoded cp1251 is invalid UTF-8). Titles inside `tLink`
+  anchors carry nested highlight spans — flatten tags (reuse the
+  `forumcommon/posts.go` tag-flattening helpers) and unescape HTML
+  entities; the same entity-unescape applies to rutor titles.
+
+Both implementations get fixture-based unit tests (recorded/representative
+HTML in `testdata/`, consistent with every existing plugin test) plus e2e
+coverage via `HostRewriteTransport` where practical.
+
+### 3. API — `GET /api/v1/trackers/search`
+
+Authenticated route (same group as `/trackers/match`).
+
+Query params:
+- `q` (required, trimmed; 400 when empty; max 200 runes)
+- `trackers` (optional CSV of tracker names to restrict; unknown names ignored)
+
+Response `200`:
+
+```json
+{
+  "results": [
+    {
+      "tracker_name": "rutor",
+      "tracker_display_name": "Rutor.org",
+      "title": "...",
+      "url": "https://rutor.org/torrent/123",
+      "size": "1.4 GB",
+      "seeders": 17,
+      "category": "..."
+    }
+  ],
+  "errors": [
+    { "tracker_name": "rutracker", "error": "search requires credentials" }
+  ]
+}
+```
+
+Handler behaviour:
+- Iterate `registry.ListTrackers()`, keep `WithSearch` implementors,
+  apply the `trackers` filter.
+- For each searchable tracker that also implements `WithCredentials`: load
+  the requesting user's credential for that tracker
+  (`Creds.GetForTracker`), decrypt the secret **and, when present, the
+  session blob** (`session_enc` — the credentials-test handler decrypts
+  both; session-based trackers validate the session, not the password, so
+  omitting it would plant a latent bug for a future searchable LostFilm),
+  and ensure a live session: `Verify` first, `Login` only on failed
+  verify. Note this Verify-first ordering is deliberately **new** — it is
+  neither `loginAndVerify` (Login→Verify, always both — correct for
+  validating fresh credentials, wasteful per search) nor the scheduler's
+  `loadCredentials` (Login only). On a warm in-process session it costs
+  one cheap GET; after a backend restart the first search takes the
+  Verify-fail → Login path once. Tolerant degradation: any
+  credential/login failure degrades to `creds = nil` and lets the plugin
+  decide, so RuTracker reports `ErrSearchRequiresCredentials` instead of
+  the whole request failing.
+- Fan out concurrently (`errgroup` or plain WaitGroup), one goroutine per
+  tracker, each with its own `context.WithTimeout(r.Context(), 15s)`.
+  Collect results + per-tracker errors under a mutex. **Fail-open per
+  tracker** — the endpoint returns 200 with partial results and an `errors`
+  array; it only 4xxs on a bad request shape.
+- Results are interleaved sorted by `seeders` descending (unknown last),
+  stable by tracker name. No global cap beyond the per-tracker 50.
+- The handler needs new deps (`Creds`, `Master`) on the `Trackers` handler
+  struct — wire in `router.go`.
+
+Timeout note: 15s per tracker mirrors the existing preview (15s) budget;
+the fan-out means total latency ≈ slowest tracker, not the sum.
+
+Abuse guard: a **per-user single-in-flight** gate (small in-memory
+`map[userID]struct{}` under a mutex; concurrent second search → 429). Each
+search fans out real scraping requests, and a scripted loop could get the
+instance's IP banned by trackers. No general rate-limit middleware exists
+in the codebase; this one-map guard is the proportionate version.
+
+Decision (explicit): search failures do NOT feed
+`domains.Store.ReportFailure` — domain rotation stays scheduler-driven.
+An interactive search hitting a cold mirror shouldn't spin the ring the
+scheduler depends on.
+
+### 4. Capability discovery
+
+`GET /api/v1/system/info` tracker entries gain
+`"supports_search": bool` (same pattern as `supports_credentials`), so the
+frontend can (a) show the search affordance only when ≥1 tracker is
+searchable and (b) label which trackers are being searched / which need an
+account.
+
+### 5. Metrics
+
+One counter, consistent with existing scheduler/tracker collectors:
+
+```
+marauder_tracker_search_total{tracker, result}  // result: ok|error|no_credentials
+```
+
+(Label is `tracker` — the code's actual convention across every existing
+tracker-labelled collector; CLAUDE.md's `{tracker_name}` prose is stale.)
+
+Registered in `internal/metrics`, incremented in the handler fan-out (not
+in plugins).
+
+### 6. Frontend
+
+New component `frontend/src/components/topics/TrackerSearch.tsx`
+(≤250 lines; sub-components split out if it grows):
+
+- **Hosted in `AddTopicCard` (79 lines), NOT TopicForm** — TopicForm is
+  418 lines, already over the 250 ceiling (tracked tech debt), and its
+  add-mode URL lives in internal `addUrl` state initialized once from
+  `initial.url`. AddTopicCard renders the mode toggle (two tab buttons —
+  **By URL** default, **Search**) above either TrackerSearch or TopicForm.
+  Picking a search result sets AddTopicCard-local `selectedUrl` state,
+  switches to By-URL mode, and remounts the form via
+  `<TopicForm key={selectedUrl} initial={{...EMPTY, url: selectedUrl}}>` —
+  the existing debounced match/preview flow fires as if the URL was
+  pasted. **TopicForm delta: zero lines.** Edit mode (EditTopicCard) never
+  shows the toggle.
+- Search mode: text input + explicit search button (Enter submits; **no
+  search-as-you-type** — these are slow scraping calls, one request per
+  deliberate action; React Query `useQuery` with `enabled: false` +
+  `refetch()` on submit, key `QK.trackerSearch(q)` added to
+  `queryKeys.ts`).
+- Results list: each row shows title (truncated), tracker badge, size,
+  seeders, category. Click → `onSelect(url)` up to AddTopicCard (see
+  hosting note above).
+- Per-tracker errors render as a dismissable muted line under the results
+  ("RuTracker: needs a tracker account — add one under Accounts"), mapping
+  `search requires credentials` to a friendly i18n string.
+- Empty state after a search: honest "No results" (`—` style, per
+  no-synthetic-data).
+- i18n: new keys in both `en` and `ru` dictionaries.
+- Tests: `TrackerSearch.test.tsx` — renders results from a mocked fetch,
+  click fills URL, credential-error row shown, empty state.
+
+### 7. Documentation & site
+
+- `docs/trackers.md`: new "Searching trackers" section (which trackers,
+  credential requirements).
+- `CLAUDE.md`: registry capability list + handler/route/table updates.
+- `CHANGELOG.md` `[Unreleased]`: feature bullet.
+- `site/` (marauder.cc): add search to the feature list where the existing
+  features are enumerated (keep copy consistent with the site's tone).
+- `README.md` feature list: one bullet.
+
+## Security considerations
+
+- **SSRF**: search URLs are built exclusively from `effectiveDomain()`
+  (allowlist-resolved) + URL-escaped query — the user controls only the
+  query string, never the host. Same posture as existing canonical-URL
+  builders.
+- **Credential handling**: decrypt-in-handler mirrors the existing
+  credentials-test endpoint; plaintext secrets never leave the process,
+  never logged, never in responses.
+- **XSS**: scraped titles/categories flow through React text rendering
+  (auto-escaped); no `dangerouslySetInnerHTML`.
+- **Injection into the pipeline**: a search result URL still passes
+  through `CanParse` + `Parse` + the topics handler's normal validation —
+  search grants no shortcut around URL validation.
+- **Metrics cardinality**: `tracker_name` is a small closed set; `result`
+  is a 3-value enum. No user data in labels.
+
+## Success criteria (verifiable)
+
+1. `go build ./... && go vet ./... && go test -race ./...` green in the
+   golang:1.25 container.
+2. `npm run typecheck && npm test && npm run build` green in node:20-alpine.
+3. Live check against the local dev stack: `GET /api/v1/trackers/search?q=<real query>`
+   returns real Rutor results (read-only live fetch — allowed by the
+   no-synthetic-data rule); a click on a result in the UI creates a
+   monitored topic end-to-end. **Known risk:** `rutor.org` (canonical
+   domain) 403s some datacenter/VPS IPs while `rutor.info` serves fine —
+   if the live check fails with 403, switch the active domain to
+   `rutor.info` via the admin Tracker domains card (issue #126 machinery)
+   rather than debugging the plugin.
+4. `/code-review` findings fixed or explicitly triaged.
+
+## Open questions resolved by default
+
+- *Should search hit all trackers or only ones the user has credentials
+  for?* → All searchable ones; credential-less login-gated trackers report
+  a friendly per-tracker error instead of being silently absent.
+- *Debounced live search?* → No; explicit submit. Scraping calls are
+  expensive and slow; a keystroke-debounced fan-out would hammer trackers.
+- *Cache results?* → React Query's in-memory cache only (default staleness);
+  no server-side cache in phase 1.

--- a/docs/superpowers/plans/2026-07-23-tracker-search.md
+++ b/docs/superpowers/plans/2026-07-23-tracker-search.md
@@ -1,0 +1,901 @@
+# Tracker Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In-app tracker search (issue #129): type a query, get results from searchable trackers, click one to pre-fill the AddTopic flow.
+
+**Architecture:** New optional `registry.WithSearch` tracker capability implemented by Rutor (public) and RuTracker (login-gated); a concurrent fan-out handler at `GET /api/v1/trackers/search` with per-tracker fail-open; a search mode toggle hosted in `AddTopicCard` that feeds selected result URLs into the untouched `TopicForm` via key-remount. Spec: `docs/superpowers/plans/2026-07-23-tracker-search-spec.md` (verified revision).
+
+**Tech Stack:** Go 1.25 (regex scraping, no new deps — `x/text/charmap` already present), chi router, React 19 + React Query + Vitest.
+
+## Global Constraints
+
+- Backend verify: `docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 sh -c "gofmt -l . | tee /dev/stderr | (! grep .) && go build ./... && go vet ./... && go test -race ./..."`
+- Frontend verify: `docker run --rm -v "E:/Projects/Stukans/Marauder/frontend:/frontend" -w //frontend node:20-alpine sh -c "npm run typecheck && npm test -- --run && npm run build"`
+- Never edit `frontend/src/components/ui/*` (shadcn-managed).
+- `TopicForm.tsx` delta must be **zero lines** (418 lines, over the 250 ceiling).
+- Metrics label is `tracker` (NOT `tracker_name`).
+- RuTracker query param `nm` must be cp1251-encoded then percent-escaped; rutor query must use `url.PathEscape` (path segment).
+- No AI attribution anywhere (commits, comments, PR).
+- Commit messages: imperative, ≤72-char subject, reference #129.
+- Per-tracker result cap: 50. Per-tracker timeout: 15s. Query cap: 200 runes.
+
+---
+
+### Task 1: `registry.WithSearch` capability + sentinel
+
+**Files:**
+- Modify: `backend/internal/plugins/registry/registry.go` (after `WithAuthorComment`, ~line 148)
+- Modify: `backend/internal/plugins/registry/errors.go` (append)
+
+**Interfaces:**
+- Produces: `registry.SearchResult{Title, URL, Size string; Seeders int; Category string}`, `registry.WithSearch{ Search(ctx, query string, creds *domain.TrackerCredential) ([]SearchResult, error) }`, `registry.ErrSearchRequiresCredentials`.
+
+- [ ] **Step 1: Add the types** (pure declarations — no test; compile check is the gate)
+
+In `registry.go` after the `WithAuthorComment` interface:
+
+```go
+// SearchResult is one release found by a tracker search (issue #129). URL is
+// the topic page in the tracker's canonical form — exactly what a user would
+// paste into the AddTopic form, so every result feeds the existing
+// match → parse → create pipeline unchanged. Size and Category are
+// display-only strings exactly as scraped (no byte parsing — a mis-parsed
+// size would render as a confident wrong number). Seeders is -1 when the
+// tracker doesn't expose a count.
+type SearchResult struct {
+	Title    string `json:"title"`
+	URL      string `json:"url"`
+	Size     string `json:"size,omitempty"`
+	Seeders  int    `json:"seeders"`
+	Category string `json:"category,omitempty"`
+}
+
+// WithSearch is an optional tracker capability: search the tracker by free-
+// text query and return candidate topics to monitor. creds may be nil; a
+// tracker whose search page is login-gated returns
+// ErrSearchRequiresCredentials so callers can distinguish "needs an
+// account" from "found nothing". Implementations cap results at the first
+// page (≤50) and never treat an empty result set as an error.
+type WithSearch interface {
+	Tracker
+	Search(ctx context.Context, query string, creds *domain.TrackerCredential) ([]SearchResult, error)
+}
+```
+
+In `errors.go`:
+
+```go
+// ErrSearchRequiresCredentials is returned by a WithSearch tracker whose
+// search page is login-gated (RuTracker's tracker.php) when no credential —
+// or no longer-valid session — is available. The search handler surfaces it
+// as a per-tracker "needs an account" notice instead of a hard failure.
+var ErrSearchRequiresCredentials = errors.New("search requires credentials")
+```
+
+- [ ] **Step 2: Compile check** — backend verify command (build portion). Expected: clean.
+- [ ] **Step 3: Commit** — `feat: add WithSearch tracker capability (#129)`
+
+---
+
+### Task 2: `forumcommon.EncodeWindows1251Query`
+
+**Files:**
+- Modify: `backend/internal/plugins/trackers/forumcommon/text.go`
+- Test: `backend/internal/plugins/trackers/forumcommon/text_test.go` (append)
+
+**Interfaces:**
+- Produces: `forumcommon.EncodeWindows1251Query(s string) string` — cp1251-transcode then percent-escape every byte outside RFC-3986 unreserved.
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestEncodeWindows1251Query(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{"ascii passthrough", "dune", "dune"},
+		{"space escaped", "dune part", "dune%20part"},
+		// Д=0xC4 ю=0xFE н=0xED а=0xE0 in cp1251.
+		{"cyrillic cp1251 bytes", "Дюна", "%C4%FE%ED%E0"},
+		{"mixed", "Дюна 2", "%C4%FE%ED%E0%202"},
+		{"unreserved kept", "a-b_c.d~e", "a-b_c.d~e"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EncodeWindows1251Query(tt.in); got != tt.want {
+				t.Errorf("EncodeWindows1251Query(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (undefined function)
+- [ ] **Step 3: Implement**
+
+```go
+// EncodeWindows1251Query percent-escapes s for use as a query parameter on a
+// cp1251 site (RuTracker's tracker.php?nm=). Go's url.Values.Encode emits
+// UTF-8 percent-encoding, which cp1251 backends read as mojibake — every
+// Cyrillic search would return zero results. So: transcode to cp1251 first
+// (unmappable runes become the encoder's substitute byte rather than failing
+// the whole query), then percent-escape everything outside RFC-3986
+// unreserved.
+func EncodeWindows1251Query(s string) string {
+	enc, err := encoding.ReplaceUnsupported(charmap.Windows1251.NewEncoder()).String(s)
+	if err != nil {
+		enc = s // fall back to UTF-8 bytes; a degraded search beats an error
+	}
+	var b strings.Builder
+	for i := 0; i < len(enc); i++ {
+		c := enc[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			c == '-', c == '.', c == '_', c == '~':
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+```
+
+Add imports: `fmt`, `golang.org/x/text/encoding`.
+
+- [ ] **Step 4: Run — expect PASS**
+- [ ] **Step 5: Commit** — `feat: add cp1251 query encoder for forum tracker search (#129)`
+
+---
+
+### Task 3: Rutor `Search`
+
+**Files:**
+- Modify: `backend/internal/plugins/trackers/rutor/rutor.go`
+- Test: `backend/internal/plugins/trackers/rutor/rutor_test.go` (append; follow the file's existing httptest/domain-injection pattern — read it first)
+
+**Interfaces:**
+- Consumes: `registry.SearchResult`, `registry.WithSearch` (Task 1); existing `p.effectiveDomain()`, `p.fetch`.
+- Produces: rutor implements `registry.WithSearch`.
+
+- [ ] **Step 1: Failing test** — serve a fixture search page from an httptest server (reuse the existing test-injection style in `rutor_test.go` — the tests there already build a `plugin` literal with a test domain/client). Fixture: during implementation first try to capture real HTML (`curl -s "https://rutor.info/search/0/0/000/0/test"`), trim to a few rows; if unreachable, hand-write rows matching the verified live markup:
+
+```html
+<tr class="gai"><td>22&nbsp;Июл&nbsp;26</td><td>
+<a class="downgif" href="/download/975045"><img src="/s/i/d.gif" alt="D"></a>
+<a href="magnet:?xt=urn:btih:aaaabbbbccccddddeeeeffff0000111122223333"><img src="/s/i/m.gif" alt="M"></a>
+<a href="/torrent/975045/test-release-1080p">Test release <b>1080p</b></a></td>
+<td align="right">1.4&nbsp;GB</td>
+<td align="center"><span class="green">&nbsp;17&nbsp;</span>&nbsp;<span class="red">3</span></td></tr>
+```
+
+Test asserts: one result; `Title == "Test release 1080p"` (tags flattened, entities unescaped); `URL == "<server-host>/torrent/975045"` canonical rebuild; `Size == "1.4 GB"` (nbsp normalized to space); `Seeders == 17`; empty query returns `(nil, nil)`; a page with no rows returns empty slice, no error.
+
+- [ ] **Step 2: Run — expect FAIL**
+- [ ] **Step 3: Implement**
+
+```go
+var _ registry.WithSearch = (*plugin)(nil)
+
+var (
+	searchRowRe   = regexp.MustCompile(`(?s)<tr[^>]*>(.*?)</tr>`)
+	searchLinkRe  = regexp.MustCompile(`(?s)<a href="/torrent/(\d+)[^"]*">(.*?)</a>`)
+	searchSizeRe  = regexp.MustCompile(`<td align="right">([^<]+)</td>`)
+	searchSeedsRe = regexp.MustCompile(`<span class="green">[^0-9]*(\d+)`)
+)
+
+// Search implements registry.WithSearch. Rutor's search is public; the
+// query is a path segment (page 0, category 0, filter 000, sort 0).
+func (p *plugin) Search(ctx context.Context, query string, _ *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	target := fmt.Sprintf("https://%s/search/0/0/000/0/%s", p.effectiveDomain(), url.PathEscape(q))
+	body, err := p.fetch(ctx, target)
+	if err != nil {
+		return nil, fmt.Errorf("rutor search: %w", err)
+	}
+	var out []registry.SearchResult
+	for _, row := range searchRowRe.FindAllSubmatch(body, -1) {
+		cell := row[1]
+		link := searchLinkRe.FindSubmatch(cell)
+		if link == nil {
+			continue // header/spacer row
+		}
+		r := registry.SearchResult{
+			Title:   htmlFlatten(string(link[2])),
+			URL:     fmt.Sprintf("https://%s/torrent/%s", p.effectiveDomain(), link[1]),
+			Seeders: -1,
+		}
+		if m := searchSizeRe.FindSubmatch(cell); m != nil {
+			r.Size = htmlFlatten(string(m[1]))
+		}
+		if m := searchSeedsRe.FindSubmatch(cell); m != nil {
+			if n, err := strconv.Atoi(string(m[1])); err == nil {
+				r.Seeders = n
+			}
+		}
+		out = append(out, r)
+		if len(out) == 50 {
+			break
+		}
+	}
+	return out, nil
+}
+
+// htmlFlatten strips tags and entities from a scraped fragment and
+// collapses the &nbsp; runs rutor uses as padding.
+func htmlFlatten(s string) string {
+	return strings.TrimSpace(forumcommon.HTMLToText(s))
+}
+```
+
+NOTE for implementer: check `forumcommon.HTMLToText` first — if it already trims/unescapes, keep the wrapper trivial; if it doesn't unescape entities, add `html.UnescapeString`. The test (nbsp → space) is the arbiter. Add imports as needed (`strconv`, `forumcommon`).
+
+- [ ] **Step 4: Run — expect PASS** (whole rutor package)
+- [ ] **Step 5: Commit** — `feat: rutor search support (#129)`
+
+---
+
+### Task 4: RuTracker `Search`
+
+**Files:**
+- Create: `backend/internal/plugins/trackers/rutracker/search.go`
+- Test: `backend/internal/plugins/trackers/rutracker/search_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 types, Task 2 `EncodeWindows1251Query`, existing `p.fetchBytes`, `p.effectiveDomain()`, `forumcommon.DecodeWindows1251`.
+- Produces: rutracker implements `registry.WithSearch`.
+
+- [ ] **Step 1: Failing tests** (new file; use the package's existing transport-injection pattern — `p.transport` + httptest, see `rutracker_test.go`):
+  - nil creds → `errors.Is(err, registry.ErrSearchRequiresCredentials)`, no HTTP call made.
+  - Authenticated page (body contains `id="logged-in-username"`) with two `tCenter` result rows → titles cp1251-decoded and tag-flattened, URLs rebuilt `https://<host>/forum/viewtopic.php?t=<id>`, size from `tor-size` cell, seeders from `seedmed`, category from the forum-link cell.
+  - Response WITHOUT the logged-in marker (anonymous redirect to login form) → `ErrSearchRequiresCredentials`.
+  - Cyrillic query: assert the request URL's `nm=` equals the cp1251 escape (`%C4%FE%ED%E0` for `Дюна`) — capture via the test server handler.
+
+Fixture rows (cp1251-encode the file bytes in the test server response, or serve UTF-8 and rely on the decode passthrough — prefer real cp1251 bytes via `charmap.Windows1251.NewEncoder()` in the test to exercise decoding):
+
+```html
+<table id="tor-tbl"><tr class="tCenter hl-tr">
+<td class="row1 t-ico"></td>
+<td class="row1 f-name-col"><div class="f-name"><a class="gen f ts-text" href="tracker.php?f=313">Зарубежное кино</a></div></td>
+<td class="row4 med tLeft t-title-col"><div class="t-title"><a data-topic_id="100" class="med tLink tt-text ts-text hl-tags bold" href="viewtopic.php?t=100">Дюна <span class="brackets-pair">[2026]</span></a></div></td>
+<td class="row1 t-author-col"></td>
+<td class="row4 med tor-size" data-ts_text="1500000000"><a class="small tr-dl dl-stub" href="dl.php?t=100">1.4&nbsp;GB</a></td>
+<td class="row4 nowrap" data-ts_text="17"><b class="seedmed">17</b></td>
+<td class="row4 leechmed bold">3</td><td class="row4 small nowrap">22-Июл-26</td>
+</tr></table>
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+- [ ] **Step 3: Implement** `search.go`:
+
+```go
+package rutracker
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/plugins/trackers/forumcommon"
+)
+
+var _ registry.WithSearch = (*plugin)(nil)
+
+var (
+	searchRowRe   = regexp.MustCompile(`(?s)<tr class="[^"]*tCenter[^"]*"[^>]*>(.*?)</tr>`)
+	searchLinkRe  = regexp.MustCompile(`(?s)<a[^>]*class="[^"]*tLink[^"]*"[^>]*>(.*?)</a>`)
+	searchTIDRe   = regexp.MustCompile(`viewtopic\.php\?t=(\d+)`)
+	searchSizeRe  = regexp.MustCompile(`(?s)<td[^>]*class="[^"]*tor-size[^"]*"[^>]*>(.*?)</td>`)
+	searchSeedsRe = regexp.MustCompile(`<b class="seedmed">\s*(\d+)`)
+	searchForumRe = regexp.MustCompile(`(?s)<a[^>]*href="tracker\.php\?f=\d+[^"]*"[^>]*>(.*?)</a>`)
+)
+
+// Search implements registry.WithSearch. RuTracker's tracker.php is
+// login-gated: with no credential (or a dead session that Login could not
+// revive at the handler layer) it returns ErrSearchRequiresCredentials.
+// The nm param must be cp1251-percent-encoded — UTF-8 encoding reads as
+// mojibake server-side and returns zero results for Cyrillic queries.
+func (p *plugin) Search(ctx context.Context, query string, creds *domain.TrackerCredential) ([]registry.SearchResult, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	if creds == nil {
+		return nil, registry.ErrSearchRequiresCredentials
+	}
+	target := fmt.Sprintf("https://%s/forum/tracker.php?nm=%s",
+		p.effectiveDomain(), forumcommon.EncodeWindows1251Query(q))
+	body, err := p.fetchBytes(ctx, nil, creds, target)
+	if err != nil {
+		return nil, fmt.Errorf("rutracker search: %w", err)
+	}
+	page := forumcommon.DecodeWindows1251(string(body))
+	if !strings.Contains(page, `id="logged-in-username"`) {
+		// tracker.php served the anonymous login shell — session is dead.
+		return nil, registry.ErrSearchRequiresCredentials
+	}
+	var out []registry.SearchResult
+	for _, row := range searchRowRe.FindAllStringSubmatch(page, -1) {
+		cell := row[1]
+		linkM := searchLinkRe.FindStringSubmatchIndex(cell)
+		if linkM == nil {
+			continue
+		}
+		anchor := cell[linkM[0]:linkM[1]]
+		tid := searchTIDRe.FindStringSubmatch(anchor)
+		if tid == nil {
+			continue
+		}
+		r := registry.SearchResult{
+			Title:   htmlFlatten(cell[linkM[2]:linkM[3]]),
+			URL:     fmt.Sprintf("https://%s/forum/viewtopic.php?t=%s", p.effectiveDomain(), tid[1]),
+			Seeders: -1,
+		}
+		if m := searchSizeRe.FindStringSubmatch(cell); m != nil {
+			r.Size = htmlFlatten(m[1])
+		}
+		if m := searchSeedsRe.FindStringSubmatch(cell); m != nil {
+			if n, cerr := strconv.Atoi(m[1]); cerr == nil {
+				r.Seeders = n
+			}
+		}
+		if m := searchForumRe.FindStringSubmatch(cell); m != nil {
+			r.Category = htmlFlatten(m[1])
+		}
+		out = append(out, r)
+		if len(out) == 50 {
+			break
+		}
+	}
+	return out, nil
+}
+
+// htmlFlatten strips nested highlight spans and entities from scraped cells.
+func htmlFlatten(s string) string {
+	return strings.TrimSpace(forumcommon.HTMLToText(s))
+}
+```
+
+(Same `HTMLToText` caveat as Task 3 — one shared verification, adjust both.)
+
+- [ ] **Step 4: Run — expect PASS** (whole rutracker package)
+- [ ] **Step 5: Commit** — `feat: rutracker login-gated search (#129)`
+
+---
+
+### Task 5: Search API handler + metrics + router
+
+**Files:**
+- Modify: `backend/internal/metrics/metrics.go` (tracker metrics section)
+- Create: `backend/internal/api/handlers/trackers_search.go`
+- Modify: `backend/internal/api/handlers/trackers.go` (struct fields only)
+- Modify: `backend/internal/api/router.go` (~line 132 handler ctor, ~line 172 route)
+- Test: `backend/internal/api/handlers/trackers_search_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 types; `credentialStore` seam + `currentUserID` + `writeJSON` + `problem` (all already in package `handlers`); `crypto.MasterKey` decrypt calls — copy the exact decrypt sequence from `Credentials.Test` (`credentials.go`, secret + session blob).
+- Produces: `GET /api/v1/trackers/search?q=&trackers=` → `{results: [...], errors: [...]}`; `metrics.TrackerSearchTotal`.
+
+- [ ] **Step 1: Metrics counter** in the tracker section of `metrics.go`:
+
+```go
+	// TrackerSearchTotal counts interactive tracker searches (issue #129),
+	// partitioned by tracker and outcome.
+	TrackerSearchTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "marauder_tracker_search_total",
+			Help: "Number of tracker search attempts, partitioned by tracker and result.",
+		},
+		[]string{"tracker", "result"}, // "ok" | "error" | "no_credentials"
+	)
+```
+
+- [ ] **Step 2: Failing handler tests.** Register fakes via `registry.RegisterTracker` + `t.Cleanup(registry.Reset)` (existing `trackers_test.go` pattern; note Reset nukes real plugins for the process — the existing tests already accept that). Fakes: `fakeSearchTracker` (returns two results, seeders 5 and 12), `fakeCredsSearchTracker` (implements `WithCredentials` + `WithSearch`, returns `ErrSearchRequiresCredentials` when creds nil), `fakeSlowSearchTracker` (blocks on ctx.Done). Cases:
+  - missing `q` → 400.
+  - q > 200 runes → 400.
+  - happy path → 200, results sorted seeders desc across trackers, `errors` empty.
+  - creds-tracker with no stored credential (fake store returns not-found) → result set from the public fake only + `errors: [{tracker_name, error: "search requires credentials"}]`.
+  - `trackers=fake-a` filter → only that tracker searched.
+  - second concurrent request for same user → 429 (start slow search in goroutine, assert second returns 429, cancel).
+
+Fake credential store: implement the package's existing `credentialStore` interface; only `GetForTracker` matters (return `nil, pgx.ErrNoRows`-equivalent error).
+
+- [ ] **Step 3: Run — expect FAIL**
+- [ ] **Step 4: Implement.** Extend the struct in `trackers.go`:
+
+```go
+type Trackers struct {
+	BaseURL string
+	Creds   credentialStore   // nil-safe: skipped when absent (tests)
+	Master  *crypto.MasterKey // used only to decrypt stored credentials for login-gated search
+	searchInFlight sync.Map   // userID -> struct{}; per-user single-flight gate
+}
+```
+
+`trackers_search.go` — full handler:
+
+```go
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/metrics"
+	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
+	"github.com/artyomsv/marauder/backend/internal/problem"
+)
+
+const (
+	searchQueryMaxRunes    = 200
+	searchPerTrackerBudget = 15 * time.Second
+)
+
+// searchResultView is one row of GET /trackers/search — a registry result
+// plus which tracker produced it.
+type searchResultView struct {
+	TrackerName        string `json:"tracker_name"`
+	TrackerDisplayName string `json:"tracker_display_name"`
+	registry.SearchResult
+}
+
+type searchErrorView struct {
+	TrackerName string `json:"tracker_name"`
+	Error       string `json:"error"`
+}
+
+// Search handles GET /api/v1/trackers/search?q=<query>&trackers=<csv>.
+// Fans out to every WithSearch tracker concurrently; per-tracker failures
+// degrade to entries in `errors` (fail-open) — only a bad request shape
+// produces a non-200. A per-user single-flight gate returns 429 on
+// concurrent searches: every call triggers real scraping requests, and a
+// runaway loop could get the instance's IP banned by trackers.
+func (h *Trackers) Search(w http.ResponseWriter, r *http.Request) {
+	uid, perr := currentUserID(r)
+	if perr != nil {
+		problem.Write(w, r, h.BaseURL, perr)
+		return
+	}
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+	if q == "" {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("q query parameter is required"))
+		return
+	}
+	if utf8.RuneCountInString(q) > searchQueryMaxRunes {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("query too long (max 200 characters)"))
+		return
+	}
+	var filter map[string]bool
+	if raw := strings.TrimSpace(r.URL.Query().Get("trackers")); raw != "" {
+		filter = map[string]bool{}
+		for _, n := range strings.Split(raw, ",") {
+			if n = strings.TrimSpace(n); n != "" {
+				filter[n] = true
+			}
+		}
+	}
+	if _, busy := h.searchInFlight.LoadOrStore(uid, struct{}{}); busy {
+		problem.Write(w, r, h.BaseURL, problem.ErrTooManyRequests("a search is already running; wait for it to finish"))
+		return
+	}
+	defer h.searchInFlight.Delete(uid)
+
+	type outcome struct {
+		results []searchResultView
+		errView *searchErrorView
+	}
+	var (
+		searchers []registry.WithSearch
+	)
+	for _, t := range registry.ListTrackers() {
+		ws, ok := t.(registry.WithSearch)
+		if !ok || (filter != nil && !filter[t.Name()]) {
+			continue
+		}
+		searchers = append(searchers, ws)
+	}
+	outcomes := make([]outcome, len(searchers))
+	done := make(chan int)
+	for i, ws := range searchers {
+		go func(i int, ws registry.WithSearch) {
+			defer func() { done <- i }()
+			ctx, cancel := context.WithTimeout(r.Context(), searchPerTrackerBudget)
+			defer cancel()
+			name := ws.Name()
+			creds := h.searchCredentials(ctx, uid, ws)
+			results, err := ws.Search(ctx, q, creds)
+			switch {
+			case errors.Is(err, registry.ErrSearchRequiresCredentials):
+				metrics.TrackerSearchTotal.WithLabelValues(name, "no_credentials").Inc()
+				outcomes[i] = outcome{errView: &searchErrorView{TrackerName: name, Error: "search requires credentials"}}
+			case err != nil:
+				metrics.TrackerSearchTotal.WithLabelValues(name, "error").Inc()
+				log.Warn().Str("tracker", name).Err(err).Msg("tracker search failed")
+				outcomes[i] = outcome{errView: &searchErrorView{TrackerName: name, Error: err.Error()}}
+			default:
+				metrics.TrackerSearchTotal.WithLabelValues(name, "ok").Inc()
+				views := make([]searchResultView, 0, len(results))
+				for _, res := range results {
+					views = append(views, searchResultView{
+						TrackerName:        name,
+						TrackerDisplayName: ws.DisplayName(),
+						SearchResult:       res,
+					})
+				}
+				outcomes[i] = outcome{results: views}
+			}
+		}(i, ws)
+	}
+	for range searchers {
+		<-done
+	}
+
+	results := []searchResultView{}
+	errViews := []searchErrorView{}
+	for _, o := range outcomes {
+		results = append(results, o.results...)
+		if o.errView != nil {
+			errViews = append(errViews, *o.errView)
+		}
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		si, sj := results[i].Seeders, results[j].Seeders
+		if si != sj {
+			return si > sj // unknown (-1) sorts last
+		}
+		return results[i].TrackerName < results[j].TrackerName
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results, "errors": errViews})
+}
+
+// searchCredentials loads, decrypts, and warms the user's credential for a
+// login-gated searchable tracker. Every failure degrades to nil (the plugin
+// then reports ErrSearchRequiresCredentials) — search must never hard-fail
+// on credential trouble. Ordering is Verify-first, Login-on-miss: on a warm
+// in-process session Verify is one cheap GET; only a cold/dead session pays
+// the Login round-trip. (Deliberately neither loginAndVerify — Login→Verify
+// always, right for validating fresh credentials, wasteful per search — nor
+// the scheduler's Login-only loadCredentials.)
+func (h *Trackers) searchCredentials(ctx context.Context, uid uuid.UUID, t registry.Tracker) *domain.TrackerCredential {
+	wc, needsCreds := t.(registry.WithCredentials)
+	if !needsCreds || h.Creds == nil || h.Master == nil {
+		return nil
+	}
+	stored, err := h.Creds.GetForTracker(ctx, uid, t.Name())
+	if err != nil || stored == nil {
+		return nil
+	}
+	// Decrypt secret + session exactly like Credentials.Test does — session
+	// trackers validate the session blob, not the password.
+	// >>> copy the decrypt sequence from credentials.go Test verbatim here <<<
+	if ok, verr := wc.Verify(ctx, stored); verr == nil && ok {
+		return stored
+	}
+	if lerr := wc.Login(ctx, stored); lerr != nil {
+		log.Debug().Str("tracker", t.Name()).Err(lerr).Msg("search credential login failed; searching anonymously")
+		return nil
+	}
+	return stored
+}
+```
+
+The `>>> <<<` marker is the one intentional lookup: replicate `Credentials.Test`'s decrypt calls (secret into `SecretEnc`, session blob when non-empty) with identical error handling — degrade to `return nil` instead of writing a problem. If `problem.ErrTooManyRequests` doesn't exist yet, add it to `backend/internal/problem` following `ErrBadRequest`'s shape with status 429.
+
+Router wiring (`router.go`): `trackersH := &handlers.Trackers{BaseURL: ..., Creds: d.Creds, Master: d.Master}` and `r.Get("/trackers/search", trackersH.Search)` next to the other `/trackers/*` routes.
+
+- [ ] **Step 5: Run — expect PASS** (handlers package, race on)
+- [ ] **Step 6: Commit** — `feat: tracker search API with per-tracker fail-open fan-out (#129)`
+
+---
+
+### Task 6: `supports_search` in /system/info
+
+**Files:**
+- Modify: `backend/internal/api/handlers/system.go:101-114` (`listTrackerInfos`)
+- Test: existing system handler test file (append one assertion; find it via `grep -l listTrackerInfos backend/internal/api/handlers/*_test.go` — if none tests this function, add a focused test registering one fake `WithSearch` tracker and asserting the flag)
+
+- [ ] **Step 1: Failing test** — fake tracker with `Search` method registered → `/system/info` tracker entry has `"supports_search": true`; plain fake → `false`.
+- [ ] **Step 2: Implement** — add to `listTrackerInfos`:
+
+```go
+	_, hasSearch := t.(registry.WithSearch)
+	// inside the map literal:
+	"supports_search": hasSearch,
+```
+
+- [ ] **Step 3: Run — expect PASS**
+- [ ] **Step 4: Commit** — `feat: expose supports_search in system info (#129)`
+
+---
+
+### Task 7: Frontend — search mode in AddTopicCard
+
+**Files:**
+- Modify: `frontend/src/lib/queryKeys.ts` (add key)
+- Create: `frontend/src/components/topics/TrackerSearch.tsx`
+- Modify: `frontend/src/components/topics/AddTopicCard.tsx` (host toggle + remount plumbing)
+- Modify: `frontend/src/i18n/en.ts`, `frontend/src/i18n/ru.ts`
+- Test: `frontend/src/components/topics/TrackerSearch.test.tsx`
+- **Do NOT touch** `TopicForm.tsx`.
+
+**Interfaces:**
+- Consumes: `GET /trackers/search?q=` response `{results: [{tracker_name, tracker_display_name, title, url, size, seeders, category}], errors: [{tracker_name, error}]}`.
+- Produces: `<TrackerSearch onSelect={(url: string) => void} />`.
+
+- [ ] **Step 1: queryKeys.ts**
+
+```ts
+  // /trackers/search?q=… cross-tracker release search (issue #129). Used by
+  // the AddTopic search mode.
+  trackerSearch: (q: string) => ["trackerSearch", q] as const,
+```
+
+- [ ] **Step 2: Failing tests** (`TrackerSearch.test.tsx`, Vitest + RTL + userEvent, mock `api.get`):
+  - typing a query + pressing the search button calls `/trackers/search?q=…` once (no search-as-you-type: typing alone must NOT fire).
+  - results render title, tracker badge, size, seeders; clicking a row calls `onSelect` with the result URL.
+  - per-tracker error `search requires credentials` renders the friendly needs-account line.
+  - empty results after a search → "No results" empty state.
+
+- [ ] **Step 3: Implement `TrackerSearch.tsx`** — shape (final code may adjust classes to match sibling components; follow `TopicForm`'s input/button primitives):
+
+```tsx
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, Search as SearchIcon } from "lucide-react";
+
+import { api } from "@/lib/api";
+import { QK } from "@/lib/queryKeys";
+import { useT } from "@/i18n";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface SearchResultRow {
+  tracker_name: string;
+  tracker_display_name: string;
+  title: string;
+  url: string;
+  size?: string;
+  seeders: number;
+  category?: string;
+}
+
+interface SearchResponse {
+  results: SearchResultRow[];
+  errors: { tracker_name: string; error: string }[];
+}
+
+interface TrackerSearchProps {
+  onSelect: (url: string) => void;
+}
+
+// Cross-tracker release search (issue #129). Explicit submit only — every
+// search fans out real scraping requests server-side, so no
+// search-as-you-type. A picked result is handed up to AddTopicCard, which
+// switches back to URL mode with the URL prefilled.
+export function TrackerSearch({ onSelect }: TrackerSearchProps) {
+  const t = useT();
+  const [query, setQuery] = useState("");
+  const [submitted, setSubmitted] = useState("");
+
+  const search = useQuery({
+    queryKey: QK.trackerSearch(submitted),
+    queryFn: () =>
+      api.get<SearchResponse>(`/trackers/search?q=${encodeURIComponent(submitted)}`),
+    enabled: submitted.length > 0,
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = query.trim();
+    if (q) setSubmitted(q);
+  };
+
+  const results = search.data?.results ?? [];
+  const trackerErrors = search.data?.errors ?? [];
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t("topics.search.placeholder")}
+          autoFocus
+        />
+        <Button type="submit" disabled={search.isFetching || !query.trim()}>
+          {search.isFetching ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <SearchIcon className="size-4" />
+          )}
+          {t("topics.search.button")}
+        </Button>
+      </form>
+
+      {search.isError && (
+        <p className="text-xs text-destructive">{t("topics.search.failed")}</p>
+      )}
+
+      {results.length > 0 && (
+        <ul className="max-h-80 divide-y divide-border/60 overflow-y-auto rounded-md border border-border/60">
+          {results.map((r) => (
+            <li key={`${r.tracker_name}-${r.url}`}>
+              <button
+                type="button"
+                onClick={() => onSelect(r.url)}
+                className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted/50"
+              >
+                <span className="min-w-0 flex-1 truncate text-sm">{r.title}</span>
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                  {r.tracker_display_name}
+                </span>
+                {r.size && (
+                  <span className="shrink-0 text-xs text-muted-foreground">{r.size}</span>
+                )}
+                <span className="shrink-0 text-xs tabular-nums text-success">
+                  {r.seeders >= 0 ? `↑${r.seeders}` : "—"}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {search.isSuccess && results.length === 0 && (
+        <p className="py-4 text-center text-sm text-muted-foreground">
+          {t("topics.search.noResults")}
+        </p>
+      )}
+
+      {trackerErrors.map((e) => (
+        <p key={e.tracker_name} className="text-xs text-muted-foreground">
+          {e.tracker_name}:{" "}
+          {e.error === "search requires credentials"
+            ? t("topics.search.needsAccount")
+            : e.error}
+        </p>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: AddTopicCard toggle.** Replace the card body with mode state; TopicForm remounts via `key`:
+
+```tsx
+type AddMode = "url" | "search";
+
+export function AddTopicCard({ onClose, onCreated }: AddTopicCardProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<AddMode>("url");
+  const [prefillUrl, setPrefillUrl] = useState("");
+  const t = useT();
+  // create mutation unchanged …
+
+  return (
+    <motion.div /* unchanged animation props */>
+      <Card className="overflow-hidden">
+        <div className="flex gap-1 px-6 pt-4">
+          <ModeTab active={mode === "url"} onClick={() => setMode("url")}>
+            {t("topics.search.byUrl")}
+          </ModeTab>
+          <ModeTab active={mode === "search"} onClick={() => setMode("search")}>
+            {t("topics.search.tab")}
+          </ModeTab>
+        </div>
+        {mode === "search" ? (
+          <div className="p-6 pt-4">
+            <TrackerSearch
+              onSelect={(url) => {
+                setPrefillUrl(url);
+                setMode("url");
+              }}
+            />
+          </div>
+        ) : (
+          <TopicForm
+            key={prefillUrl} /* remount when a search result is picked */
+            mode="add"
+            heading="Add a new topic"
+            submitLabel="Add topic"
+            initial={{ ...EMPTY, url: prefillUrl }}
+            isPending={create.isPending}
+            error={error}
+            onClose={onClose}
+            onSubmit={(v) => {
+              setError(null);
+              create.mutate(v);
+            }}
+          />
+        )}
+      </Card>
+    </motion.div>
+  );
+}
+```
+
+`ModeTab` is a tiny local styled button component in the same file (~10 lines). Heading/submitLabel strings stay as-is (they're currently English literals in the existing code — do not convert unrelated strings in this PR).
+
+- [ ] **Step 5: i18n keys** — `en.ts`:
+
+```ts
+  "topics.search.tab": "Search trackers",
+  "topics.search.byUrl": "By URL",
+  "topics.search.placeholder": "Search releases across your trackers…",
+  "topics.search.button": "Search",
+  "topics.search.failed": "Search failed. Try again.",
+  "topics.search.noResults": "No results",
+  "topics.search.needsAccount": "needs a tracker account — add one under Accounts",
+```
+
+`ru.ts`:
+
+```ts
+  "topics.search.tab": "Поиск по трекерам",
+  "topics.search.byUrl": "По ссылке",
+  "topics.search.placeholder": "Поиск релизов по вашим трекерам…",
+  "topics.search.button": "Найти",
+  "topics.search.failed": "Поиск не удался. Попробуйте ещё раз.",
+  "topics.search.noResults": "Ничего не найдено",
+  "topics.search.needsAccount": "нужен аккаунт трекера — добавьте его в разделе «Аккаунты»",
+```
+
+(Match the surrounding dictionaries' key style on sight — flat dotted keys.)
+
+- [ ] **Step 6: Run frontend verify — expect PASS** (typecheck + tests + build)
+- [ ] **Step 7: Commit** — `feat: tracker search mode in the add-topic flow (#129)`
+
+---
+
+### Task 8: Docs, site, changelog
+
+**Files:**
+- Modify: `docs/trackers.md` (new "Searching trackers" section: which trackers are searchable, RuTracker needs an account, results cap/timeout)
+- Modify: `CLAUDE.md` (registry capability list + `WithSearch` blurb, trackers handler routes, metrics mention, frontend component)
+- Modify: `README.md` (one feature bullet)
+- Modify: `CHANGELOG.md` `[Unreleased]` (feature bullet linking #129)
+- Modify: `site/` — find the feature enumeration (`grep -ri "tracker" site/src/pages/index.astro site/src/data/` first) and add search phrasing consistent with existing copy
+- Test: site builds — `docker run --rm -v "E:/Projects/Stukans/Marauder/site:/site" -w //site node:20 sh -c "npm run build"` (Linux container mandatory — node_modules is a Linux install)
+
+- [ ] **Step 1: Write all doc edits**
+- [ ] **Step 2: Site build — expect PASS**
+- [ ] **Step 3: Commit** — `docs: tracker search guide, changelog, site copy (#129)`
+
+---
+
+### Task 9: Full verification + live check + local docker update
+
+- [ ] **Step 1:** Backend verify command (Global Constraints) — expect all green.
+- [ ] **Step 2:** Frontend verify command — expect green.
+- [ ] **Step 3:** Update the local dev stack (per memory: `--no-deps` so postgres isn't recreated):
+
+```bash
+docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dev.yml up -d --build --no-deps backend frontend
+```
+
+- [ ] **Step 4:** Live check (real data only): login to http://localhost:34080 API, `GET /api/v1/trackers/search?q=ubuntu` → expect real rutor results (fallback: switch rutor active domain to `rutor.info` via admin domains card if `rutor.org` 403s). Verify `errors` contains the rutracker needs-credentials entry when no account is configured. No test topics created unless immediately deleted.
+- [ ] **Step 5:** Fix anything found; re-run; commit fixes.
+
+---
+
+### Task 10: Code review, PR
+
+- [ ] **Step 1:** Run `/code-review` (skill) on the branch; fix ALL findings; re-verify.
+- [ ] **Step 2:** Push branch `129-tracker-search`; open PR titled `feat: in-app tracker search to add topics (#129)` — body: problem/solution summary, research evidence line, screenshots note for morning verification, `Closes #129`. No AI attribution.

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -41,6 +41,35 @@ The form then renders:
 
 ---
 
+## Searching trackers from the AddTopic form
+
+Since issue #129 you don't have to hunt down the topic URL in a browser
+first: the **Topics → Add topic** card has a **Search trackers** tab.
+Type a title, press Search, and Marauder queries every searchable
+tracker concurrently (15 s budget each, first result page only, max 50
+rows per tracker). Clicking a result switches back to the By-URL tab
+with the topic URL prefilled — from there the normal match → preview →
+create flow applies unchanged.
+
+Searchable trackers today:
+
+| Tracker | Account needed for search? | Notes |
+|---|---|---|
+| Rutor | No | Public search; works with zero configuration |
+| RuTracker | **Yes** | `tracker.php` is login-gated. Add a RuTracker account under **Accounts** first; without one the search reports "needs a tracker account" and other trackers still return results |
+
+Per-tracker failures never block the rest: a tracker that is down,
+slow, or missing credentials shows a one-line notice under the results
+while the others' results render normally. Searches are also
+rate-limited to one in flight per user — every search triggers real
+scraping requests against the tracker, and hammering them is how
+instances get IP-banned.
+
+Cyrillic queries work on RuTracker: Marauder transcodes the query to
+the cp1251 encoding the site expects before sending it.
+
+---
+
 ## Generic plugins (no account required)
 
 ### Generic magnet

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -57,6 +57,7 @@ Searchable trackers today:
 |---|---|---|
 | Rutor | No | Public search; works with zero configuration |
 | RuTracker | **Yes** | `tracker.php` is login-gated. Add a RuTracker account under **Accounts** first; without one the search reports "needs a tracker account" and other trackers still return results |
+| LostFilm | No | Searches the public series catalog (the site's own search box endpoint). Results are **series** to subscribe to, not individual releases — seeders show as "—" |
 
 Per-tracker failures never block the rest: a tracker that is down,
 slow, or missing credentials shows a one-line notice under the results

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -58,6 +58,8 @@ Searchable trackers today:
 | Rutor | No | Public search; works with zero configuration |
 | RuTracker | **Yes** | `tracker.php` is login-gated. Add a RuTracker account under **Accounts** first; without one the search reports "needs a tracker account" and other trackers still return results |
 | LostFilm | No | Searches the public series catalog (the site's own search box endpoint). Results are **series** to subscribe to, not individual releases — seeders show as "—" |
+| Kinozal | No | Public `browse.php` search (works anonymously; a stored account's session is reused when present). Cyrillic queries are cp1251-encoded |
+| Anilibria | No | Searches the AniLiberty v1 API. Results are **release pages** to subscribe to — seeders show as "—" |
 
 Per-tracker failures never block the rest: a tracker that is down,
 slow, or missing credentials shows a one-line notice under the results

--- a/frontend/src/components/topics/AddTopicCard.test.tsx
+++ b/frontend/src/components/topics/AddTopicCard.test.tsx
@@ -76,14 +76,22 @@ beforeEach(() => {
 });
 
 describe("AddTopicCard", () => {
+  // Visibility is asserted via the panes' `hidden` attribute rather than
+  // toBeVisible(): the card's framer-motion wrapper starts at opacity 0 in
+  // jsdom (animations don't run), which makes CSS-visibility matchers lie.
+  const inHiddenPane = (el: HTMLElement) => el.closest("div[hidden]") !== null;
+
   it("opens in URL mode with the topic form visible", () => {
     render(<AddTopicCard onClose={() => {}} onCreated={() => {}} />, {
       wrapper: wrap(),
     });
-    expect(screen.getByLabelText(/url or magnet link/i)).toBeInTheDocument();
+    expect(inHiddenPane(screen.getByLabelText(/url or magnet link/i))).toBe(false);
+    // The search pane stays mounted (state preservation) but hidden.
     expect(
-      screen.queryByPlaceholderText(/search releases across your trackers/i),
-    ).toBeNull();
+      inHiddenPane(
+        screen.getByPlaceholderText(/search releases across your trackers/i),
+      ),
+    ).toBe(true);
   });
 
   it("switches to search mode via the tab", async () => {
@@ -92,9 +100,27 @@ describe("AddTopicCard", () => {
     });
     await userEvent.click(screen.getByRole("button", { name: /search trackers/i }));
     expect(
-      screen.getByPlaceholderText(/search releases across your trackers/i),
-    ).toBeInTheDocument();
-    expect(screen.queryByLabelText(/url or magnet link/i)).toBeNull();
+      inHiddenPane(
+        screen.getByPlaceholderText(/search releases across your trackers/i),
+      ),
+    ).toBe(false);
+    expect(inHiddenPane(screen.getByLabelText(/url or magnet link/i))).toBe(true);
+  });
+
+  it("preserves half-filled form state across a tab peek", async () => {
+    render(<AddTopicCard onClose={() => {}} onCreated={() => {}} />, {
+      wrapper: wrap(),
+    });
+    const urlInput = screen.getByLabelText(/url or magnet link/i);
+    await userEvent.type(urlInput, "https://rutor.org/torrent/12345");
+
+    await userEvent.click(screen.getByRole("button", { name: /search trackers/i }));
+    await userEvent.click(screen.getByRole("button", { name: /by url/i }));
+
+    // Peeking at the search tab must not wipe what the user typed.
+    expect(screen.getByLabelText(/url or magnet link/i)).toHaveValue(
+      "https://rutor.org/torrent/12345",
+    );
   });
 
   it("prefills the URL form when a search result is picked", async () => {

--- a/frontend/src/components/topics/AddTopicCard.test.tsx
+++ b/frontend/src/components/topics/AddTopicCard.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+
+// AddTopicCard pulls in TopicForm (clients/credentials/match/preview
+// queries) and TrackerSearch (search query) — mock the whole api surface
+// they touch.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      get: vi.fn(),
+      post: vi.fn(),
+      previewTracker: vi.fn(),
+      getClientCategories: vi.fn(),
+    },
+  };
+});
+
+import { api } from "@/lib/api";
+import { AddTopicCard } from "./AddTopicCard";
+
+const mockApi = api as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  previewTracker: ReturnType<typeof vi.fn>;
+  getClientCategories: ReturnType<typeof vi.fn>;
+};
+
+function wrap() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const SEARCH_RESULTS = {
+  results: [
+    {
+      tracker_name: "rutor",
+      tracker_display_name: "Rutor.org",
+      title: "Picked release",
+      url: "https://rutor.org/torrent/975045",
+      size: "1.4 GB",
+      seeders: 17,
+    },
+  ],
+  errors: [],
+};
+
+beforeEach(() => {
+  mockApi.get.mockReset();
+  mockApi.get.mockImplementation((path: string) => {
+    if (path.startsWith("/trackers/search")) return Promise.resolve(SEARCH_RESULTS);
+    if (path.startsWith("/trackers/match"))
+      return Promise.resolve({
+        tracker_name: "rutor",
+        display_name: "Rutor.org",
+        supports_episode_filter: false,
+        supports_season_catalog: false,
+        requires_credentials: false,
+        credentials_optional: false,
+        uses_cloudflare: false,
+      });
+    if (path.startsWith("/clients")) return Promise.resolve({ clients: [] });
+    if (path.startsWith("/credentials")) return Promise.resolve({ credentials: [] });
+    return Promise.resolve({});
+  });
+  mockApi.previewTracker.mockResolvedValue({ title: "", image_url: "" });
+  mockApi.getClientCategories.mockResolvedValue({ supported: false, categories: [] });
+});
+
+describe("AddTopicCard", () => {
+  it("opens in URL mode with the topic form visible", () => {
+    render(<AddTopicCard onClose={() => {}} onCreated={() => {}} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getByLabelText(/url or magnet link/i)).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(/search releases across your trackers/i),
+    ).toBeNull();
+  });
+
+  it("switches to search mode via the tab", async () => {
+    render(<AddTopicCard onClose={() => {}} onCreated={() => {}} />, {
+      wrapper: wrap(),
+    });
+    await userEvent.click(screen.getByRole("button", { name: /search trackers/i }));
+    expect(
+      screen.getByPlaceholderText(/search releases across your trackers/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/url or magnet link/i)).toBeNull();
+  });
+
+  it("prefills the URL form when a search result is picked", async () => {
+    render(<AddTopicCard onClose={() => {}} onCreated={() => {}} />, {
+      wrapper: wrap(),
+    });
+    await userEvent.click(screen.getByRole("button", { name: /search trackers/i }));
+    await userEvent.type(
+      screen.getByPlaceholderText(/search releases across your trackers/i),
+      "picked",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await userEvent.click(await screen.findByText("Picked release"));
+
+    // Back in URL mode, form remounted with the picked URL prefilled.
+    const urlInput = screen.getByLabelText(/url or magnet link/i);
+    expect(urlInput).toHaveValue("https://rutor.org/torrent/975045");
+  });
+});

--- a/frontend/src/components/topics/AddTopicCard.tsx
+++ b/frontend/src/components/topics/AddTopicCard.tsx
@@ -101,16 +101,20 @@ export function AddTopicCard({ onClose, onCreated }: AddTopicCardProps) {
             {t("topics.search.tab")}
           </ModeTab>
         </div>
-        {mode === "search" ? (
-          <div className="p-6 pt-4">
-            <TrackerSearch
-              onSelect={(url) => {
-                setPrefillUrl(url);
-                setMode("url");
-              }}
-            />
-          </div>
-        ) : (
+        {/* Both panes stay mounted; tabs only toggle the `hidden` attribute.
+            Unmounting TopicForm on a tab peek would silently discard any
+            half-filled fields (URL, quality, client, …). The key-remount
+            still fires when a search result is picked — that reset is
+            intentional (the user chose a new URL). */}
+        <div hidden={mode !== "search"} className="p-6 pt-4">
+          <TrackerSearch
+            onSelect={(url) => {
+              setPrefillUrl(url);
+              setMode("url");
+            }}
+          />
+        </div>
+        <div hidden={mode === "search"}>
           <TopicForm
             key={prefillUrl} /* remount when a search result is picked */
             mode="add"
@@ -125,7 +129,7 @@ export function AddTopicCard({ onClose, onCreated }: AddTopicCardProps) {
               create.mutate(v);
             }}
           />
-        )}
+        </div>
       </Card>
     </motion.div>
   );

--- a/frontend/src/components/topics/AddTopicCard.tsx
+++ b/frontend/src/components/topics/AddTopicCard.tsx
@@ -3,8 +3,11 @@ import { useMutation } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 
 import { api, type Topic } from "@/lib/api";
+import { useT } from "@/i18n";
+import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
 import { TopicForm, type TopicFormValues } from "./TopicForm";
+import { TrackerSearch } from "./TrackerSearch";
 
 interface AddTopicCardProps {
   onClose: () => void;
@@ -27,10 +30,41 @@ const EMPTY: TopicFormValues = {
   replaceDeleteData: true,
 };
 
+type AddMode = "url" | "search";
+
+interface ModeTabProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function ModeTab({ active, onClick, children }: ModeTabProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-muted text-foreground"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 // Card wrapping the shared TopicForm for creating a new topic via
-// POST /topics. Owns the create mutation; the form owns the field state.
+// POST /topics. Owns the create mutation and the URL/search mode toggle
+// (issue #129); the form owns the field state. A picked search result
+// remounts TopicForm via key with the URL prefilled, so the existing
+// debounced match/preview flow fires as if the URL was pasted.
 export function AddTopicCard({ onClose, onCreated }: AddTopicCardProps) {
+  const t = useT();
   const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<AddMode>("url");
+  const [prefillUrl, setPrefillUrl] = useState("");
 
   const create = useMutation({
     mutationFn: (v: TopicFormValues) =>
@@ -59,19 +93,39 @@ export function AddTopicCard({ onClose, onCreated }: AddTopicCardProps) {
       transition={{ duration: 0.2 }}
     >
       <Card className="overflow-hidden">
-        <TopicForm
-          mode="add"
-          heading="Add a new topic"
-          submitLabel="Add topic"
-          initial={EMPTY}
-          isPending={create.isPending}
-          error={error}
-          onClose={onClose}
-          onSubmit={(v) => {
-            setError(null);
-            create.mutate(v);
-          }}
-        />
+        <div className="flex gap-1 px-6 pt-4">
+          <ModeTab active={mode === "url"} onClick={() => setMode("url")}>
+            {t("topics.search.byUrl")}
+          </ModeTab>
+          <ModeTab active={mode === "search"} onClick={() => setMode("search")}>
+            {t("topics.search.tab")}
+          </ModeTab>
+        </div>
+        {mode === "search" ? (
+          <div className="p-6 pt-4">
+            <TrackerSearch
+              onSelect={(url) => {
+                setPrefillUrl(url);
+                setMode("url");
+              }}
+            />
+          </div>
+        ) : (
+          <TopicForm
+            key={prefillUrl} /* remount when a search result is picked */
+            mode="add"
+            heading="Add a new topic"
+            submitLabel="Add topic"
+            initial={{ ...EMPTY, url: prefillUrl }}
+            isPending={create.isPending}
+            error={error}
+            onClose={onClose}
+            onSubmit={(v) => {
+              setError(null);
+              create.mutate(v);
+            }}
+          />
+        )}
       </Card>
     </motion.div>
   );

--- a/frontend/src/components/topics/TopicEventsTimeline.test.tsx
+++ b/frontend/src/components/topics/TopicEventsTimeline.test.tsx
@@ -15,15 +15,18 @@ function wrap(ui: React.ReactNode) {
 
 describe("TopicEventsTimeline", () => {
   beforeEach(() => vi.clearAllMocks());
-  it("renders events newest-first with labels", async () => {
+  it("renders event labels and timestamps without the duplicated topic title", async () => {
     (api.topicEvents as ReturnType<typeof vi.fn>).mockResolvedValue({
       events: [
-        { id: 2, event_type: "release.found", severity: "info", message: "New release", created_at: "2026-06-25T10:00:00Z" },
-        { id: 1, event_type: "check.failed", severity: "error", message: "boom", created_at: "2026-06-25T09:00:00Z" },
+        { id: 2, event_type: "release.found", severity: "info", message: "Super Mario Galaxy Movie [2026, DCPRip 1080p]", created_at: "2026-06-25T10:00:00Z" },
+        { id: 1, event_type: "check.failed", severity: "error", message: "Super Mario Galaxy Movie [2026, DCPRip 1080p]", created_at: "2026-06-25T09:00:00Z" },
       ],
     });
     wrap(<TopicEventsTimeline topicId="t1" />);
-    expect(await screen.findByText("New release")).toBeInTheDocument();
-    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(await screen.findByText("new release")).toBeInTheDocument();
+    expect(screen.getByText("error")).toBeInTheDocument();
+    // The persisted message is the topic's own title — inside a per-topic
+    // timeline it must not be rendered (it duplicated on every row).
+    expect(screen.queryByText(/Super Mario Galaxy Movie/)).toBeNull();
   });
 });

--- a/frontend/src/components/topics/TopicEventsTimeline.tsx
+++ b/frontend/src/components/topics/TopicEventsTimeline.tsx
@@ -49,7 +49,11 @@ export function TopicEventsTimeline({ topicId }: TopicEventsTimelineProps) {
             <div className="font-medium">
               {EVENT_LABELS[e.event_type] ? t(EVENT_LABELS[e.event_type]) : e.event_type}
             </div>
-            {e.message && <div className="text-muted-foreground">{e.message}</div>}
+            {/* The persisted message is the event's Title, which for every
+                topic-scoped event is (a variant of) the topic's own display
+                name — pure duplication inside a per-topic timeline, so it is
+                deliberately not rendered. Error details have their own home
+                (TopicError / last_error_code). */}
             <time className="text-xs text-muted-foreground">
               {new Date(e.created_at).toLocaleString()}
             </time>

--- a/frontend/src/components/topics/TrackerSearch.test.tsx
+++ b/frontend/src/components/topics/TrackerSearch.test.tsx
@@ -45,26 +45,79 @@ const RESULTS = {
   ],
 };
 
+const SYSTEM_INFO = {
+  version: { version: "test", commit: "", buildDate: "" },
+  trackers: [
+    {
+      name: "rutor",
+      display_name: "Rutor.org",
+      supports_interactive_login: false,
+      supports_credentials: false,
+      supports_search: true,
+    },
+    {
+      name: "rutracker",
+      display_name: "RuTracker.org",
+      supports_interactive_login: false,
+      supports_credentials: true,
+      supports_search: true,
+    },
+    {
+      name: "toloka",
+      display_name: "Toloka",
+      supports_interactive_login: false,
+      supports_credentials: true,
+      supports_search: false,
+    },
+  ],
+  clients: [],
+  notifiers: [],
+};
+
+// Dispatches by path: the component queries /system/info (coverage widget)
+// and /trackers/search. searchCalls() counts only real searches so
+// call-count assertions ignore the manifest fetch.
+function mockSearchResponse(response: unknown) {
+  mockApi.get.mockImplementation((path: string) => {
+    if (path.startsWith("/system/info")) return Promise.resolve(SYSTEM_INFO);
+    return Promise.resolve(response);
+  });
+}
+
+const searchCalls = () =>
+  mockApi.get.mock.calls.filter(([p]) => String(p).startsWith("/trackers/search"));
+
 beforeEach(() => {
   mockApi.get.mockReset();
 });
 
 describe("TrackerSearch", () => {
   it("does not search while typing; fires once on submit", async () => {
-    mockApi.get.mockResolvedValue(RESULTS);
+    mockSearchResponse(RESULTS);
     render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
 
     await userEvent.type(screen.getByRole("textbox"), "test");
-    expect(mockApi.get).not.toHaveBeenCalled();
+    expect(searchCalls()).toHaveLength(0);
 
     await userEvent.click(screen.getByRole("button", { name: /search/i }));
     expect(await screen.findByText("Test release 1080p")).toBeInTheDocument();
-    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    expect(searchCalls()).toHaveLength(1);
     expect(mockApi.get).toHaveBeenCalledWith("/trackers/search?q=test");
   });
 
+  it("lists the searchable trackers from the plugin manifest", async () => {
+    mockSearchResponse(RESULTS);
+    render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
+
+    expect(await screen.findByText("Searches:")).toBeInTheDocument();
+    expect(screen.getByText("Rutor.org")).toBeInTheDocument();
+    expect(screen.getByText("RuTracker.org")).toBeInTheDocument();
+    // Non-searchable trackers must not appear in the coverage widget.
+    expect(screen.queryByText("Toloka")).toBeNull();
+  });
+
   it("renders result metadata and reports selection", async () => {
-    mockApi.get.mockResolvedValue(RESULTS);
+    mockSearchResponse(RESULTS);
     const onSelect = vi.fn();
     render(<TrackerSearch onSelect={onSelect} />, { wrapper: wrap() });
 
@@ -72,7 +125,8 @@ describe("TrackerSearch", () => {
     await userEvent.click(screen.getByRole("button", { name: /search/i }));
 
     const row = await screen.findByText("Test release 1080p");
-    expect(screen.getByText("Rutor.org")).toBeInTheDocument();
+    // "Rutor.org" appears in both the coverage widget and the result badge.
+    expect(screen.getAllByText("Rutor.org").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("1.4 GB")).toBeInTheDocument();
     expect(screen.getByText("↑17")).toBeInTheDocument();
 
@@ -81,7 +135,7 @@ describe("TrackerSearch", () => {
   });
 
   it("maps the credentials error to a friendly notice", async () => {
-    mockApi.get.mockResolvedValue(RESULTS);
+    mockSearchResponse(RESULTS);
     render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
 
     await userEvent.type(screen.getByRole("textbox"), "test");
@@ -91,7 +145,7 @@ describe("TrackerSearch", () => {
   });
 
   it("shows an honest empty state after a search with no results", async () => {
-    mockApi.get.mockResolvedValue({ results: [], errors: [] });
+    mockSearchResponse({ results: [], errors: [] });
     render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
 
     await userEvent.type(screen.getByRole("textbox"), "nothing");
@@ -101,8 +155,14 @@ describe("TrackerSearch", () => {
   });
 
   it("shows the failure notice and actually retries the same query", async () => {
-    mockApi.get.mockRejectedValueOnce(new Error("boom"));
-    mockApi.get.mockResolvedValueOnce(RESULTS);
+    let searchAttempts = 0;
+    mockApi.get.mockImplementation((path: string) => {
+      if (path.startsWith("/system/info")) return Promise.resolve(SYSTEM_INFO);
+      searchAttempts += 1;
+      return searchAttempts === 1
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve(RESULTS);
+    });
     render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
 
     await userEvent.type(screen.getByRole("textbox"), "test");
@@ -112,11 +172,11 @@ describe("TrackerSearch", () => {
     // Same query, second click — must refetch, not silently no-op.
     await userEvent.click(screen.getByRole("button", { name: /search/i }));
     expect(await screen.findByText("Test release 1080p")).toBeInTheDocument();
-    expect(mockApi.get).toHaveBeenCalledTimes(2);
+    expect(searchCalls()).toHaveLength(2);
   });
 
   it("labels login_failed differently from a missing account", async () => {
-    mockApi.get.mockResolvedValue({
+    mockSearchResponse({
       results: [],
       errors: [
         {

--- a/frontend/src/components/topics/TrackerSearch.test.tsx
+++ b/frontend/src/components/topics/TrackerSearch.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+
+// The component talks to the backend only through api.get.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: { get: vi.fn() } };
+});
+
+import { api } from "@/lib/api";
+import { TrackerSearch } from "./TrackerSearch";
+
+const mockApi = api as unknown as { get: ReturnType<typeof vi.fn> };
+
+function wrap() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const RESULTS = {
+  results: [
+    {
+      tracker_name: "rutor",
+      tracker_display_name: "Rutor.org",
+      title: "Test release 1080p",
+      url: "https://rutor.org/torrent/975045",
+      size: "1.4 GB",
+      seeders: 17,
+    },
+  ],
+  errors: [{ tracker_name: "rutracker", error: "search requires credentials" }],
+};
+
+beforeEach(() => {
+  mockApi.get.mockReset();
+});
+
+describe("TrackerSearch", () => {
+  it("does not search while typing; fires once on submit", async () => {
+    mockApi.get.mockResolvedValue(RESULTS);
+    render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
+
+    await userEvent.type(screen.getByRole("textbox"), "test");
+    expect(mockApi.get).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+    expect(await screen.findByText("Test release 1080p")).toBeInTheDocument();
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    expect(mockApi.get).toHaveBeenCalledWith("/trackers/search?q=test");
+  });
+
+  it("renders result metadata and reports selection", async () => {
+    mockApi.get.mockResolvedValue(RESULTS);
+    const onSelect = vi.fn();
+    render(<TrackerSearch onSelect={onSelect} />, { wrapper: wrap() });
+
+    await userEvent.type(screen.getByRole("textbox"), "test");
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    const row = await screen.findByText("Test release 1080p");
+    expect(screen.getByText("Rutor.org")).toBeInTheDocument();
+    expect(screen.getByText("1.4 GB")).toBeInTheDocument();
+    expect(screen.getByText("↑17")).toBeInTheDocument();
+
+    await userEvent.click(row);
+    expect(onSelect).toHaveBeenCalledWith("https://rutor.org/torrent/975045");
+  });
+
+  it("maps the credentials error to a friendly notice", async () => {
+    mockApi.get.mockResolvedValue(RESULTS);
+    render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
+
+    await userEvent.type(screen.getByRole("textbox"), "test");
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    expect(await screen.findByText(/needs a tracker account/i)).toBeInTheDocument();
+  });
+
+  it("shows an honest empty state after a search with no results", async () => {
+    mockApi.get.mockResolvedValue({ results: [], errors: [] });
+    render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
+
+    await userEvent.type(screen.getByRole("textbox"), "nothing");
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    expect(await screen.findByText("No results")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/topics/TrackerSearch.test.tsx
+++ b/frontend/src/components/topics/TrackerSearch.test.tsx
@@ -35,7 +35,14 @@ const RESULTS = {
       seeders: 17,
     },
   ],
-  errors: [{ tracker_name: "rutracker", error: "search requires credentials" }],
+  errors: [
+    {
+      tracker_name: "rutracker",
+      tracker_display_name: "RuTracker.org",
+      code: "no_credentials",
+      error: "search requires credentials",
+    },
+  ],
 };
 
 beforeEach(() => {
@@ -91,5 +98,41 @@ describe("TrackerSearch", () => {
     await userEvent.click(screen.getByRole("button", { name: /search/i }));
 
     expect(await screen.findByText("No results")).toBeInTheDocument();
+  });
+
+  it("shows the failure notice and actually retries the same query", async () => {
+    mockApi.get.mockRejectedValueOnce(new Error("boom"));
+    mockApi.get.mockResolvedValueOnce(RESULTS);
+    render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
+
+    await userEvent.type(screen.getByRole("textbox"), "test");
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+    expect(await screen.findByText(/search failed\. try again\./i)).toBeInTheDocument();
+
+    // Same query, second click — must refetch, not silently no-op.
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+    expect(await screen.findByText("Test release 1080p")).toBeInTheDocument();
+    expect(mockApi.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("labels login_failed differently from a missing account", async () => {
+    mockApi.get.mockResolvedValue({
+      results: [],
+      errors: [
+        {
+          tracker_name: "rutracker",
+          tracker_display_name: "RuTracker.org",
+          code: "login_failed",
+          error: "tracker login failed",
+        },
+      ],
+    });
+    render(<TrackerSearch onSelect={() => {}} />, { wrapper: wrap() });
+
+    await userEvent.type(screen.getByRole("textbox"), "test");
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    expect(await screen.findByText(/tracker login failed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/needs a tracker account/i)).toBeNull();
   });
 });

--- a/frontend/src/components/topics/TrackerSearch.tsx
+++ b/frontend/src/components/topics/TrackerSearch.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, Search as SearchIcon } from "lucide-react";
+
+import { api } from "@/lib/api";
+import { QK } from "@/lib/queryKeys";
+import { useT } from "@/i18n";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface SearchResultRow {
+  tracker_name: string;
+  tracker_display_name: string;
+  title: string;
+  url: string;
+  size?: string;
+  seeders: number;
+  category?: string;
+}
+
+interface SearchResponse {
+  results: SearchResultRow[];
+  errors: { tracker_name: string; error: string }[];
+}
+
+interface TrackerSearchProps {
+  onSelect: (url: string) => void;
+}
+
+// Cross-tracker release search (issue #129). Explicit submit only — every
+// search fans out real scraping requests server-side, so no
+// search-as-you-type. A picked result is handed up to AddTopicCard, which
+// switches back to URL mode with the URL prefilled.
+export function TrackerSearch({ onSelect }: TrackerSearchProps) {
+  const t = useT();
+  const [query, setQuery] = useState("");
+  const [submitted, setSubmitted] = useState("");
+
+  const search = useQuery({
+    queryKey: QK.trackerSearch(submitted),
+    queryFn: () =>
+      api.get<SearchResponse>(`/trackers/search?q=${encodeURIComponent(submitted)}`),
+    enabled: submitted.length > 0,
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = query.trim();
+    if (q) setSubmitted(q);
+  };
+
+  const results = search.data?.results ?? [];
+  const trackerErrors = search.data?.errors ?? [];
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t("topics.search.placeholder")}
+          aria-label={t("topics.search.tab")}
+          autoFocus
+        />
+        <Button type="submit" disabled={search.isFetching || !query.trim()}>
+          {search.isFetching ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <SearchIcon className="size-4" />
+          )}
+          {t("topics.search.button")}
+        </Button>
+      </form>
+
+      {search.isError && (
+        <p className="text-xs text-destructive">{t("topics.search.failed")}</p>
+      )}
+
+      {results.length > 0 && (
+        <ul className="max-h-80 divide-y divide-border/60 overflow-y-auto rounded-md border border-border/60">
+          {results.map((r) => (
+            <li key={`${r.tracker_name}-${r.url}`}>
+              <button
+                type="button"
+                onClick={() => onSelect(r.url)}
+                className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted/50"
+              >
+                <span className="min-w-0 flex-1 truncate text-sm">{r.title}</span>
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                  {r.tracker_display_name}
+                </span>
+                {r.size && (
+                  <span className="shrink-0 text-xs text-muted-foreground">{r.size}</span>
+                )}
+                <span className="shrink-0 text-xs tabular-nums text-success">
+                  {r.seeders >= 0 ? `↑${r.seeders}` : "—"}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {search.isSuccess && results.length === 0 && (
+        <p className="py-4 text-center text-sm text-muted-foreground">
+          {t("topics.search.noResults")}
+        </p>
+      )}
+
+      {trackerErrors.map((e) => (
+        <p key={e.tracker_name} className="text-xs text-muted-foreground">
+          {e.tracker_name}:{" "}
+          {e.error === "search requires credentials"
+            ? t("topics.search.needsAccount")
+            : e.error}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/topics/TrackerSearch.tsx
+++ b/frontend/src/components/topics/TrackerSearch.tsx
@@ -18,9 +18,18 @@ interface SearchResultRow {
   category?: string;
 }
 
+interface SearchTrackerError {
+  tracker_name: string;
+  tracker_display_name: string;
+  // Stable classification from the backend; the raw error text never
+  // reaches the client (it can embed admin-configured mirror hosts).
+  code: "no_credentials" | "login_failed" | "timeout" | "failed";
+  error: string;
+}
+
 interface SearchResponse {
   results: SearchResultRow[];
-  errors: { tracker_name: string; error: string }[];
+  errors: SearchTrackerError[];
 }
 
 interface TrackerSearchProps {
@@ -48,7 +57,12 @@ export function TrackerSearch({ onSelect }: TrackerSearchProps) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const q = query.trim();
-    if (q) setSubmitted(q);
+    if (!q) return;
+    // Re-submitting the same query must actually retry: setState with the
+    // identical value is a React no-op, so a failed search would otherwise
+    // ignore the "Try again" click until the user edits the text.
+    if (q === submitted) void search.refetch();
+    else setSubmitted(q);
   };
 
   const results = search.data?.results ?? [];
@@ -111,10 +125,12 @@ export function TrackerSearch({ onSelect }: TrackerSearchProps) {
 
       {trackerErrors.map((e) => (
         <p key={e.tracker_name} className="text-xs text-muted-foreground">
-          {e.tracker_name}:{" "}
-          {e.error === "search requires credentials"
+          {e.tracker_display_name || e.tracker_name}:{" "}
+          {e.code === "no_credentials"
             ? t("topics.search.needsAccount")
-            : e.error}
+            : e.code === "login_failed"
+              ? t("topics.search.loginFailed")
+              : t("topics.search.trackerFailed")}
         </p>
       ))}
     </div>

--- a/frontend/src/components/topics/TrackerSearch.tsx
+++ b/frontend/src/components/topics/TrackerSearch.tsx
@@ -5,6 +5,7 @@ import { Loader2, Search as SearchIcon } from "lucide-react";
 import { api } from "@/lib/api";
 import { QK } from "@/lib/queryKeys";
 import { useT } from "@/i18n";
+import { useSystemInfo } from "@/lib/hooks/useSystemInfo";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -44,6 +45,13 @@ export function TrackerSearch({ onSelect }: TrackerSearchProps) {
   const t = useT();
   const [query, setQuery] = useState("");
   const [submitted, setSubmitted] = useState("");
+
+  // Which trackers this search actually covers — from the plugin manifest,
+  // so the list stays truthful as plugins gain WithSearch.
+  const systemInfo = useSystemInfo();
+  const searchableTrackers = (systemInfo.data?.trackers ?? []).filter(
+    (tr) => tr.supports_search,
+  );
 
   const search = useQuery({
     queryKey: QK.trackerSearch(submitted),
@@ -87,6 +95,20 @@ export function TrackerSearch({ onSelect }: TrackerSearchProps) {
           {t("topics.search.button")}
         </Button>
       </form>
+
+      {searchableTrackers.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span>{t("topics.search.coverage")}</span>
+          {searchableTrackers.map((tr) => (
+            <span
+              key={tr.name}
+              className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium"
+            >
+              {tr.display_name}
+            </span>
+          ))}
+        </div>
+      )}
 
       {search.isError && (
         <p className="text-xs text-destructive">{t("topics.search.failed")}</p>

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -60,6 +60,7 @@ const en: Record<string, string> = {
   "topics.search.needsAccount": "needs a tracker account — add one under Accounts",
   "topics.search.loginFailed": "tracker login failed — check your account under Accounts",
   "topics.search.trackerFailed": "search failed on this tracker",
+  "topics.search.coverage": "Searches:",
   "topics.add.urlPlaceholder":
     "magnet:?xt=urn:btih:... or https://tracker.example.com/.../file.torrent",
   "topics.add.displayName": "Display name (optional)",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -58,6 +58,8 @@ const en: Record<string, string> = {
   "topics.search.failed": "Search failed. Try again.",
   "topics.search.noResults": "No results",
   "topics.search.needsAccount": "needs a tracker account — add one under Accounts",
+  "topics.search.loginFailed": "tracker login failed — check your account under Accounts",
+  "topics.search.trackerFailed": "search failed on this tracker",
   "topics.add.urlPlaceholder":
     "magnet:?xt=urn:btih:... or https://tracker.example.com/.../file.torrent",
   "topics.add.displayName": "Display name (optional)",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -51,6 +51,13 @@ const en: Record<string, string> = {
   "topics.empty.cta": "Add your first topic",
   "topics.add.title": "Add a new topic",
   "topics.add.url": "URL or magnet link",
+  "topics.search.tab": "Search trackers",
+  "topics.search.byUrl": "By URL",
+  "topics.search.placeholder": "Search releases across your trackers…",
+  "topics.search.button": "Search",
+  "topics.search.failed": "Search failed. Try again.",
+  "topics.search.noResults": "No results",
+  "topics.search.needsAccount": "needs a tracker account — add one under Accounts",
   "topics.add.urlPlaceholder":
     "magnet:?xt=urn:btih:... or https://tracker.example.com/.../file.torrent",
   "topics.add.displayName": "Display name (optional)",

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -53,6 +53,13 @@ const ru: Record<string, string> = {
   "topics.empty.cta": "Добавить первую тему",
   "topics.add.title": "Добавить новую тему",
   "topics.add.url": "URL или magnet-ссылка",
+  "topics.search.tab": "Поиск по трекерам",
+  "topics.search.byUrl": "По ссылке",
+  "topics.search.placeholder": "Поиск релизов по вашим трекерам…",
+  "topics.search.button": "Найти",
+  "topics.search.failed": "Поиск не удался. Попробуйте ещё раз.",
+  "topics.search.noResults": "Ничего не найдено",
+  "topics.search.needsAccount": "нужен аккаунт трекера — добавьте его в разделе «Аккаунты»",
   "topics.add.urlPlaceholder":
     "magnet:?xt=urn:btih:... или https://tracker.example.com/.../file.torrent",
   "topics.add.displayName": "Отображаемое имя (необязательно)",

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -60,6 +60,8 @@ const ru: Record<string, string> = {
   "topics.search.failed": "Поиск не удался. Попробуйте ещё раз.",
   "topics.search.noResults": "Ничего не найдено",
   "topics.search.needsAccount": "нужен аккаунт трекера — добавьте его в разделе «Аккаунты»",
+  "topics.search.loginFailed": "не удалось войти на трекер — проверьте аккаунт в разделе «Аккаунты»",
+  "topics.search.trackerFailed": "поиск на этом трекере не удался",
   "topics.add.urlPlaceholder":
     "magnet:?xt=urn:btih:... или https://tracker.example.com/.../file.torrent",
   "topics.add.displayName": "Отображаемое имя (необязательно)",

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -62,6 +62,7 @@ const ru: Record<string, string> = {
   "topics.search.needsAccount": "нужен аккаунт трекера — добавьте его в разделе «Аккаунты»",
   "topics.search.loginFailed": "не удалось войти на трекер — проверьте аккаунт в разделе «Аккаунты»",
   "topics.search.trackerFailed": "поиск на этом трекере не удался",
+  "topics.search.coverage": "Поиск по:",
   "topics.add.urlPlaceholder":
     "magnet:?xt=urn:btih:... или https://tracker.example.com/.../file.torrent",
   "topics.add.displayName": "Отображаемое имя (необязательно)",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -463,6 +463,7 @@ export type SystemInfo = {
     display_name: string;
     supports_interactive_login: boolean;
     supports_credentials: boolean;
+    supports_search: boolean;
   }[];
   clients: { name: string; display_name: string }[];
   notifiers: { name: string; display_name: string }[];

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -62,6 +62,10 @@ export const QK = {
   // to suggest values in the AddTopic form's category combobox.
   clientCategories: (id: string) => ["clientCategories", id] as const,
 
+  // /trackers/search?q=… cross-tracker release search (issue #129). Used by
+  // the AddTopic search mode.
+  trackerSearch: (q: string) => ["trackerSearch", q] as const,
+
   // /system/trackers/domains — per-tracker mirror/domain configuration
   // (admin only, issue #126).
   trackerDomains: ["tracker-domains"] as const,

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -91,6 +91,18 @@ const sections = [
     ],
   },
   {
+    title: "In-app tracker search",
+    intro:
+      "Adding a topic used to mean finding the release in your browser first — fighting mirrors, Cloudflare, and login walls just to copy a URL. Now the add-topic form searches your trackers directly.",
+    bullets: [
+      "Type a title in the Search trackers tab; Marauder queries every searchable tracker concurrently and merges the results, sorted by seeders",
+      "Click a result and the topic URL is prefilled into the normal add flow — capability detection, poster preview, and quality options all apply unchanged",
+      "Rutor searches anonymously out of the box; RuTracker search uses your stored account and reports “needs a tracker account” instead of failing when you haven't added one",
+      "Cyrillic queries are transcoded to the cp1251 encoding RuTracker expects, so «Дюна» finds Дюна",
+      "Per-tracker fail-open: a slow or unreachable tracker shows a one-line notice while the others' results render normally",
+    ],
+  },
+  {
     title: "Configurable tracker domains + mirror fallback",
     intro:
       "Trackers move. When a primary domain is blocked or down, point the tracker at a working mirror — instance-wide, without recreating a single topic — and let Marauder rotate mirrors automatically when the current one starts failing.",

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -97,7 +97,7 @@ const sections = [
     bullets: [
       "Type a title in the Search trackers tab; Marauder queries every searchable tracker concurrently and merges the results, sorted by seeders",
       "Click a result and the topic URL is prefilled into the normal add flow — capability detection, poster preview, and quality options all apply unchanged",
-      "Rutor and LostFilm search anonymously out of the box; RuTracker search uses your stored account and reports “needs a tracker account” instead of failing when you haven't added one",
+      "Rutor, Kinozal, LostFilm, and Anilibria search anonymously out of the box; RuTracker search uses your stored account and reports “needs a tracker account” instead of failing when you haven't added one",
       "Cyrillic queries are transcoded to the cp1251 encoding RuTracker expects, so «Дюна» finds Дюна",
       "Per-tracker fail-open: a slow or unreachable tracker shows a one-line notice while the others' results render normally",
     ],

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -97,7 +97,7 @@ const sections = [
     bullets: [
       "Type a title in the Search trackers tab; Marauder queries every searchable tracker concurrently and merges the results, sorted by seeders",
       "Click a result and the topic URL is prefilled into the normal add flow — capability detection, poster preview, and quality options all apply unchanged",
-      "Rutor searches anonymously out of the box; RuTracker search uses your stored account and reports “needs a tracker account” instead of failing when you haven't added one",
+      "Rutor and LostFilm search anonymously out of the box; RuTracker search uses your stored account and reports “needs a tracker account” instead of failing when you haven't added one",
       "Cyrillic queries are transcoded to the cp1251 encoding RuTracker expects, so «Дюна» finds Дюна",
       "Per-tracker fail-open: a slow or unreachable tracker shows a one-line notice while the others' results render normally",
     ],

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -47,7 +47,7 @@ const featureCards: { icon: IconName; title: string; body: string }[] = [
   {
     icon: "radio-tower",
     title: "Watch any forum tracker",
-    body: "Drop in a RuTracker, Kinozal, NNM-Club, LostFilm, Anidub, Anilibria, Toloka, or generic .torrent URL. Marauder scrapes the topic page and detects when an uploader replaces the file — logging in where the tracker requires it, or fetching anonymously where it does not.",
+    body: "Drop in a RuTracker, Kinozal, NNM-Club, LostFilm, Anidub, Anilibria, Toloka, or generic .torrent URL — or search supported trackers by title right from the add-topic form and pick a result. Marauder scrapes the topic page and detects when an uploader replaces the file — logging in where the tracker requires it, or fetching anonymously where it does not.",
   },
   {
     icon: "globe",


### PR DESCRIPTION
## Problem

Adding a topic required already having the topic URL — a browser trip to the tracker (mirrors, Cloudflare, login walls) just to copy a link. Biggest onboarding friction in the product; also the single most-converged feature gap in the 2026-07-23 competitor/community research sweep (monitorrent #316 asked for exactly this; RuTracker's own bot is built around search; qBittorrent's search-plugins repo sits at 6.4k stars).

## What this does

The **Add topic** card gains a **Search trackers** tab: type a title, get live results from every searchable tracker merged and sorted by seeders, click one — the topic URL is prefilled into the normal By-URL flow, and the existing match → preview → quality → create pipeline runs unchanged.

### Backend

- New optional `registry.WithSearch` capability + `registry.ErrSearchRequiresCredentials` sentinel; `SearchResult` carries title/url/size/seeders/category (size stays a display string — no invented byte parsing)
- **Rutor**: public path-segment search (`/search/0/0/000/0/<q>`), zero config
- **RuTracker**: login-gated `tracker.php?nm=` search using the stored account; the query is **cp1251-percent-encoded** (`forumcommon.EncodeWindows1251Query`) — UTF-8 encoding silently returns zero results for Cyrillic queries
- `GET /api/v1/trackers/search?q=&trackers=`: concurrent per-tracker fan-out (15s budget each, WaitGroup + panic recovery), **fail-open per tracker** into an `errors` array with stable codes (`no_credentials` / `login_failed` / `timeout` / `failed`) — raw transport errors (mirror hosts, IPs) never reach clients, they're server-log-only
- Credential warm-up: Verify-first, Login-on-miss; every failure degrades to anonymous search; a stored-but-dead login reports `login_failed`, not "add an account"
- Abuse gates: per-user single-flight + 2s sequential cooldown (both 429) — a dead session replays a real login per search, so unbounded searching risks tracker-side lockouts and IP bans
- `supports_search` in `/system/info`; `marauder_tracker_search_total{tracker,result}` metric
- rutracker `fetchBytes` gains the same host/scheme allowlist guard rutor's `fetch` already had

### Frontend

- `TrackerSearch` component (explicit submit — no search-as-you-type against scraping backends) hosted by an `AddTopicCard` mode toggle; a picked result key-remounts `TopicForm` with the URL prefilled (`TopicForm` itself: zero lines changed)
- Per-tracker error notices localized (en+ru) by error code; same-query re-submit actually refetches

### Deferred (follow-ups tracked in #129)

Kinozal search (phase 2), NNM-Club (Cloudflare latency), Prowlarr/Jackett-backed search source, Torznab search output.

## Verification

- Backend: `gofmt` clean, `go vet` clean, full `go test -race ./...` green
- Frontend: typecheck, full vitest suite, production build green; site builds
- Live against real trackers: `q=ubuntu` and `q=дюна` return real rutor results sorted by seeders; RuTracker degrades to a friendly needs-account notice; second immediate search → 429; result click → topic created end-to-end on the dev stack
- Four-agent code review (security incl. Semgrep — 0 findings, quality, rules, QA) — all findings fixed or explicitly dismissed with rationale; spec was independently verified before implementation (caught the cp1251 query-encoding blocker)

## Morning checklist for review

1. `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dev.yml up -d --build --no-deps backend frontend` (local stack already runs this build)
2. http://localhost:34080 → Topics → Add topic → **Search trackers** tab → search something, pick a result
3. Optional: add a RuTracker account under Accounts, re-search — RuTracker results appear (Cyrillic queries work)

Closes #129