### PR TITLE
feat: dedup repeat release events and bound history growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Repeated "New release detected" events and notifications while a
+  download keeps failing.** A failed download deliberately persists the
+  topic's *old* hash so the change is re-detected and retried, which meant
+  every retry tick re-emitted `release.found` — a persisted **and**
+  notifiable event. One unreachable torrent client turned a single release
+  into dozens of history rows and dozens of push notifications. It is now
+  deduped on the pre-check `ConsecutiveErrors` snapshot, the same guard
+  `check.failed` already used, so it fires once per error episode.
+
+### Added
+
+- **`topic_events` history retention.** The table was append-only with
+  nothing ever deleting from it, so a topic's timeline grew for the life of
+  the install. A background pruner now trims rows older than
+  `MARAUDER_EVENTS_RETENTION_DAYS` (default 90) every
+  `MARAUDER_EVENTS_PRUNE_INTERVAL` (default 24h); set the retention to `0`
+  to keep history forever.
+
+### Changed
+
+- The per-topic history timeline collapses runs of consecutive same-type
+  events into a single row with a `×N` count and the time range they span,
+  so a burst of repeats no longer buries the events that differ.
+
 ## [1.13.0] - 2026-07-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ techdebt/       Debt-tracking files (one per issue, see global rule)
 | `plugins/e2etest` | shared `HostRewriteTransport` test helper for tracker e2e tests |
 | `problem` | RFC-7807 error responses |
 | **`progress`** | background download-completion watcher: polls `WithStatus` clients for in-flight `topic_deliveries` (`completed_at IS NULL`), and on seeding/100% atomically marks `completed_at` (NULL→now, dedup survives restart); emits `events.DownloadProgress` (Data: infohash/percent_done/state) on each change and `events.DownloadCompleted` via the bus. Go-forward only — migration `0011` backfills existing deliveries as complete so upgrading doesn't back-notify. Gated by `MARAUDER_PROGRESS_WATCHER_ENABLED`, polls every `MARAUDER_PROGRESS_POLL_INTERVAL` (default 5s); zero idle cost |
+| **`retention`** | background `Pruner` that trims the append-only `topic_events` history (`TopicEvents.DeleteOlderThan`). Nothing else deletes from that table, so without it the per-topic timeline grows for the life of the install. Prunes once at boot then every `MARAUDER_EVENTS_PRUNE_INTERVAL` (default 24h), deleting rows older than `MARAUDER_EVENTS_RETENTION_DAYS` (default 90; **0 keeps history forever** and skips the DELETE entirely). Best-effort: a DB error is logged and the loop retries next tick |
 | `scheduler` | per-topic check loop with bounded worker pool, exponential backoff, per-episode multi-download loop, and unit tests |
 | `version` | build-time version stamping (`-ldflags -X`) |
 
@@ -101,6 +102,16 @@ techdebt/       Debt-tracking files (one per issue, see global rule)
    on errors, capped at 6h) and writes the run summary metrics.
 
 **Event emission:** the scheduler emits typed `events.Event`s via `events.Bus.Emit` at key points: `check.started`/`check.completed`/`check.failed` (per check cycle), `release.found` (per new torrent detected), `download.submitted` (after client send), and `session.expired` (on credential session loss). (`topic.added` is emitted separately by the topics HTTP handler on `POST /topics`, not by the scheduler.) The bus fans out to `topic_events` history table (all events persisted if policy allows), the notifier dispatcher (for event-type subscriptions), and the SSE hub (wired as of Phase 3 — `sse.Hub`, the live `events.Publisher`).
+
+**Repeat-emission dedup:** both `release.found` and `check.failed` are gated on
+the pre-check `ConsecutiveErrors == 0` snapshot, so they fire **once per error
+episode**, not once per retry tick. This matters because the failed-download
+path deliberately persists the *old* hash (see below), which makes every retry
+re-enter the `updated` branch with the same release. Both events are
+`Persist:true, Notifiable:true`, so without the guard one unreachable client
+turns a single release into an unbounded stream of history rows *and* user
+notifications. Deliberate trade-off: a genuinely new release that lands while
+the topic is still failing stays silent until the topic recovers.
 
 **Per-topic delivery:** `sendViaClient` passes `domain.AddOptions{DownloadDir:
 t.DownloadDir, Category: t.Category}` to the client plugin. Category is a
@@ -181,6 +192,8 @@ src/
 │   ├── queryKeys.ts           Centralised React Query key factory (QK)
 │   ├── utils.ts               cn() helper
 │   ├── events.ts              Event type defs + `eventLabel()` i18n helper
+│   │                          + `groupConsecutiveEvents()` — collapses runs of
+│   │                          the same event type into one timeline row
 │   ├── check-status.ts        zustand store: live per-topic check phase (checking/idle/error)
 │   ├── sse-status.ts          zustand store: SSE connection state (connected boolean)
 │   ├── events-stream.ts       `applyEvent` router: patches React Query cache + check store on SSE events
@@ -245,8 +258,18 @@ The **status poll fallback** (in `DeliveryStatus`) is now gated by `useSseStatus
 # Backend (Docker — never install Go locally)
 docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 sh -c "go build ./... && go vet ./... && go test -race ./..."
 
-# Frontend
-docker run --rm -v "E:/Projects/Stukans/Marauder/frontend:/frontend" -w //frontend node:22-alpine sh -c "npm run typecheck && npm test && npm run build"
+# Frontend — run from a container-local node_modules volume, NOT the bind mount.
+# node_modules is a linux-x64-musl install (alpine is correct; glibc node:22 and
+# the Windows host both fail on the missing rolldown native binding). Running
+# vitest 4 straight off the Windows bind mount makes every worker miss its 60s
+# startup deadline ("Timeout waiting for worker to respond") — the source is
+# fine, the mount is just too slow. One-time setup:
+#   docker volume create marauder-fe-nm
+#   docker run --rm -v "E:/Projects/Stukans/Marauder/frontend:/host:ro" -v marauder-fe-nm:/app \
+#     node:22-alpine sh -c "cp /host/package.json /host/package-lock.json /app/ && cd /app && npm ci"
+# Then per run (copies only the small source tree, ~3s):
+docker run --rm -v "E:/Projects/Stukans/Marauder/frontend:/host:ro" -v marauder-fe-nm:/app -w //app node:22-alpine \
+  sh -c "cp -r /host/src /host/vitest.config.ts /host/vite.config.ts /host/index.html /host/tsconfig*.json /app/ 2>/dev/null; npx tsc --noEmit && npx vitest run"
 
 # Stack up — dev (source-build base + dev overlay: ports + qbit/transmission)
 docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dev.yml up -d
@@ -426,6 +449,7 @@ container is the backend itself.
 - `MARAUDER_VERSION` — image tag the prebuilt `docker-compose.ghcr.yml` stack pulls (default `1.0.1`); ignored by the source-build stack
 - `MARAUDER_SCHEDULER_WORKERS` — worker pool size (default 8)
 - `MARAUDER_SCHEDULER_MAX_EPISODES_PER_TICK` — per-episode loop cap (default 25)
+- `MARAUDER_EVENTS_RETENTION_DAYS` / `MARAUDER_EVENTS_PRUNE_INTERVAL` — `topic_events` history retention (default 90 days, pruned every 24h; 0 days = keep forever)
 - `MARAUDER_OIDC_*` — Keycloak settings (optional, gated by `MARAUDER_OIDC_ENABLED`)
 - See `deploy/.env.example` for the full list.
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/artyomsv/marauder/backend/internal/notify"
 	"github.com/artyomsv/marauder/backend/internal/plugins/registry"
 	"github.com/artyomsv/marauder/backend/internal/progress"
+	"github.com/artyomsv/marauder/backend/internal/retention"
 	"github.com/artyomsv/marauder/backend/internal/scheduler"
 	"github.com/artyomsv/marauder/backend/internal/sonarr"
 	"github.com/artyomsv/marauder/backend/internal/sse"
@@ -199,6 +200,23 @@ func run() error {
 		)
 		if err := watcher.Start(rootCtx); err != nil {
 			logger.Error().Err(err).Msg("progress watcher failed to start")
+		}
+	}
+
+	// History retention: topic_events is append-only, so without this the
+	// table (and the per-topic timeline built on it) grows forever.
+	// MARAUDER_EVENTS_RETENTION_DAYS=0 keeps everything.
+	if cfg.EventsRetentionDays > 0 {
+		pruner := retention.New(
+			topicEventsRepo,
+			retention.Config{
+				MaxAge:   time.Duration(cfg.EventsRetentionDays) * 24 * time.Hour,
+				Interval: cfg.EventsPruneInterval,
+			},
+			logger,
+		)
+		if err := pruner.Start(rootCtx); err != nil {
+			logger.Error().Err(err).Msg("history pruner failed to start")
 		}
 	}
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -75,6 +75,10 @@ type Config struct {
 	ProgressPollInterval   time.Duration `env:"MARAUDER_PROGRESS_POLL_INTERVAL" envDefault:"5s"`
 	SSEHeartbeatInterval   time.Duration `env:"MARAUDER_SSE_HEARTBEAT_INTERVAL" envDefault:"25s"`
 
+	// topic_events history retention. 0 days keeps history forever.
+	EventsRetentionDays int           `env:"MARAUDER_EVENTS_RETENTION_DAYS" envDefault:"90"`
+	EventsPruneInterval time.Duration `env:"MARAUDER_EVENTS_PRUNE_INTERVAL" envDefault:"24h"`
+
 	// Optional Cloudflare solver sidecar
 	CFSolverEnabled bool   `env:"MARAUDER_CFSOLVER_ENABLED" envDefault:"false"`
 	CFSolverURL     string `env:"MARAUDER_CFSOLVER_URL" envDefault:""`
@@ -109,6 +113,12 @@ func (c *Config) validate() error {
 	}
 	if c.SSEHeartbeatInterval <= 0 {
 		return errors.New("MARAUDER_SSE_HEARTBEAT_INTERVAL must be > 0")
+	}
+	if c.EventsRetentionDays < 0 {
+		return errors.New("MARAUDER_EVENTS_RETENTION_DAYS must be >= 0 (0 keeps history forever)")
+	}
+	if c.EventsPruneInterval <= 0 {
+		return errors.New("MARAUDER_EVENTS_PRUNE_INTERVAL must be > 0")
 	}
 	return nil
 }

--- a/backend/internal/db/repo/topic_events.go
+++ b/backend/internal/db/repo/topic_events.go
@@ -90,6 +90,19 @@ LIMIT 200`
 	return scanTopicEvents(rows)
 }
 
+// DeleteOlderThan prunes history rows created before cutoff and returns how
+// many were removed. topic_events is otherwise append-only — nothing else in
+// the codebase deletes from it — so without periodic pruning the table grows
+// for the life of the install.
+func (r *TopicEvents) DeleteOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	const q = `DELETE FROM topic_events WHERE created_at < $1`
+	tag, err := r.pool.Exec(ctx, q, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("topic_events: prune: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 func scanTopicEvents(rows pgx.Rows) ([]*domain.TopicEvent, error) {
 	var out []*domain.TopicEvent
 	for rows.Next() {

--- a/backend/internal/db/repo/topic_events_test.go
+++ b/backend/internal/db/repo/topic_events_test.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ type fakeTEPool struct {
 	lastSQL  string
 	lastArgs []any
 	row      fakeRow
+	execTag  pgconn.CommandTag
 }
 
 func (f *fakeTEPool) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
@@ -35,8 +37,10 @@ func (f *fakeTEPool) QueryRow(_ context.Context, sql string, args ...any) pgx.Ro
 func (f *fakeTEPool) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
 	return nil, nil
 }
-func (f *fakeTEPool) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
-	return pgconn.CommandTag{}, nil
+func (f *fakeTEPool) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	f.lastSQL = sql
+	f.lastArgs = args
+	return f.execTag, nil
 }
 
 func TestTopicEvents_Record_ReturnsID_AndMarshalsData(t *testing.T) {
@@ -62,5 +66,28 @@ func TestTopicEvents_Record_ReturnsID_AndMarshalsData(t *testing.T) {
 	var back map[string]any
 	if err := json.Unmarshal(raw, &back); err != nil {
 		t.Fatalf("data not valid JSON: %v", err)
+	}
+}
+
+// TestTopicEvents_DeleteOlderThan_PrunesByCutoff pins the retention query:
+// topic_events is append-only and nothing else ever deletes from it, so
+// without this the table grows without bound.
+func TestTopicEvents_DeleteOlderThan_PrunesByCutoff(t *testing.T) {
+	pool := &fakeTEPool{execTag: pgconn.NewCommandTag("DELETE 42")}
+	r := &TopicEvents{pool: pool}
+	cutoff := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+
+	n, err := r.DeleteOlderThan(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("DeleteOlderThan: %v", err)
+	}
+	if n != 42 {
+		t.Errorf("rows deleted = %d, want 42", n)
+	}
+	if len(pool.lastArgs) != 1 || pool.lastArgs[0] != cutoff {
+		t.Errorf("query args = %v, want the cutoff %v as the only bind", pool.lastArgs, cutoff)
+	}
+	if !strings.Contains(pool.lastSQL, "DELETE FROM topic_events") {
+		t.Errorf("SQL = %q, want a DELETE against topic_events", pool.lastSQL)
 	}
 }

--- a/backend/internal/retention/pruner.go
+++ b/backend/internal/retention/pruner.go
@@ -1,0 +1,88 @@
+// Package retention runs a background pruner that trims the append-only
+// topic_events history to a bounded age. Nothing else in the codebase deletes
+// from that table, so without this the history — and the per-topic timeline
+// built on it — grows for the life of the install.
+package retention
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Store is the consumer-side seam over *repo.TopicEvents.
+type Store interface {
+	DeleteOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+}
+
+// Config holds the pruner's runtime knobs. A zero MaxAge disables pruning
+// entirely (history is kept forever).
+type Config struct {
+	MaxAge   time.Duration
+	Interval time.Duration
+}
+
+// Pruner periodically deletes history rows older than Config.MaxAge.
+type Pruner struct {
+	store Store
+	cfg   Config
+	log   zerolog.Logger
+
+	// now is a clock seam so tests can pin the cutoff.
+	now func() time.Time
+	// done closes when the loop exits, letting tests await shutdown.
+	done chan struct{}
+}
+
+// New constructs a Pruner.
+func New(store Store, cfg Config, log zerolog.Logger) *Pruner {
+	return &Pruner{
+		store: store,
+		cfg:   cfg,
+		log:   log.With().Str("component", "retention").Logger(),
+		now:   time.Now,
+		done:  make(chan struct{}),
+	}
+}
+
+// Start launches the prune loop in a goroutine and returns. The loop stops
+// when ctx is cancelled.
+func (p *Pruner) Start(ctx context.Context) error {
+	go p.run(ctx)
+	return nil
+}
+
+func (p *Pruner) run(ctx context.Context) {
+	defer close(p.done)
+	ticker := time.NewTicker(p.cfg.Interval)
+	defer ticker.Stop()
+	// Prune once at boot so a long-running install that was restarted doesn't
+	// wait a full interval before reclaiming.
+	p.pruneOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.pruneOnce(ctx)
+		}
+	}
+}
+
+// pruneOnce deletes one batch. Housekeeping is best-effort: a DB error is
+// logged and swallowed so the loop survives to retry on the next tick.
+func (p *Pruner) pruneOnce(ctx context.Context) {
+	if p.cfg.MaxAge <= 0 {
+		return
+	}
+	cutoff := p.now().Add(-p.cfg.MaxAge)
+	deleted, err := p.store.DeleteOlderThan(ctx, cutoff)
+	if err != nil {
+		p.log.Warn().Err(err).Time("cutoff", cutoff).Msg("topic_events prune failed")
+		return
+	}
+	if deleted > 0 {
+		p.log.Info().Int64("deleted", deleted).Time("cutoff", cutoff).Msg("pruned topic_events history")
+	}
+}

--- a/backend/internal/retention/pruner_test.go
+++ b/backend/internal/retention/pruner_test.go
@@ -1,0 +1,85 @@
+package retention
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// fakeStore records every prune call.
+type fakeStore struct {
+	calls   []time.Time
+	deleted int64
+	err     error
+}
+
+func (f *fakeStore) DeleteOlderThan(_ context.Context, cutoff time.Time) (int64, error) {
+	f.calls = append(f.calls, cutoff)
+	return f.deleted, f.err
+}
+
+func newPruner(t *testing.T, store Store, cfg Config) *Pruner {
+	t.Helper()
+	p := New(store, cfg, zerolog.New(io.Discard))
+	// Pin the clock so the expected cutoff is exact.
+	p.now = func() time.Time { return time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC) }
+	return p
+}
+
+func TestPruner_PruneOnce_DeletesEverythingOlderThanMaxAge(t *testing.T) {
+	store := &fakeStore{deleted: 30}
+	p := newPruner(t, store, Config{MaxAge: 90 * 24 * time.Hour, Interval: time.Hour})
+
+	p.pruneOnce(context.Background())
+
+	if len(store.calls) != 1 {
+		t.Fatalf("DeleteOlderThan calls = %d, want 1", len(store.calls))
+	}
+	want := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	if !store.calls[0].Equal(want) {
+		t.Errorf("cutoff = %v, want %v (now - 90d)", store.calls[0], want)
+	}
+}
+
+// A zero MaxAge is the documented "keep history forever" setting, so it must
+// never issue a DELETE — a cutoff of now would wipe the whole table.
+func TestPruner_PruneOnce_MaxAgeZero_KeepsEverything(t *testing.T) {
+	store := &fakeStore{}
+	p := newPruner(t, store, Config{MaxAge: 0, Interval: time.Hour})
+
+	p.pruneOnce(context.Background())
+
+	if len(store.calls) != 0 {
+		t.Errorf("DeleteOlderThan calls = %d, want 0 when retention is disabled", len(store.calls))
+	}
+}
+
+// Pruning is housekeeping: a DB error must be logged and swallowed so the loop
+// survives to try again rather than taking the process down.
+func TestPruner_PruneOnce_StoreError_IsSwallowed(t *testing.T) {
+	store := &fakeStore{err: errors.New("connection reset")}
+	p := newPruner(t, store, Config{MaxAge: time.Hour, Interval: time.Hour})
+
+	p.pruneOnce(context.Background())
+
+	if len(store.calls) != 1 {
+		t.Errorf("DeleteOlderThan calls = %d, want 1", len(store.calls))
+	}
+}
+
+// Start must return promptly and its loop must exit on ctx cancellation.
+func TestPruner_Start_StopsOnContextCancel(t *testing.T) {
+	store := &fakeStore{}
+	p := newPruner(t, store, Config{MaxAge: time.Hour, Interval: time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cancel()
+	<-p.done
+}

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -408,8 +408,18 @@ func (s *Scheduler) runCheck(ctx context.Context, log zerolog.Logger, t *domain.
 		// stamped onto both notifiable update events below.
 		authorComment = s.fetchAuthorComment(ctx, log, t, tr, creds)
 
-		// Emit release.found once per new hash, before draining episodes.
-		if s.emit != nil {
+		// Emit release.found once per error episode, before draining episodes.
+		//
+		// Deduped by the pre-check ConsecutiveErrors snapshot, the same guard
+		// notifyError uses. A failed download persists the OLD hash on purpose
+		// (see the dlErr branch below), so every retry tick re-enters this
+		// branch with the same release. release.found is both persisted and
+		// notifiable, so without this guard one unreachable client turns a
+		// single release into an unbounded stream of history rows and user
+		// notifications. The trade-off is deliberate: a genuinely new release
+		// arriving while the topic is still stuck stays silent until the topic
+		// recovers — at which point the next tick announces it.
+		if s.emit != nil && t.ConsecutiveErrors == 0 {
 			s.emit.Emit(ctx, events.Event{
 				UserID: t.UserID, TopicID: &t.ID, NotifierID: t.NotifierID,
 				Type: events.ReleaseFound, Severity: "info",

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -766,6 +766,62 @@ func TestRunCheck_CheckError_AlreadyErrored_NoNotify(t *testing.T) {
 	}
 }
 
+// TestRunCheck_DownloadFails_AlreadyErrored_NoReleaseFound pins the dedup for
+// the stuck-download loop. A failed download deliberately persists the OLD
+// hash so the change is re-detected next tick — which means every retry
+// re-enters the `updated` branch. Without a guard that re-emits release.found
+// (persisted AND notifiable) on every retry, so one unreachable client turns
+// into an unbounded stream of "New release detected" rows and notifications.
+func TestRunCheck_DownloadFails_AlreadyErrored_NoReleaseFound(t *testing.T) {
+	const hash = "c12fe1c06bba254a9dc9f519b335aa7c1367a88a"
+	tr := &fakeTracker{
+		name: "faketracker",
+		checks: []checkResult{
+			{check: &domain.Check{Hash: "new-hash"}, err: nil},
+		},
+		downloads: []downloadResult{
+			{payload: &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:" + hash}, err: nil},
+		},
+	}
+	f := newFixture(t, tr, false)
+	// The client is unreachable, so the submit fails for this tick.
+	f.clientPlugin.addErr = errors.New("dial tcp 192.0.2.1:8083: connect: connection refused")
+	// This is a RETRY: the topic already failed at least once, so the release
+	// was announced back then and must not be announced again.
+	f.topic.ConsecutiveErrors = 1
+
+	f.s.runCheck(context.Background(), f.s.log, f.topic)
+
+	if evs := f.emitter.ofType(events.ReleaseFound); len(evs) != 0 {
+		t.Errorf("expected no release.found event on a retry of an already-failing topic, got %d", len(evs))
+	}
+}
+
+// TestRunCheck_DownloadFails_FirstFailure_EmitsReleaseFound guards the other
+// side of the dedup: the FIRST detection must still announce, even though its
+// download fails. Suppressing it would hide the release entirely.
+func TestRunCheck_DownloadFails_FirstFailure_EmitsReleaseFound(t *testing.T) {
+	const hash = "c12fe1c06bba254a9dc9f519b335aa7c1367a88a"
+	tr := &fakeTracker{
+		name: "faketracker",
+		checks: []checkResult{
+			{check: &domain.Check{Hash: "new-hash"}, err: nil},
+		},
+		downloads: []downloadResult{
+			{payload: &domain.Payload{MagnetURI: "magnet:?xt=urn:btih:" + hash}, err: nil},
+		},
+	}
+	f := newFixture(t, tr, false)
+	f.clientPlugin.addErr = errors.New("dial tcp 192.0.2.1:8083: connect: connection refused")
+	f.topic.ConsecutiveErrors = 0 // healthy until this tick
+
+	f.s.runCheck(context.Background(), f.s.log, f.topic)
+
+	if evs := f.emitter.ofType(events.ReleaseFound); len(evs) != 1 {
+		t.Errorf("expected 1 release.found event on the first failing detection, got %d", len(evs))
+	}
+}
+
 func TestRunCheck_Episodes_NotifiesWithEpisodeLabels(t *testing.T) {
 	const h1 = "1111111111111111111111111111111111111111"
 	const h2 = "2222222222222222222222222222222222222222"

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -68,6 +68,12 @@ MARAUDER_PROGRESS_POLL_INTERVAL=5s
 # --- SSE live event stream: keepalive heartbeat interval for GET /api/v1/events
 MARAUDER_SSE_HEARTBEAT_INTERVAL=25s
 
+# --- Topic history retention: how long topic_events rows are kept before the
+# background pruner deletes them. The table is append-only, so 0 (keep forever)
+# means the per-topic timeline grows for the life of the install.
+MARAUDER_EVENTS_RETENTION_DAYS=90
+MARAUDER_EVENTS_PRUNE_INTERVAL=24h
+
 # --- OIDC (optional) ------------------------------------------------
 # Set MARAUDER_OIDC_ENABLED=true and fill the four variables below to
 # allow login via Keycloak, Authentik, Auth0, or any OIDC provider.

--- a/frontend/src/components/topics/TopicEventsTimeline.test.tsx
+++ b/frontend/src/components/topics/TopicEventsTimeline.test.tsx
@@ -29,4 +29,33 @@ describe("TopicEventsTimeline", () => {
     // timeline it must not be rendered (it duplicated on every row).
     expect(screen.queryByText(/Super Mario Galaxy Movie/)).toBeNull();
   });
+
+  it("collapses a run of repeated events into one row with a count", async () => {
+    // A stuck download re-detects the same release every retry tick, so the
+    // raw feed is dominated by identical rows.
+    (api.topicEvents as ReturnType<typeof vi.fn>).mockResolvedValue({
+      events: [
+        { id: 4, event_type: "release.found", severity: "info", message: "", created_at: "2026-07-27T15:35:24Z" },
+        { id: 3, event_type: "release.found", severity: "info", message: "", created_at: "2026-07-27T09:34:23Z" },
+        { id: 2, event_type: "release.found", severity: "info", message: "", created_at: "2026-07-26T21:32:27Z" },
+        { id: 1, event_type: "check.failed", severity: "error", message: "", created_at: "2026-07-26T21:22:34Z" },
+      ],
+    });
+    wrap(<TopicEventsTimeline topicId="t1" />);
+
+    expect(await screen.findByText("×3")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("shows no count badge when an event did not repeat", async () => {
+    (api.topicEvents as ReturnType<typeof vi.fn>).mockResolvedValue({
+      events: [
+        { id: 1, event_type: "release.found", severity: "info", message: "", created_at: "2026-07-27T15:35:24Z" },
+      ],
+    });
+    wrap(<TopicEventsTimeline topicId="t1" />);
+
+    expect(await screen.findByText("new release")).toBeInTheDocument();
+    expect(screen.queryByText(/^×/)).toBeNull();
+  });
 });

--- a/frontend/src/components/topics/TopicEventsTimeline.tsx
+++ b/frontend/src/components/topics/TopicEventsTimeline.tsx
@@ -4,7 +4,7 @@ import { Loader2, Clock } from "lucide-react";
 import { api } from "@/lib/api";
 import { QK } from "@/lib/queryKeys";
 import { useT } from "@/i18n";
-import { EVENT_LABELS } from "@/lib/events";
+import { EVENT_LABELS, groupConsecutiveEvents } from "@/lib/events";
 
 interface TopicEventsTimelineProps {
   topicId: string;
@@ -40,22 +40,36 @@ export function TopicEventsTimeline({ topicId }: TopicEventsTimelineProps) {
       </div>
     );
   }
+  // Runs of the same event type collapse into one row. A topic whose download
+  // keeps failing re-detects the same release every retry tick, so the raw
+  // feed is mostly duplicates that bury the rows which actually differ.
+  const groups = groupConsecutiveEvents(events);
+
   return (
     <ol className="space-y-2 p-2">
-      {events.map((e) => (
-        <li key={e.id} className="flex items-start gap-3 text-sm">
-          <span className={`mt-1.5 size-2 shrink-0 rounded-full ${severityDot[e.severity] ?? "bg-muted"}`} />
+      {groups.map((g) => (
+        <li key={g.id} className="flex items-start gap-3 text-sm">
+          <span className={`mt-1.5 size-2 shrink-0 rounded-full ${severityDot[g.severity] ?? "bg-muted"}`} />
           <div className="min-w-0">
-            <div className="font-medium">
-              {EVENT_LABELS[e.event_type] ? t(EVENT_LABELS[e.event_type]) : e.event_type}
+            <div className="flex items-center gap-2 font-medium">
+              {EVENT_LABELS[g.event_type] ? t(EVENT_LABELS[g.event_type]) : g.event_type}
+              {g.count > 1 && (
+                <span
+                  className="rounded-full bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground"
+                  aria-label={t("topics.history.repeated", { count: g.count })}
+                >
+                  ×{g.count}
+                </span>
+              )}
             </div>
             {/* The persisted message is the event's Title, which for every
                 topic-scoped event is (a variant of) the topic's own display
                 name — pure duplication inside a per-topic timeline, so it is
                 deliberately not rendered. Error details have their own home
                 (TopicError / last_error_code). */}
-            <time className="text-xs text-muted-foreground">
-              {new Date(e.created_at).toLocaleString()}
+            <time className="text-xs text-muted-foreground" dateTime={g.newestAt}>
+              {new Date(g.newestAt).toLocaleString()}
+              {g.count > 1 && ` – ${new Date(g.oldestAt).toLocaleString()}`}
             </time>
           </div>
         </li>

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -246,6 +246,7 @@ const en: Record<string, string> = {
   "topics.history.empty": "No history yet",
   "topics.history.show": "History",
   "topics.history.hide": "Hide history",
+  "topics.history.repeated": "repeated {count} times",
 
   // Generic
   "common.loading": "Loading...",

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -248,6 +248,7 @@ const ru: Record<string, string> = {
   "topics.history.empty": "История пока пуста",
   "topics.history.show": "История",
   "topics.history.hide": "Скрыть историю",
+  "topics.history.repeated": "повторов: {count}",
 
   // Generic
   "common.loading": "Загрузка...",

--- a/frontend/src/lib/events.test.ts
+++ b/frontend/src/lib/events.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { NOTIFIABLE_EVENTS, ALL_NOTIFIABLE_EVENTS, EVENT_LABELS } from "@/lib/events";
+import {
+  NOTIFIABLE_EVENTS,
+  ALL_NOTIFIABLE_EVENTS,
+  EVENT_LABELS,
+  groupConsecutiveEvents,
+} from "@/lib/events";
+import type { TopicEvent } from "@/lib/api";
+
+// Newest-first, matching what GET /topics/{id}/events returns.
+function ev(id: number, type: string, at: string, severity: TopicEvent["severity"] = "info"): TopicEvent {
+  return { id, event_type: type, severity, message: "", created_at: at };
+}
 
 describe("events catalog", () => {
   it("exposes the four notifiable groups", () => {
@@ -17,5 +28,57 @@ describe("events catalog", () => {
     for (const e of NOTIFIABLE_EVENTS) {
       expect(EVENT_LABELS[e]).toBeTruthy();
     }
+  });
+});
+
+describe("groupConsecutiveEvents", () => {
+  it("returns nothing for an empty feed", () => {
+    expect(groupConsecutiveEvents([])).toEqual([]);
+  });
+
+  it("collapses a run of the same event type into one group spanning its time range", () => {
+    // The scheduler re-detects a stuck release on every retry tick, so a
+    // single release can produce dozens of identical rows.
+    const groups = groupConsecutiveEvents([
+      ev(3, "release.found", "2026-07-27T15:35:24Z"),
+      ev(2, "release.found", "2026-07-27T09:34:23Z"),
+      ev(1, "release.found", "2026-07-26T21:32:27Z"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(3);
+    expect(groups[0].newestAt).toBe("2026-07-27T15:35:24Z");
+    expect(groups[0].oldestAt).toBe("2026-07-26T21:32:27Z");
+  });
+
+  it("keys each group by its newest event id so React reconciles stably", () => {
+    const groups = groupConsecutiveEvents([
+      ev(9, "release.found", "2026-07-27T15:00:00Z"),
+      ev(8, "release.found", "2026-07-27T14:00:00Z"),
+    ]);
+    expect(groups[0].id).toBe(9);
+  });
+
+  it("does not merge same-type runs separated by a different event", () => {
+    // Grouping is CONSECUTIVE-only: merging globally would reorder history
+    // and hide that a failure happened between two detections.
+    const groups = groupConsecutiveEvents([
+      ev(4, "release.found", "2026-07-27T15:00:00Z"),
+      ev(3, "check.failed", "2026-07-27T14:00:00Z", "error"),
+      ev(2, "release.found", "2026-07-27T13:00:00Z"),
+      ev(1, "release.found", "2026-07-27T12:00:00Z"),
+    ]);
+    expect(groups.map((g) => [g.event_type, g.count])).toEqual([
+      ["release.found", 1],
+      ["check.failed", 1],
+      ["release.found", 2],
+    ]);
+  });
+
+  it("carries the severity of the run so the dot still reflects the events", () => {
+    const groups = groupConsecutiveEvents([
+      ev(2, "check.failed", "2026-07-27T15:00:00Z", "error"),
+      ev(1, "check.failed", "2026-07-27T14:00:00Z", "error"),
+    ]);
+    expect(groups[0].severity).toBe("error");
   });
 });

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -24,6 +24,60 @@ export const EVENT_GROUP_EVENTS: Record<NotifiableEvent, string[]> = {
 // are on by default — matching the backend's empty-input default.
 export const ALL_NOTIFIABLE_EVENTS: string[] = Object.values(EVENT_GROUP_EVENTS).flat();
 
+// One collapsed run of consecutive same-type events in the history timeline.
+// `newestAt`/`oldestAt` are equal when the run holds a single event.
+export interface EventGroup {
+  // The newest event's id — a stable React key that survives newer events
+  // being prepended to the feed.
+  id: number;
+  event_type: string;
+  severity: string;
+  count: number;
+  newestAt: string;
+  oldestAt: string;
+}
+
+// The minimum an event needs to be groupable. Kept structural rather than
+// importing TopicEvent so the helper stays usable for any event-shaped feed.
+interface GroupableEvent {
+  id: number;
+  event_type: string;
+  severity: string;
+  created_at: string;
+}
+
+// Collapse runs of CONSECUTIVE same-type events into one entry each.
+//
+// The scheduler re-detects a stuck release on every retry tick, so a single
+// unreachable client can push dozens of identical release.found rows into a
+// topic's history. Rendering one row per event turns the timeline into a wall
+// of duplicates that buries the events that actually differ.
+//
+// Grouping is deliberately consecutive-only: merging every same-type event in
+// the feed would reorder history and hide that, say, a check.failed happened
+// between two detections. Input is expected newest-first (the order the API
+// returns); the output preserves it.
+export function groupConsecutiveEvents(events: GroupableEvent[]): EventGroup[] {
+  const groups: EventGroup[] = [];
+  for (const e of events) {
+    const open = groups[groups.length - 1];
+    if (open && open.event_type === e.event_type) {
+      open.count += 1;
+      open.oldestAt = e.created_at;
+      continue;
+    }
+    groups.push({
+      id: e.id,
+      event_type: e.event_type,
+      severity: e.severity,
+      count: 1,
+      newestAt: e.created_at,
+      oldestAt: e.created_at,
+    });
+  }
+  return groups;
+}
+
 // i18n keys for each event label, used by the notifier picker and the
 // per-topic timeline. Timeline-only (non-notifiable) events are included so
 // the history view can render them too.


### PR DESCRIPTION
## Summary

A stuck download was re-announcing the same release on every retry tick. The failed-download path deliberately persists the topic's **old** hash so the change is re-detected and retried — correct in itself, but it meant every retry re-entered the `updated` branch and re-emitted `release.found`, which is both persisted **and** notifiable. One unreachable torrent client produced **30 history rows and ~30 push notifications for a single release**.

`release.found` is now deduped on the pre-check `ConsecutiveErrors` snapshot — the same guard `notifyError` already applied to `check.failed`, which is exactly why the affected topic showed 30 `release.found` against only 2 `check.failed`.

Two supporting changes bound history growth independently of that fix: `topic_events` had **no retention anywhere** (append-only, nothing ever deleted from it), and the per-topic timeline rendered one row per event with no grouping.

## Type of change

- [x] Bug fix
- [x] New feature (tracker / client / notifier plugin, UI page, etc.)
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / build / tooling
- [ ] Dependency update

## What changed

| Area | Change |
|---|---|
| `scheduler.go` | `release.found` emitted only when `ConsecutiveErrors == 0` |
| `internal/retention/` (new) | `Pruner` — trims `topic_events`; prunes at boot then every interval; errors logged and swallowed so the loop survives |
| `repo/topic_events.go` | `DeleteOlderThan(ctx, cutoff)` |
| `config.go` / `main.go` / `.env.example` | `MARAUDER_EVENTS_RETENTION_DAYS` (default 90, `0` = keep forever), `MARAUDER_EVENTS_PRUNE_INTERVAL` (default 24h) |
| `lib/events.ts` | `groupConsecutiveEvents()` — collapses runs of one event type into a single entry |
| `TopicEventsTimeline.tsx` | renders groups with a `×N` badge (i18n `aria-label`) and the spanned time range |

## Deliberate trade-offs

- **A new release arriving while the topic is still failing stays silent** until the topic recovers, then announces on the next tick. This is the cost of the no-migration dedup; the alternative was a `last_announced_hash` column. Documented at the call site and in CLAUDE.md.
- **Grouping is consecutive-only.** Merging every same-type event globally would reorder history and hide that a `check.failed` happened between two detections.
- **Retention defaults to 90 days, not off.** Existing installs will prune on first boot after upgrade. Set `MARAUDER_EVENTS_RETENTION_DAYS=0` to keep the old keep-forever behaviour.

## Test plan

All changes are test-first; each test was watched failing before the implementation existed.

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -race ./...` passes; `gofmt -l .` empty
- [x] Frontend: `tsc --noEmit` clean, **140/140 tests across 26 files**

New tests:

- `TestRunCheck_DownloadFails_AlreadyErrored_NoReleaseFound` — a retry of an already-failing topic emits nothing
- `TestRunCheck_DownloadFails_FirstFailure_EmitsReleaseFound` — guards the other side: the first detection still announces even though its download fails
- `TestTopicEvents_DeleteOlderThan_PrunesByCutoff` — pins the retention query and bind
- `TestPruner_*` — cutoff arithmetic, `MaxAge == 0` issues no DELETE, DB errors swallowed, loop exits on ctx cancel
- `groupConsecutiveEvents` — empty feed, run collapsing, stable React key, non-consecutive runs stay separate, severity carried
- `TopicEventsTimeline` — count badge appears for a run, absent for a singleton

## Documentation

- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] CLAUDE.md: new `retention` package row, the repeat-emission dedup rationale in the scheduler section, new env vars, `groupConsecutiveEvents` in the frontend tree
- [x] New public types (`Pruner`, `Store`, `Config`, `groupConsecutiveEvents`, `EventGroup`) carry doc comments explaining *why*

CLAUDE.md's frontend verify command was also corrected: running vitest 4 off the Windows bind mount makes every worker miss its 60s startup deadline (`Timeout waiting for worker to respond`) for *all* files including untouched ones. The documented command now runs from a container-local `node_modules` volume — full suite in ~20s instead of timing out. Note `node_modules` is a linux-x64-musl install, so `node:22-alpine` is required; glibc `node:22` and the Windows host both fail on a missing rolldown native binding.

## Reviewer notes

- The `feat:` title will cut a **minor** release via `auto-release.yml`. If you'd rather ship this as a patch, retitle to `fix:` before merging.
- Worth pushing back on the silent-while-erroring trade-off if you'd prefer the `last_announced_hash` migration instead — that variant announces correctly in every case.
- The retention default (90 days) is the one behaviour change existing installs will notice on upgrade.
