### PR TITLE
feat(topics): add a Check now action to retry without resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Check now** — retry a topic immediately instead of waiting out its backoff.
+  A failing topic can back off for up to six hours, which is right while a
+  tracker is down and wrong once you have fixed the cause; previously the only
+  way to force a check was Reset, which removes the downloaded torrents from
+  your client. Available per row and over a multi-select. Not offered for
+  paused topics, since those are not checked at all.
+
 ## [1.17.0] - 2026-08-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,24 @@ Frontend: `components/topics/ResetTopicCard` (an inline card, not a modal — th
 project has no shadcn Dialog primitive), opened from a per-row `RotateCcw` button
 and from the Topics page bulk action bar.
 
+**Topic recheck:** `POST /api/v1/topics/{id}/recheck` is the non-destructive
+counterpart to reset — `Topics.QueueRecheck` writes `next_check_at = now()` and
+nothing else, so a topic parked on a backoff (capped at 6h) after a tracker
+outage can be retried the moment the cause is fixed. `status`, `last_error` and
+`last_checked_at` are deliberately untouched: the scheduler clears them on the
+next successful check, and reporting the topic healthy before anything verified
+that would be a lie. Paused topics are excluded in the SQL because
+`DueForCheck` ignores them, so the endpoint answers **409** rather than a 204
+that promises a check which never runs (**404** for unknown/not-owned, which is
+also what a paused topic belonging to someone else returns). Writing
+`next_check_at` moves half of the `(last_checked_at, next_check_at)`
+check-state token, so a recheck landing mid-check discards that worker's result
+exactly as a reset does — bounded, self-correcting, and documented in the reset
+design's "Known limitation". No audit row and no `topic_events` entry (it
+matches pause/resume, not reset); the `check.*` events that follow are the
+record. Frontend: a `RefreshCw` row action hidden for paused topics, plus a
+bulk entry that fans out through `mapWithConcurrency`.
+
 **Errored-topic retry:** `DueForCheck` selects `WHERE status IN
 ('active','error')`, so a topic that errors keeps retrying on its already-
 persisted backoff `next_check_at` (≤6h) instead of parking permanently. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,7 @@ The **status poll fallback** (in `DeliveryStatus`) is now gated by `useSseStatus
 - **Component size**: max 250 lines per file (currently breached by
   `Clients.tsx` and `TopicForm.tsx` — pre-existing tech debt, tracked in
   `techdebt/frontend/`. `Topics.tsx` was fixed by the topic-reset work: it
-  dropped from 425 to 216 lines by extracting `TopicRow`, `BulkActionBar`,
+  dropped from 425 to 237 lines by extracting `TopicRow`, `BulkActionBar`,
   `DensityToggle`, `TopicsEmptyState` and `StatusIndicator` into
   `components/topics/`).
 - **Path alias**: `@/` maps to `src/`.

--- a/backend/internal/api/handlers/topics.go
+++ b/backend/internal/api/handlers/topics.go
@@ -37,6 +37,7 @@ type topicStore interface {
 	UpdateStatus(ctx context.Context, id, userID uuid.UUID, status domain.TopicStatus) error
 	Update(ctx context.Context, id, userID uuid.UUID, displayName string, clientID, notifierID *uuid.UUID, downloadDir, category string, replaceOnUpdate, replaceDeleteData bool, extra map[string]any) (*domain.Topic, error)
 	ResetCheckState(ctx context.Context, id, userID uuid.UUID) error
+	QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error)
 }
 
 // deliveriesStore is the consumer seam over *repo.Deliveries for the
@@ -534,6 +535,48 @@ func (h *Topics) setStatus(w http.ResponseWriter, r *http.Request, status domain
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// Recheck handles POST /topics/{id}/recheck: bring the topic's next scheduled
+// check forward to now.
+//
+// This exists because a failing topic backs off up to six hours, which is
+// correct while a tracker is down and wrong the moment the operator fixes the
+// cause. Reset is the only other way to force a check and it is destructive —
+// it removes delivered torrents from the client.
+//
+// Nothing but next_check_at changes, so the stale error stays on screen until
+// the check that follows actually says otherwise.
+func (h *Topics) Recheck(w http.ResponseWriter, r *http.Request) {
+	uid, perr := currentUserID(r)
+	if perr != nil {
+		problem.Write(w, r, h.BaseURL, perr)
+		return
+	}
+	id, ierr := uuid.Parse(chi.URLParam(r, "id"))
+	if ierr != nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("invalid id"))
+		return
+	}
+	queued, qerr := h.Topics.QueueRecheck(r.Context(), id, uid)
+	if qerr != nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrInternal(qerr.Error()))
+		return
+	}
+	if queued {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	// No row matched: the topic is paused, or it is not this user's. Only the
+	// rare failing path pays for the extra lookup, and it buys an honest
+	// answer — a 404 for a paused topic would be a lie, and a 204 would
+	// promise a check the scheduler is never going to run.
+	t, gerr := h.Topics.GetByID(r.Context(), id, &uid)
+	if gerr != nil || t == nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrNotFound("topic not found"))
+		return
+	}
+	problem.Write(w, r, h.BaseURL, problem.ErrConflict("topic is paused; resume it first"))
 }
 
 // resetFinishTimeout bounds the reset's two fail-closed steps once they have

--- a/backend/internal/api/handlers/topics.go
+++ b/backend/internal/api/handlers/topics.go
@@ -576,6 +576,25 @@ func (h *Topics) Recheck(w http.ResponseWriter, r *http.Request) {
 		problem.Write(w, r, h.BaseURL, problem.ErrNotFound("topic not found"))
 		return
 	}
+	if t.Status != domain.TopicStatusPaused {
+		// It was ineligible when the UPDATE ran but is not paused now — it was
+		// resumed in between. Reporting "paused" here would describe a state
+		// that no longer holds and tell the user to resume an active topic, so
+		// retry the queue instead. Exactly once: the topic is eligible now, and
+		// a loop here would be a spin on a moving row.
+		requeued, rerr := h.Topics.QueueRecheck(r.Context(), id, uid)
+		if rerr != nil {
+			problem.Write(w, r, h.BaseURL, problem.ErrInternal(rerr.Error()))
+			return
+		}
+		if requeued {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		// Still nothing: the row went away between the two statements.
+		problem.Write(w, r, h.BaseURL, problem.ErrNotFound("topic not found"))
+		return
+	}
 	problem.Write(w, r, h.BaseURL, problem.ErrConflict("topic is paused; resume it first"))
 }
 

--- a/backend/internal/api/handlers/topics.go
+++ b/backend/internal/api/handlers/topics.go
@@ -37,7 +37,7 @@ type topicStore interface {
 	UpdateStatus(ctx context.Context, id, userID uuid.UUID, status domain.TopicStatus) error
 	Update(ctx context.Context, id, userID uuid.UUID, displayName string, clientID, notifierID *uuid.UUID, downloadDir, category string, replaceOnUpdate, replaceDeleteData bool, extra map[string]any) (*domain.Topic, error)
 	ResetCheckState(ctx context.Context, id, userID uuid.UUID) error
-	QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error)
+	QueueRecheck(ctx context.Context, id, userID uuid.UUID) (repo.RecheckOutcome, error)
 }
 
 // deliveriesStore is the consumer seam over *repo.Deliveries for the
@@ -547,6 +547,13 @@ func (h *Topics) setStatus(w http.ResponseWriter, r *http.Request, status domain
 //
 // Nothing but next_check_at changes, so the stale error stays on screen until
 // the check that follows actually says otherwise.
+//
+// The outcome is classified from repo.RecheckOutcome, a single statement's
+// result — not by combining QueueRecheck with a follow-up GetByID. Two
+// separate statements can each see a different database snapshot, so a
+// pause/resume landing between them makes any such inference wrong (a
+// resumed topic misreported as "paused", or a retry that misreports an
+// existing topic as 404). One snapshot cannot disagree with itself.
 func (h *Topics) Recheck(w http.ResponseWriter, r *http.Request) {
 	uid, perr := currentUserID(r)
 	if perr != nil {
@@ -558,44 +565,23 @@ func (h *Topics) Recheck(w http.ResponseWriter, r *http.Request) {
 		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("invalid id"))
 		return
 	}
-	queued, qerr := h.Topics.QueueRecheck(r.Context(), id, uid)
+	outcome, qerr := h.Topics.QueueRecheck(r.Context(), id, uid)
 	if qerr != nil {
 		problem.Write(w, r, h.BaseURL, problem.ErrInternal(qerr.Error()))
 		return
 	}
-	if queued {
+	switch {
+	case outcome.Queued:
 		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	// No row matched: the topic is paused, or it is not this user's. Only the
-	// rare failing path pays for the extra lookup, and it buys an honest
-	// answer — a 404 for a paused topic would be a lie, and a 204 would
-	// promise a check the scheduler is never going to run.
-	t, gerr := h.Topics.GetByID(r.Context(), id, &uid)
-	if gerr != nil || t == nil {
+	case !outcome.Exists:
+		// Unknown and not-this-user's are the same answer, so the response
+		// cannot be used to probe for another user's topics.
 		problem.Write(w, r, h.BaseURL, problem.ErrNotFound("topic not found"))
-		return
+	default:
+		// Exists but was not queued: it is paused. The scheduler ignores
+		// paused topics, so a 204 would promise a check that never runs.
+		problem.Write(w, r, h.BaseURL, problem.ErrConflict("topic is paused; resume it first"))
 	}
-	if t.Status != domain.TopicStatusPaused {
-		// It was ineligible when the UPDATE ran but is not paused now — it was
-		// resumed in between. Reporting "paused" here would describe a state
-		// that no longer holds and tell the user to resume an active topic, so
-		// retry the queue instead. Exactly once: the topic is eligible now, and
-		// a loop here would be a spin on a moving row.
-		requeued, rerr := h.Topics.QueueRecheck(r.Context(), id, uid)
-		if rerr != nil {
-			problem.Write(w, r, h.BaseURL, problem.ErrInternal(rerr.Error()))
-			return
-		}
-		if requeued {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		// Still nothing: the row went away between the two statements.
-		problem.Write(w, r, h.BaseURL, problem.ErrNotFound("topic not found"))
-		return
-	}
-	problem.Write(w, r, h.BaseURL, problem.ErrConflict("topic is paused; resume it first"))
 }
 
 // resetFinishTimeout bounds the reset's two fail-closed steps once they have

--- a/backend/internal/api/handlers/topics_handler_test.go
+++ b/backend/internal/api/handlers/topics_handler_test.go
@@ -89,6 +89,11 @@ type fakeTopicStore struct {
 	// Captured ResetCheckState arguments.
 	resetCalls [][2]uuid.UUID
 	resetErr   error
+
+	// Captured QueueRecheck arguments.
+	recheckCalls [][2]uuid.UUID
+	recheckOK    bool
+	recheckErr   error
 }
 
 func (s *fakeTopicStore) Create(_ context.Context, t *domain.Topic) (*domain.Topic, error) {
@@ -118,6 +123,13 @@ func (s *fakeTopicStore) ResetCheckState(ctx context.Context, id, userID uuid.UU
 	}
 	s.resetCalls = append(s.resetCalls, [2]uuid.UUID{id, userID})
 	return s.resetErr
+}
+
+// QueueRecheck records (topicID, userID) per call so tests can assert the
+// handler passed the right topic for the right owner.
+func (s *fakeTopicStore) QueueRecheck(_ context.Context, id, userID uuid.UUID) (bool, error) {
+	s.recheckCalls = append(s.recheckCalls, [2]uuid.UUID{id, userID})
+	return s.recheckOK, s.recheckErr
 }
 func (s *fakeTopicStore) Update(_ context.Context, _, _ uuid.UUID, displayName string, clientID, notifierID *uuid.UUID, downloadDir, category string, replaceOnUpdate, replaceDeleteData bool, extra map[string]any) (*domain.Topic, error) {
 	s.updateCalled = true

--- a/backend/internal/api/handlers/topics_handler_test.go
+++ b/backend/internal/api/handlers/topics_handler_test.go
@@ -91,13 +91,8 @@ type fakeTopicStore struct {
 	resetErr   error
 
 	// Captured QueueRecheck arguments.
-	recheckCalls [][2]uuid.UUID
-	recheckOK    bool
-	// recheckResults, when non-empty, supplies the QueueRecheck return value
-	// per call in order (one entry consumed per call), falling back to
-	// recheckOK once exhausted. Lets a test simulate the queue flipping from
-	// false to true across two calls (the resume-during-recheck race).
-	recheckResults []bool
+	recheckCalls   [][2]uuid.UUID
+	recheckOutcome repo.RecheckOutcome
 	recheckErr     error
 }
 
@@ -132,14 +127,9 @@ func (s *fakeTopicStore) ResetCheckState(ctx context.Context, id, userID uuid.UU
 
 // QueueRecheck records (topicID, userID) per call so tests can assert the
 // handler passed the right topic for the right owner.
-func (s *fakeTopicStore) QueueRecheck(_ context.Context, id, userID uuid.UUID) (bool, error) {
+func (s *fakeTopicStore) QueueRecheck(_ context.Context, id, userID uuid.UUID) (repo.RecheckOutcome, error) {
 	s.recheckCalls = append(s.recheckCalls, [2]uuid.UUID{id, userID})
-	if len(s.recheckResults) > 0 {
-		ok := s.recheckResults[0]
-		s.recheckResults = s.recheckResults[1:]
-		return ok, s.recheckErr
-	}
-	return s.recheckOK, s.recheckErr
+	return s.recheckOutcome, s.recheckErr
 }
 func (s *fakeTopicStore) Update(_ context.Context, _, _ uuid.UUID, displayName string, clientID, notifierID *uuid.UUID, downloadDir, category string, replaceOnUpdate, replaceDeleteData bool, extra map[string]any) (*domain.Topic, error) {
 	s.updateCalled = true

--- a/backend/internal/api/handlers/topics_handler_test.go
+++ b/backend/internal/api/handlers/topics_handler_test.go
@@ -93,7 +93,12 @@ type fakeTopicStore struct {
 	// Captured QueueRecheck arguments.
 	recheckCalls [][2]uuid.UUID
 	recheckOK    bool
-	recheckErr   error
+	// recheckResults, when non-empty, supplies the QueueRecheck return value
+	// per call in order (one entry consumed per call), falling back to
+	// recheckOK once exhausted. Lets a test simulate the queue flipping from
+	// false to true across two calls (the resume-during-recheck race).
+	recheckResults []bool
+	recheckErr     error
 }
 
 func (s *fakeTopicStore) Create(_ context.Context, t *domain.Topic) (*domain.Topic, error) {
@@ -129,6 +134,11 @@ func (s *fakeTopicStore) ResetCheckState(ctx context.Context, id, userID uuid.UU
 // handler passed the right topic for the right owner.
 func (s *fakeTopicStore) QueueRecheck(_ context.Context, id, userID uuid.UUID) (bool, error) {
 	s.recheckCalls = append(s.recheckCalls, [2]uuid.UUID{id, userID})
+	if len(s.recheckResults) > 0 {
+		ok := s.recheckResults[0]
+		s.recheckResults = s.recheckResults[1:]
+		return ok, s.recheckErr
+	}
 	return s.recheckOK, s.recheckErr
 }
 func (s *fakeTopicStore) Update(_ context.Context, _, _ uuid.UUID, displayName string, clientID, notifierID *uuid.UUID, downloadDir, category string, replaceOnUpdate, replaceDeleteData bool, extra map[string]any) (*domain.Topic, error) {

--- a/backend/internal/api/handlers/topics_recheck_test.go
+++ b/backend/internal/api/handlers/topics_recheck_test.go
@@ -34,7 +34,9 @@ func TestRecheck_QueuesTheTopicAndReturns204(t *testing.T) {
 }
 
 // A paused topic must NOT be reported as success: the scheduler ignores paused
-// rows, so a 204 would promise a check that never happens.
+// rows, so a 204 would promise a check that never happens. It must also not
+// retry the queue — the topic is genuinely paused, so a second QueueRecheck
+// call would just observe the same ineligible row again.
 func TestRecheck_PausedTopic_Returns409(t *testing.T) {
 	store := &fakeTopicStore{
 		recheckOK: false,
@@ -48,6 +50,41 @@ func TestRecheck_PausedTopic_Returns409(t *testing.T) {
 
 	if w.Code != http.StatusConflict {
 		t.Fatalf("status %d, want 409; body %s", w.Code, w.Body.String())
+	}
+	if len(store.recheckCalls) != 1 {
+		t.Fatalf("QueueRecheck called %d times, want 1 (must not retry a genuinely paused topic)", len(store.recheckCalls))
+	}
+}
+
+// TestRecheck_ResumedBetweenQueueAndLookup_Returns204 covers the TOCTOU race:
+// QueueRecheck's UPDATE matches nothing (topic was paused at that instant),
+// but by the time GetByID runs, the topic has been resumed by another
+// request. Reporting "paused" here would describe a state that no longer
+// holds and send the user to resume an already-active topic, so the handler
+// must retry the queue instead — and that retry must succeed (204), not 409.
+func TestRecheck_ResumedBetweenQueueAndLookup_Returns204(t *testing.T) {
+	store := &fakeTopicStore{
+		recheckResults: []bool{false, true},
+		getByID:        &domain.Topic{ID: uuid.New(), Status: domain.TopicStatusActive},
+	}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	uid := uuid.New()
+	id := uuid.New()
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uid, nil), "id", id.String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204; body %s", w.Code, w.Body.String())
+	}
+	if len(store.recheckCalls) != 2 {
+		t.Fatalf("QueueRecheck called %d times, want 2 (initial + retry)", len(store.recheckCalls))
+	}
+	for i, call := range store.recheckCalls {
+		if call != [2]uuid.UUID{id, uid} {
+			t.Errorf("QueueRecheck call %d got %v, want {topicID, userID} = {%s, %s}", i, call, id, uid)
+		}
 	}
 }
 

--- a/backend/internal/api/handlers/topics_recheck_test.go
+++ b/backend/internal/api/handlers/topics_recheck_test.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+)
+
+func TestRecheck_QueuesTheTopicAndReturns204(t *testing.T) {
+	store := &fakeTopicStore{recheckOK: true}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	uid := uuid.New()
+	id := uuid.New()
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uid, nil), "id", id.String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204; body %s", w.Code, w.Body.String())
+	}
+	if len(store.recheckCalls) != 1 {
+		t.Fatalf("QueueRecheck called %d times, want 1", len(store.recheckCalls))
+	}
+	if store.recheckCalls[0] != [2]uuid.UUID{id, uid} {
+		t.Errorf("QueueRecheck got %v, want {topicID, userID} = {%s, %s}",
+			store.recheckCalls[0], id, uid)
+	}
+}
+
+// A paused topic must NOT be reported as success: the scheduler ignores paused
+// rows, so a 204 would promise a check that never happens.
+func TestRecheck_PausedTopic_Returns409(t *testing.T) {
+	store := &fakeTopicStore{
+		recheckOK: false,
+		getByID:   &domain.Topic{ID: uuid.New(), Status: domain.TopicStatusPaused},
+	}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", uuid.New().String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status %d, want 409; body %s", w.Code, w.Body.String())
+	}
+}
+
+// Not found and not-yours are the same answer, so the response cannot be used
+// to probe for another user's topics.
+func TestRecheck_UnknownTopic_Returns404(t *testing.T) {
+	store := &fakeTopicStore{recheckOK: false, getByID: nil}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", uuid.New().String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want 404; body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRecheck_MalformedID_Returns400(t *testing.T) {
+	store := &fakeTopicStore{}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", "not-a-uuid")
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", w.Code)
+	}
+	if len(store.recheckCalls) != 0 {
+		t.Error("store must not be touched for a malformed id")
+	}
+}
+
+func TestRecheck_StoreError_Returns500(t *testing.T) {
+	store := &fakeTopicStore{recheckErr: errors.New("db down")}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", uuid.New().String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status %d, want 500", w.Code)
+	}
+}

--- a/backend/internal/api/handlers/topics_recheck_test.go
+++ b/backend/internal/api/handlers/topics_recheck_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/artyomsv/marauder/backend/internal/domain"
+	"github.com/artyomsv/marauder/backend/internal/db/repo"
 )
 
 func TestRecheck_QueuesTheTopicAndReturns204(t *testing.T) {
-	store := &fakeTopicStore{recheckOK: true}
+	store := &fakeTopicStore{recheckOutcome: repo.RecheckOutcome{Exists: true, Queued: true}}
 	h := &Topics{Topics: store, BaseURL: "http://test"}
 
 	uid := uuid.New()
@@ -34,14 +34,11 @@ func TestRecheck_QueuesTheTopicAndReturns204(t *testing.T) {
 }
 
 // A paused topic must NOT be reported as success: the scheduler ignores paused
-// rows, so a 204 would promise a check that never happens. It must also not
-// retry the queue — the topic is genuinely paused, so a second QueueRecheck
-// call would just observe the same ineligible row again.
+// rows, so a 204 would promise a check that never happens. Exists=true,
+// Queued=false is the single-statement outcome for exactly this case — there
+// is no follow-up lookup or retry to assert on.
 func TestRecheck_PausedTopic_Returns409(t *testing.T) {
-	store := &fakeTopicStore{
-		recheckOK: false,
-		getByID:   &domain.Topic{ID: uuid.New(), Status: domain.TopicStatusPaused},
-	}
+	store := &fakeTopicStore{recheckOutcome: repo.RecheckOutcome{Exists: true, Queued: false}}
 	h := &Topics{Topics: store, BaseURL: "http://test"}
 
 	w := httptest.NewRecorder()
@@ -52,46 +49,15 @@ func TestRecheck_PausedTopic_Returns409(t *testing.T) {
 		t.Fatalf("status %d, want 409; body %s", w.Code, w.Body.String())
 	}
 	if len(store.recheckCalls) != 1 {
-		t.Fatalf("QueueRecheck called %d times, want 1 (must not retry a genuinely paused topic)", len(store.recheckCalls))
-	}
-}
-
-// TestRecheck_ResumedBetweenQueueAndLookup_Returns204 covers the TOCTOU race:
-// QueueRecheck's UPDATE matches nothing (topic was paused at that instant),
-// but by the time GetByID runs, the topic has been resumed by another
-// request. Reporting "paused" here would describe a state that no longer
-// holds and send the user to resume an already-active topic, so the handler
-// must retry the queue instead — and that retry must succeed (204), not 409.
-func TestRecheck_ResumedBetweenQueueAndLookup_Returns204(t *testing.T) {
-	store := &fakeTopicStore{
-		recheckResults: []bool{false, true},
-		getByID:        &domain.Topic{ID: uuid.New(), Status: domain.TopicStatusActive},
-	}
-	h := &Topics{Topics: store, BaseURL: "http://test"}
-
-	uid := uuid.New()
-	id := uuid.New()
-	w := httptest.NewRecorder()
-	req := withURLParam(authedReq(t, uid, nil), "id", id.String())
-	h.Recheck(w, req)
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("status %d, want 204; body %s", w.Code, w.Body.String())
-	}
-	if len(store.recheckCalls) != 2 {
-		t.Fatalf("QueueRecheck called %d times, want 2 (initial + retry)", len(store.recheckCalls))
-	}
-	for i, call := range store.recheckCalls {
-		if call != [2]uuid.UUID{id, uid} {
-			t.Errorf("QueueRecheck call %d got %v, want {topicID, userID} = {%s, %s}", i, call, id, uid)
-		}
+		t.Fatalf("QueueRecheck called %d times, want 1", len(store.recheckCalls))
 	}
 }
 
 // Not found and not-yours are the same answer, so the response cannot be used
-// to probe for another user's topics.
+// to probe for another user's topics. Exists=false is the single-statement
+// outcome for both.
 func TestRecheck_UnknownTopic_Returns404(t *testing.T) {
-	store := &fakeTopicStore{recheckOK: false, getByID: nil}
+	store := &fakeTopicStore{recheckOutcome: repo.RecheckOutcome{Exists: false, Queued: false}}
 	h := &Topics{Topics: store, BaseURL: "http://test"}
 
 	w := httptest.NewRecorder()

--- a/backend/internal/api/handlers/topics_reset_test.go
+++ b/backend/internal/api/handlers/topics_reset_test.go
@@ -532,8 +532,8 @@ func (s *concurrentResetStore) ResetCheckState(_ context.Context, id, _ uuid.UUI
 	s.reset = append(s.reset, id)
 	return nil
 }
-func (s *concurrentResetStore) QueueRecheck(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
-	return false, nil
+func (s *concurrentResetStore) QueueRecheck(context.Context, uuid.UUID, uuid.UUID) (repo.RecheckOutcome, error) {
+	return repo.RecheckOutcome{}, nil
 }
 
 func (s *concurrentResetStore) resetIDs() []uuid.UUID {

--- a/backend/internal/api/handlers/topics_reset_test.go
+++ b/backend/internal/api/handlers/topics_reset_test.go
@@ -532,6 +532,9 @@ func (s *concurrentResetStore) ResetCheckState(_ context.Context, id, _ uuid.UUI
 	s.reset = append(s.reset, id)
 	return nil
 }
+func (s *concurrentResetStore) QueueRecheck(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+	return false, nil
+}
 
 func (s *concurrentResetStore) resetIDs() []uuid.UUID {
 	s.mu.Lock()

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -185,6 +185,7 @@ func NewRouter(d Deps) http.Handler {
 			r.Post("/topics/{id}/pause", topicsH.Pause)
 			r.Post("/topics/{id}/resume", topicsH.Resume)
 			r.Post("/topics/{id}/reset", topicsH.Reset)
+			r.Post("/topics/{id}/recheck", topicsH.Recheck)
 
 			r.Get("/clients", clientsH.List)
 			r.Post("/clients", clientsH.Create)

--- a/backend/internal/db/repo/topics.go
+++ b/backend/internal/db/repo/topics.go
@@ -415,6 +415,19 @@ WHERE id = $1 AND user_id = $2`
 	return nil
 }
 
+// RecheckOutcome is the atomic result of QueueRecheck: whether the topic
+// exists for this user, and whether its next check was actually brought
+// forward. Both facts come from ONE statement, deliberately.
+//
+// Classifying by combining separate statements does not work here: the handler
+// needs to tell "paused" from "not found", and any interleaving of a pause or
+// resume between two queries makes that inference wrong. A single snapshot
+// cannot disagree with itself.
+type RecheckOutcome struct {
+	Exists bool
+	Queued bool
+}
+
 // QueueRecheck brings a topic's next check forward to now, so the scheduler
 // picks it up on its next tick. It is the non-destructive counterpart to
 // ResetCheckState: a topic parked on a backoff after a tracker outage can be
@@ -429,23 +442,30 @@ WHERE id = $1 AND user_id = $2`
 // optimistic-concurrency token, so disturbing it needlessly would widen the
 // window in which an in-flight check discards its own result.
 //
-// Paused topics are excluded because DueForCheck ignores them; moving their
-// next_check_at would be a silent no-op that the API would have to report as
+// Paused topics are not queued because DueForCheck ignores them; moving their
+// next_check_at would be a silent no-op the API would have to report as
 // success. Ownership is enforced by the statement, matching ResetCheckState.
 //
-// Returns whether a row was updated. False means the topic does not exist, is
-// not this user's, or is paused — the handler tells those apart.
-func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error) {
+// Exists and Queued are read from the same CTE snapshot, so there is no gap
+// between "does it exist" and "was it updated" for a concurrent pause/resume
+// to fall into — see the RecheckOutcome doc comment for why that matters.
+func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (RecheckOutcome, error) {
 	const q = `
-UPDATE topics SET
-    next_check_at = now(),
-    updated_at    = now()
-WHERE id = $1 AND user_id = $2 AND status <> 'paused'`
-	ct, err := r.pool.Exec(ctx, q, id, userID)
-	if err != nil {
-		return false, fmt.Errorf("topics: queue recheck: %w", err)
+WITH target AS (
+    SELECT id, status FROM topics WHERE id = $1 AND user_id = $2
+), updated AS (
+    UPDATE topics SET
+        next_check_at = now(),
+        updated_at    = now()
+    WHERE id = (SELECT id FROM target WHERE status <> 'paused')
+    RETURNING 1
+)
+SELECT EXISTS (SELECT 1 FROM target), EXISTS (SELECT 1 FROM updated)`
+	var out RecheckOutcome
+	if err := r.pool.QueryRow(ctx, q, id, userID).Scan(&out.Exists, &out.Queued); err != nil {
+		return RecheckOutcome{}, fmt.Errorf("topics: queue recheck: %w", err)
 	}
-	return ct.RowsAffected() > 0, nil
+	return out, nil
 }
 
 // Update edits a topic's user-editable fields (display name, client, notifier,

--- a/backend/internal/db/repo/topics.go
+++ b/backend/internal/db/repo/topics.go
@@ -450,14 +450,24 @@ type RecheckOutcome struct {
 // between "does it exist" and "was it updated" for a concurrent pause/resume
 // to fall into — see the RecheckOutcome doc comment for why that matters.
 func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (RecheckOutcome, error) {
+	// The eligibility predicate (status <> 'paused') MUST live in the UPDATE's
+	// own WHERE clause, not in the target CTE. Under READ COMMITTED, Postgres
+	// re-evaluates an UPDATE's own WHERE against the newest committed row
+	// version after locking it, so a pause committed between the statement
+	// snapshot and the update is still honoured. A status tested inside a CTE
+	// is frozen at the snapshot, which would let a concurrent pause slip
+	// through and return 204 — promising a check DueForCheck then ignores.
+	//
+	// target therefore tests only existence and ownership, which is what the
+	// caller needs to tell "paused" (409) from "not found" (404).
 	const q = `
 WITH target AS (
-    SELECT id, status FROM topics WHERE id = $1 AND user_id = $2
+    SELECT 1 FROM topics WHERE id = $1 AND user_id = $2
 ), updated AS (
     UPDATE topics SET
         next_check_at = now(),
         updated_at    = now()
-    WHERE id = (SELECT id FROM target WHERE status <> 'paused')
+    WHERE id = $1 AND user_id = $2 AND status <> 'paused'
     RETURNING 1
 )
 SELECT EXISTS (SELECT 1 FROM target), EXISTS (SELECT 1 FROM updated)`

--- a/backend/internal/db/repo/topics.go
+++ b/backend/internal/db/repo/topics.go
@@ -460,6 +460,13 @@ func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (Rechec
 	//
 	// target therefore tests only existence and ownership, which is what the
 	// caller needs to tell "paused" (409) from "not found" (404).
+	//
+	// The eligibility set deliberately mirrors DueForCheck's WHERE clause
+	// (status IN ('active', 'error')) rather than the logically-equivalent
+	// status <> 'paused' — today's two other statuses make them the same set,
+	// but a future third status would be silently queued here and silently
+	// ignored by DueForCheck, reintroducing the "204 promising a check that
+	// never runs" failure this endpoint exists to avoid. Keep the two in step.
 	const q = `
 WITH target AS (
     SELECT 1 FROM topics WHERE id = $1 AND user_id = $2
@@ -467,7 +474,7 @@ WITH target AS (
     UPDATE topics SET
         next_check_at = now(),
         updated_at    = now()
-    WHERE id = $1 AND user_id = $2 AND status <> 'paused'
+    WHERE id = $1 AND user_id = $2 AND status IN ('active', 'error')
     RETURNING 1
 )
 SELECT EXISTS (SELECT 1 FROM target), EXISTS (SELECT 1 FROM updated)`

--- a/backend/internal/db/repo/topics.go
+++ b/backend/internal/db/repo/topics.go
@@ -415,6 +415,39 @@ WHERE id = $1 AND user_id = $2`
 	return nil
 }
 
+// QueueRecheck brings a topic's next check forward to now, so the scheduler
+// picks it up on its next tick. It is the non-destructive counterpart to
+// ResetCheckState: a topic parked on a backoff after a tracker outage can be
+// retried the moment the cause is fixed, without removing anything from the
+// download client.
+//
+// It writes next_check_at and NOTHING else. status, last_error and
+// last_error_code belong to the scheduler, which clears them on the next
+// successful check — reporting the topic healthy before anything has verified
+// that would be a lie. last_checked_at is left alone too: it has not checked
+// anything yet, and it is half of the (last_checked_at, next_check_at)
+// optimistic-concurrency token, so disturbing it needlessly would widen the
+// window in which an in-flight check discards its own result.
+//
+// Paused topics are excluded because DueForCheck ignores them; moving their
+// next_check_at would be a silent no-op that the API would have to report as
+// success. Ownership is enforced by the statement, matching ResetCheckState.
+//
+// Returns whether a row was updated. False means the topic does not exist, is
+// not this user's, or is paused — the handler tells those apart.
+func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error) {
+	const q = `
+UPDATE topics SET
+    next_check_at = now(),
+    updated_at    = now()
+WHERE id = $1 AND user_id = $2 AND status <> 'paused'`
+	ct, err := r.pool.Exec(ctx, q, id, userID)
+	if err != nil {
+		return false, fmt.Errorf("topics: queue recheck: %w", err)
+	}
+	return ct.RowsAffected() > 0, nil
+}
+
 // Update edits a topic's user-editable fields (display name, client, notifier,
 // download dir, category, and the capability Extra map). It does NOT
 // touch url/tracker/status/hash/scheduling. Returns ErrNotFound when the

--- a/backend/internal/db/repo/topics_recheck_integration_test.go
+++ b/backend/internal/db/repo/topics_recheck_integration_test.go
@@ -27,12 +27,12 @@ func TestIntegration_QueueRecheck_BringsAnErroredTopicForward(t *testing.T) {
 	}
 
 	topics := NewTopics(pool)
-	ok, err := topics.QueueRecheck(ctx, topic.ID, userID)
+	out, err := topics.QueueRecheck(ctx, topic.ID, userID)
 	if err != nil {
 		t.Fatalf("QueueRecheck: %v", err)
 	}
-	if !ok {
-		t.Fatal("QueueRecheck reported no row updated")
+	if !out.Exists || !out.Queued {
+		t.Fatalf("QueueRecheck = %+v, want {Exists:true Queued:true}", out)
 	}
 
 	got := reload(t, pool, topic.ID)
@@ -93,8 +93,10 @@ WHERE id = $1`, topic.ID); err != nil {
 }
 
 // TestIntegration_QueueRecheck_IgnoresPausedTopics — DueForCheck skips paused
-// rows, so moving next_check_at would be a silent no-op. Reporting false lets
-// the handler answer 409 instead of a misleading 204.
+// rows, so moving next_check_at would be a silent no-op. Reporting
+// Exists=true, Queued=false lets the handler answer 409 instead of a
+// misleading 204 — and distinguishes this case from an unknown topic, which
+// is the entire point of the atomic outcome.
 func TestIntegration_QueueRecheck_IgnoresPausedTopics(t *testing.T) {
 	pool := integrationPool(t)
 	ctx := context.Background()
@@ -102,11 +104,14 @@ func TestIntegration_QueueRecheck_IgnoresPausedTopics(t *testing.T) {
 	topic := seedTopic(t, pool, userID, domain.TopicStatusPaused, nil)
 	before := reload(t, pool, topic.ID)
 
-	ok, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, userID)
+	out, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, userID)
 	if err != nil {
 		t.Fatalf("QueueRecheck: %v", err)
 	}
-	if ok {
+	if !out.Exists {
+		t.Fatal("QueueRecheck reported a paused topic as not existing")
+	}
+	if out.Queued {
 		t.Fatal("QueueRecheck reported an update for a paused topic")
 	}
 
@@ -127,12 +132,12 @@ func TestIntegration_QueueRecheck_IsScopedToTheOwner(t *testing.T) {
 	topic := seedTopic(t, pool, owner, domain.TopicStatusActive, nil)
 	before := reload(t, pool, topic.ID)
 
-	ok, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, stranger)
+	out, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, stranger)
 	if err != nil {
 		t.Fatalf("QueueRecheck: %v", err)
 	}
-	if ok {
-		t.Fatal("another user's topic was rechecked")
+	if out.Exists || out.Queued {
+		t.Fatalf("QueueRecheck = %+v, want {Exists:false Queued:false} for another user's topic", out)
 	}
 
 	got := reload(t, pool, topic.ID)
@@ -141,16 +146,18 @@ func TestIntegration_QueueRecheck_IsScopedToTheOwner(t *testing.T) {
 	}
 }
 
-// TestIntegration_QueueRecheck_UnknownTopic reports false rather than erroring,
-// so the handler can turn it into a 404.
+// TestIntegration_QueueRecheck_UnknownTopic reports Exists=false rather than
+// erroring, so the handler can turn it into a 404 — and, crucially, it is
+// distinguishable from a paused topic (Exists=true, Queued=false), which is
+// the whole reason RecheckOutcome carries both fields.
 func TestIntegration_QueueRecheck_UnknownTopic(t *testing.T) {
 	pool := integrationPool(t)
 	userID := seedUser(t, pool)
-	ok, err := NewTopics(pool).QueueRecheck(context.Background(), uuid.New(), userID)
+	out, err := NewTopics(pool).QueueRecheck(context.Background(), uuid.New(), userID)
 	if err != nil {
 		t.Fatalf("QueueRecheck: %v", err)
 	}
-	if ok {
-		t.Fatal("QueueRecheck reported an update for an unknown topic")
+	if out.Exists || out.Queued {
+		t.Fatalf("QueueRecheck = %+v, want {Exists:false Queued:false} for an unknown topic", out)
 	}
 }

--- a/backend/internal/db/repo/topics_recheck_integration_test.go
+++ b/backend/internal/db/repo/topics_recheck_integration_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package repo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+)
+
+// TestIntegration_QueueRecheck_BringsAnErroredTopicForward is the feature's
+// reason to exist: a topic parked on a six-hour backoff becomes due now.
+func TestIntegration_QueueRecheck_BringsAnErroredTopicForward(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	userID := seedUser(t, pool)
+	topic := seedTopic(t, pool, userID, domain.TopicStatusError, nil)
+
+	// Park it in the future, as a failing check would.
+	if _, err := pool.Exec(ctx,
+		`UPDATE topics SET next_check_at = now() + interval '6 hours' WHERE id = $1`, topic.ID); err != nil {
+		t.Fatalf("park topic: %v", err)
+	}
+
+	topics := NewTopics(pool)
+	ok, err := topics.QueueRecheck(ctx, topic.ID, userID)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if !ok {
+		t.Fatal("QueueRecheck reported no row updated")
+	}
+
+	got := reload(t, pool, topic.ID)
+	if d := time.Since(got.NextCheckAt); d > time.Minute || d < -time.Minute {
+		t.Errorf("next_check_at is %s from now, want ~now", d)
+	}
+}
+
+// TestIntegration_QueueRecheck_LeavesEverythingElseAlone pins the narrowness of
+// the statement. Clearing status or last_error here would claim the topic is
+// healthy before anything has verified that.
+func TestIntegration_QueueRecheck_LeavesEverythingElseAlone(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	userID := seedUser(t, pool)
+	topic := seedTopic(t, pool, userID, domain.TopicStatusError, nil)
+
+	if _, err := pool.Exec(ctx, `
+UPDATE topics SET
+    last_hash          = 'abc123',
+    last_checked_at    = now() - interval '1 hour',
+    consecutive_errors = 4,
+    last_error         = 'boom',
+    last_error_code    = 'auth'
+WHERE id = $1`, topic.ID); err != nil {
+		t.Fatalf("seed check state: %v", err)
+	}
+	before := reload(t, pool, topic.ID)
+
+	if _, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, userID); err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+
+	got := reload(t, pool, topic.ID)
+	if got.Status != before.Status {
+		t.Errorf("status = %q, want %q unchanged", got.Status, before.Status)
+	}
+	if got.LastError != before.LastError {
+		t.Errorf("last_error = %q, want %q unchanged", got.LastError, before.LastError)
+	}
+	if got.LastErrorCode != before.LastErrorCode {
+		t.Errorf("last_error_code = %q, want %q unchanged", got.LastErrorCode, before.LastErrorCode)
+	}
+	if got.LastHash != before.LastHash {
+		t.Errorf("last_hash = %q, want %q unchanged", got.LastHash, before.LastHash)
+	}
+	if got.ConsecutiveErrors != before.ConsecutiveErrors {
+		t.Errorf("consecutive_errors = %d, want %d unchanged", got.ConsecutiveErrors, before.ConsecutiveErrors)
+	}
+	// last_checked_at is half of the check-state token; leaving it alone keeps
+	// "when was this last checked?" truthful and minimises token disruption.
+	if (got.LastCheckedAt == nil) != (before.LastCheckedAt == nil) {
+		t.Fatalf("last_checked_at nullability changed")
+	}
+	if got.LastCheckedAt != nil && !got.LastCheckedAt.Equal(*before.LastCheckedAt) {
+		t.Errorf("last_checked_at = %v, want %v unchanged", got.LastCheckedAt, before.LastCheckedAt)
+	}
+}
+
+// TestIntegration_QueueRecheck_IgnoresPausedTopics — DueForCheck skips paused
+// rows, so moving next_check_at would be a silent no-op. Reporting false lets
+// the handler answer 409 instead of a misleading 204.
+func TestIntegration_QueueRecheck_IgnoresPausedTopics(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	userID := seedUser(t, pool)
+	topic := seedTopic(t, pool, userID, domain.TopicStatusPaused, nil)
+	before := reload(t, pool, topic.ID)
+
+	ok, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, userID)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if ok {
+		t.Fatal("QueueRecheck reported an update for a paused topic")
+	}
+
+	got := reload(t, pool, topic.ID)
+	if !got.NextCheckAt.Equal(before.NextCheckAt) {
+		t.Errorf("next_check_at moved for a paused topic: %v -> %v",
+			before.NextCheckAt, got.NextCheckAt)
+	}
+}
+
+// TestIntegration_QueueRecheck_IsScopedToTheOwner keeps ownership in the
+// statement rather than relying on the handler to check first.
+func TestIntegration_QueueRecheck_IsScopedToTheOwner(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	owner := seedUser(t, pool)
+	stranger := seedUser(t, pool)
+	topic := seedTopic(t, pool, owner, domain.TopicStatusActive, nil)
+	before := reload(t, pool, topic.ID)
+
+	ok, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, stranger)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if ok {
+		t.Fatal("another user's topic was rechecked")
+	}
+
+	got := reload(t, pool, topic.ID)
+	if !got.NextCheckAt.Equal(before.NextCheckAt) {
+		t.Error("next_check_at moved for another user's topic")
+	}
+}
+
+// TestIntegration_QueueRecheck_UnknownTopic reports false rather than erroring,
+// so the handler can turn it into a 404.
+func TestIntegration_QueueRecheck_UnknownTopic(t *testing.T) {
+	pool := integrationPool(t)
+	userID := seedUser(t, pool)
+	ok, err := NewTopics(pool).QueueRecheck(context.Background(), uuid.New(), userID)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if ok {
+		t.Fatal("QueueRecheck reported an update for an unknown topic")
+	}
+}

--- a/docs/superpowers/plans/2026-08-02-topic-recheck.md
+++ b/docs/superpowers/plans/2026-08-02-topic-recheck.md
@@ -1,0 +1,892 @@
+# Topic Recheck Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Check now" action that brings a topic's next scheduled check forward to now, so a topic sitting in error backoff can be retried without the destructive Reset.
+
+**Architecture:** One narrow repository method writes `next_check_at = now()` (and nothing else), a handler exposes it at `POST /topics/{id}/recheck`, and the frontend adds a row action plus a bulk-bar entry that fans out one request per selected topic. The scheduler needs no changes — `DueForCheck` already selects `status IN ('active','error') AND next_check_at <= now()`.
+
+**Tech Stack:** Go 1.25 (chi, pgx, uuid), React 19 + TypeScript (React Query, framer-motion, lucide-react), Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-08-02-topic-recheck-design.md`
+
+## Global Constraints
+
+- **Paused topics are excluded.** `DueForCheck` ignores `paused`, so writing `next_check_at` for one would silently do nothing. The SQL excludes them and the UI hides the action.
+- **Write `next_check_at` and nothing else.** Not `status`, not `last_error`, not `last_checked_at`. The scheduler clears those on the next successful check; showing the old error until then is honest.
+- **Ownership is enforced in the statement** (`AND user_id = $2`), matching `ResetCheckState` — not by caller discipline.
+- **No audit entry, no `topic_events` row.** Matches `Pause`/`Resume`. `Reset` audits because it destroys state; this moves a timestamp the scheduler rewrites every tick.
+- Go: tabs (gofmt), errors wrapped with `fmt.Errorf("...: %w", err)`, `errors.Is` for comparison.
+- Frontend: 2-space indent, `interface` over `type` for object shapes, query keys from `lib/queryKeys.ts`, i18n keys in **both** `en` and `ru`.
+- Backend verification (never install Go locally):
+  ```bash
+  docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 \
+    sh -c "gofmt -l . && go build ./... && go vet ./... && go test -race ./..."
+  ```
+- Frontend verification (container-local `node_modules` volume — the Windows bind mount is too slow for vitest):
+  ```bash
+  docker run --rm -v "E:/Projects/Stukans/Marauder/frontend:/host:ro" -v marauder-fe-nm:/app -w //app node:22-alpine \
+    sh -c "cp -r /host/src /host/vitest.config.ts /host/vite.config.ts /host/index.html /host/tsconfig*.json /app/ 2>/dev/null; npx tsc --noEmit && npx vitest run"
+  ```
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `backend/internal/db/repo/topics.go` | Add `QueueRecheck` — the single UPDATE |
+| `backend/internal/db/repo/topics_recheck_integration_test.go` *(new)* | Real-Postgres proof of the status/ownership guards, which pgxmock cannot give |
+| `backend/internal/api/handlers/topics.go` | Add `QueueRecheck` to the `topicStore` interface + the `Recheck` handler |
+| `backend/internal/api/handlers/topics_handler_test.go` | Add `QueueRecheck` to `fakeTopicStore` |
+| `backend/internal/api/handlers/topics_recheck_test.go` *(new)* | Handler status-code matrix |
+| `backend/internal/api/router.go` | Route registration |
+| `frontend/src/pages/Topics.tsx` | `recheck` mutation + row/bulk wiring |
+| `frontend/src/components/topics/TopicRow.tsx` | Row action, hidden when paused |
+| `frontend/src/components/topics/BulkActionBar.tsx` | Bulk entry |
+| `frontend/src/components/topics/TopicRow.test.tsx` *(new)* | Row action visibility + click |
+| `frontend/src/i18n/en.ts`, `ru.ts` | Copy |
+| `CLAUDE.md`, `CHANGELOG.md` | Structural note + release note |
+
+---
+
+### Task 1: Repository — `QueueRecheck`
+
+**Files:**
+- Modify: `backend/internal/db/repo/topics.go` (add after `ResetCheckState`)
+- Test: `backend/internal/db/repo/topics_recheck_integration_test.go` *(new)*
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error)` — `true` when a row was updated; `false` means not-found, not-owned, **or** paused (the handler distinguishes).
+
+> The tests are integration-tagged because the whole behaviour is SQL semantics — the `status <> 'paused'` guard and the `user_id` scoping. The package's pgxmock tests pin query text without executing it, so they cannot tell you whether the WHERE clause actually excludes anything.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/internal/db/repo/topics_recheck_integration_test.go`:
+
+```go
+//go:build integration
+
+package repo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+)
+
+// TestIntegration_QueueRecheck_BringsAnErroredTopicForward is the feature's
+// reason to exist: a topic parked on a six-hour backoff becomes due now.
+func TestIntegration_QueueRecheck_BringsAnErroredTopicForward(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	userID := seedUser(t, pool)
+	topic := seedTopic(t, pool, userID, domain.TopicStatusError, nil)
+
+	// Park it in the future, as a failing check would.
+	if _, err := pool.Exec(ctx,
+		`UPDATE topics SET next_check_at = now() + interval '6 hours' WHERE id = $1`, topic.ID); err != nil {
+		t.Fatalf("park topic: %v", err)
+	}
+
+	topics := NewTopics(pool)
+	ok, err := topics.QueueRecheck(ctx, topic.ID, userID)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if !ok {
+		t.Fatal("QueueRecheck reported no row updated")
+	}
+
+	got := reload(t, pool, topic.ID)
+	if d := time.Since(got.NextCheckAt); d > time.Minute || d < -time.Minute {
+		t.Errorf("next_check_at is %s from now, want ~now", d)
+	}
+}
+
+// TestIntegration_QueueRecheck_LeavesEverythingElseAlone pins the narrowness of
+// the statement. Clearing status or last_error here would claim the topic is
+// healthy before anything has verified that.
+func TestIntegration_QueueRecheck_LeavesEverythingElseAlone(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	userID := seedUser(t, pool)
+	topic := seedTopic(t, pool, userID, domain.TopicStatusError, nil)
+
+	if _, err := pool.Exec(ctx, `
+UPDATE topics SET
+    last_hash          = 'abc123',
+    last_checked_at    = now() - interval '1 hour',
+    consecutive_errors = 4,
+    last_error         = 'boom',
+    last_error_code    = 'auth'
+WHERE id = $1`, topic.ID); err != nil {
+		t.Fatalf("seed check state: %v", err)
+	}
+	before := reload(t, pool, topic.ID)
+
+	if _, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, userID); err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+
+	got := reload(t, pool, topic.ID)
+	if got.Status != before.Status {
+		t.Errorf("status = %q, want %q unchanged", got.Status, before.Status)
+	}
+	if got.LastError != before.LastError {
+		t.Errorf("last_error = %q, want %q unchanged", got.LastError, before.LastError)
+	}
+	if got.LastErrorCode != before.LastErrorCode {
+		t.Errorf("last_error_code = %q, want %q unchanged", got.LastErrorCode, before.LastErrorCode)
+	}
+	if got.LastHash != before.LastHash {
+		t.Errorf("last_hash = %q, want %q unchanged", got.LastHash, before.LastHash)
+	}
+	if got.ConsecutiveErrors != before.ConsecutiveErrors {
+		t.Errorf("consecutive_errors = %d, want %d unchanged", got.ConsecutiveErrors, before.ConsecutiveErrors)
+	}
+	// last_checked_at is half of the check-state token; leaving it alone keeps
+	// "when was this last checked?" truthful and minimises token disruption.
+	if (got.LastCheckedAt == nil) != (before.LastCheckedAt == nil) {
+		t.Fatalf("last_checked_at nullability changed")
+	}
+	if got.LastCheckedAt != nil && !got.LastCheckedAt.Equal(*before.LastCheckedAt) {
+		t.Errorf("last_checked_at = %v, want %v unchanged", got.LastCheckedAt, before.LastCheckedAt)
+	}
+}
+
+// TestIntegration_QueueRecheck_IgnoresPausedTopics — DueForCheck skips paused
+// rows, so moving next_check_at would be a silent no-op. Reporting false lets
+// the handler answer 409 instead of a misleading 204.
+func TestIntegration_QueueRecheck_IgnoresPausedTopics(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	userID := seedUser(t, pool)
+	topic := seedTopic(t, pool, userID, domain.TopicStatusPaused, nil)
+	before := reload(t, pool, topic.ID)
+
+	ok, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, userID)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if ok {
+		t.Fatal("QueueRecheck reported an update for a paused topic")
+	}
+
+	got := reload(t, pool, topic.ID)
+	if !got.NextCheckAt.Equal(before.NextCheckAt) {
+		t.Errorf("next_check_at moved for a paused topic: %v -> %v",
+			before.NextCheckAt, got.NextCheckAt)
+	}
+}
+
+// TestIntegration_QueueRecheck_IsScopedToTheOwner keeps ownership in the
+// statement rather than relying on the handler to check first.
+func TestIntegration_QueueRecheck_IsScopedToTheOwner(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	owner := seedUser(t, pool)
+	stranger := seedUser(t, pool)
+	topic := seedTopic(t, pool, owner, domain.TopicStatusActive, nil)
+	before := reload(t, pool, topic.ID)
+
+	ok, err := NewTopics(pool).QueueRecheck(ctx, topic.ID, stranger)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if ok {
+		t.Fatal("another user's topic was rechecked")
+	}
+
+	got := reload(t, pool, topic.ID)
+	if !got.NextCheckAt.Equal(before.NextCheckAt) {
+		t.Error("next_check_at moved for another user's topic")
+	}
+}
+
+// TestIntegration_QueueRecheck_UnknownTopic reports false rather than erroring,
+// so the handler can turn it into a 404.
+func TestIntegration_QueueRecheck_UnknownTopic(t *testing.T) {
+	pool := integrationPool(t)
+	userID := seedUser(t, pool)
+	ok, err := NewTopics(pool).QueueRecheck(context.Background(), uuid.New(), userID)
+	if err != nil {
+		t.Fatalf("QueueRecheck: %v", err)
+	}
+	if ok {
+		t.Fatal("QueueRecheck reported an update for an unknown topic")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+docker network create marauder-itest-net 2>/dev/null
+docker run --rm -d --name marauder-itest-pg --network marauder-itest-net \
+  -e POSTGRES_PASSWORD=test -e POSTGRES_DB=marauder_test postgres:17-alpine
+docker run --rm --network marauder-itest-net -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend \
+  -e MARAUDER_TEST_DB_URL="postgres://postgres:test@marauder-itest-pg:5432/marauder_test?sslmode=disable" \
+  golang:1.25 sh -c "go test -tags=integration -race ./internal/db/repo/... -run QueueRecheck -v"
+```
+
+Expected: FAIL — `topics.QueueRecheck undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `backend/internal/db/repo/topics.go`, immediately after `ResetCheckState`:
+
+```go
+// QueueRecheck brings a topic's next check forward to now, so the scheduler
+// picks it up on its next tick. It is the non-destructive counterpart to
+// ResetCheckState: a topic parked on a backoff after a tracker outage can be
+// retried the moment the cause is fixed, without removing anything from the
+// download client.
+//
+// It writes next_check_at and NOTHING else. status, last_error and
+// last_error_code belong to the scheduler, which clears them on the next
+// successful check — reporting the topic healthy before anything has verified
+// that would be a lie. last_checked_at is left alone too: it has not checked
+// anything yet, and it is half of the (last_checked_at, next_check_at)
+// optimistic-concurrency token, so disturbing it needlessly would widen the
+// window in which an in-flight check discards its own result.
+//
+// Paused topics are excluded because DueForCheck ignores them; moving their
+// next_check_at would be a silent no-op that the API would have to report as
+// success. Ownership is enforced by the statement, matching ResetCheckState.
+//
+// Returns whether a row was updated. False means the topic does not exist, is
+// not this user's, or is paused — the handler tells those apart.
+func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error) {
+	const q = `
+UPDATE topics SET
+    next_check_at = now(),
+    updated_at    = now()
+WHERE id = $1 AND user_id = $2 AND status <> 'paused'`
+	ct, err := r.pool.Exec(ctx, q, id, userID)
+	if err != nil {
+		return false, fmt.Errorf("topics: queue recheck: %w", err)
+	}
+	return ct.RowsAffected() > 0, nil
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command as Step 2. Expected: PASS (5 tests). Then tear down:
+
+```bash
+docker rm -f marauder-itest-pg; docker network rm marauder-itest-net
+```
+
+- [ ] **Step 5: Verify the normal suite is unaffected**
+
+```bash
+docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 \
+  sh -c "gofmt -l . && go build ./... && go vet ./... && go test -race ./internal/db/repo/..."
+```
+
+Expected: no gofmt output, all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/db/repo/topics.go backend/internal/db/repo/topics_recheck_integration_test.go
+git commit -m "feat(repo): queue a topic for an immediate recheck"
+```
+
+---
+
+### Task 2: Handler and route
+
+**Files:**
+- Modify: `backend/internal/api/handlers/topics.go` (the `topicStore` interface at line 32-40; new handler beside `setStatus`)
+- Modify: `backend/internal/api/handlers/topics_handler_test.go` (extend `fakeTopicStore`)
+- Modify: `backend/internal/api/router.go:187` (after the `reset` route)
+- Test: `backend/internal/api/handlers/topics_recheck_test.go` *(new)*
+
+**Interfaces:**
+- Consumes: `QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error)` (Task 1).
+- Produces: `func (h *Topics) Recheck(w http.ResponseWriter, r *http.Request)`; route `POST /api/v1/topics/{id}/recheck`; responses `204` / `409` / `404` / `400`.
+
+- [ ] **Step 1: Extend the fake store**
+
+In `backend/internal/api/handlers/topics_handler_test.go`, add to the `fakeTopicStore` struct (after the `resetErr` field):
+
+```go
+	// Captured QueueRecheck arguments.
+	recheckCalls  [][2]uuid.UUID
+	recheckOK     bool
+	recheckErr    error
+```
+
+and add the method beside `ResetCheckState`:
+
+```go
+// QueueRecheck records (topicID, userID) per call so tests can assert the
+// handler passed the right topic for the right owner.
+func (s *fakeTopicStore) QueueRecheck(_ context.Context, id, userID uuid.UUID) (bool, error) {
+	s.recheckCalls = append(s.recheckCalls, [2]uuid.UUID{id, userID})
+	return s.recheckOK, s.recheckErr
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `backend/internal/api/handlers/topics_recheck_test.go`:
+
+```go
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/artyomsv/marauder/backend/internal/domain"
+)
+
+func TestRecheck_QueuesTheTopicAndReturns204(t *testing.T) {
+	store := &fakeTopicStore{recheckOK: true}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	uid := uuid.New()
+	id := uuid.New()
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uid, nil), "id", id.String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204; body %s", w.Code, w.Body.String())
+	}
+	if len(store.recheckCalls) != 1 {
+		t.Fatalf("QueueRecheck called %d times, want 1", len(store.recheckCalls))
+	}
+	if store.recheckCalls[0] != [2]uuid.UUID{id, uid} {
+		t.Errorf("QueueRecheck got %v, want {topicID, userID} = {%s, %s}",
+			store.recheckCalls[0], id, uid)
+	}
+}
+
+// A paused topic must NOT be reported as success: the scheduler ignores paused
+// rows, so a 204 would promise a check that never happens.
+func TestRecheck_PausedTopic_Returns409(t *testing.T) {
+	store := &fakeTopicStore{
+		recheckOK: false,
+		getByID:   &domain.Topic{ID: uuid.New(), Status: domain.TopicStatusPaused},
+	}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", uuid.New().String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status %d, want 409; body %s", w.Code, w.Body.String())
+	}
+}
+
+// Not found and not-yours are the same answer, so the response cannot be used
+// to probe for another user's topics.
+func TestRecheck_UnknownTopic_Returns404(t *testing.T) {
+	store := &fakeTopicStore{recheckOK: false, getByID: nil}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", uuid.New().String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want 404; body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRecheck_MalformedID_Returns400(t *testing.T) {
+	store := &fakeTopicStore{}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", "not-a-uuid")
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", w.Code)
+	}
+	if len(store.recheckCalls) != 0 {
+		t.Error("store must not be touched for a malformed id")
+	}
+}
+
+func TestRecheck_StoreError_Returns500(t *testing.T) {
+	store := &fakeTopicStore{recheckErr: errors.New("db down")}
+	h := &Topics{Topics: store, BaseURL: "http://test"}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(authedReq(t, uuid.New(), nil), "id", uuid.New().String())
+	h.Recheck(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status %d, want 500", w.Code)
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+```bash
+docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 \
+  go test ./internal/api/handlers/ -run TestRecheck -v
+```
+
+Expected: FAIL — `h.Recheck undefined`, and `*fakeTopicStore` does not implement `topicStore` until Step 4 adds the interface method.
+
+- [ ] **Step 4: Implement**
+
+Add to the `topicStore` interface in `backend/internal/api/handlers/topics.go` (after `ResetCheckState`):
+
+```go
+	QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error)
+```
+
+Add the handler immediately after `setStatus`:
+
+```go
+// Recheck handles POST /topics/{id}/recheck: bring the topic's next scheduled
+// check forward to now.
+//
+// This exists because a failing topic backs off up to six hours, which is
+// correct while a tracker is down and wrong the moment the operator fixes the
+// cause. Reset is the only other way to force a check and it is destructive —
+// it removes delivered torrents from the client.
+//
+// Nothing but next_check_at changes, so the stale error stays on screen until
+// the check that follows actually says otherwise.
+func (h *Topics) Recheck(w http.ResponseWriter, r *http.Request) {
+	uid, perr := currentUserID(r)
+	if perr != nil {
+		problem.Write(w, r, h.BaseURL, perr)
+		return
+	}
+	id, ierr := uuid.Parse(chi.URLParam(r, "id"))
+	if ierr != nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrBadRequest("invalid id"))
+		return
+	}
+	queued, qerr := h.Topics.QueueRecheck(r.Context(), id, uid)
+	if qerr != nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrInternal(qerr.Error()))
+		return
+	}
+	if queued {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	// No row matched: the topic is paused, or it is not this user's. Only the
+	// rare failing path pays for the extra lookup, and it buys an honest
+	// answer — a 404 for a paused topic would be a lie, and a 204 would
+	// promise a check the scheduler is never going to run.
+	t, gerr := h.Topics.GetByID(r.Context(), id, &uid)
+	if gerr != nil || t == nil {
+		problem.Write(w, r, h.BaseURL, problem.ErrNotFound("topic not found"))
+		return
+	}
+	problem.Write(w, r, h.BaseURL, problem.ErrConflict("topic is paused; resume it first"))
+}
+```
+
+Register the route in `backend/internal/api/router.go`, directly after the `reset` line:
+
+```go
+			r.Post("/topics/{id}/recheck", topicsH.Recheck)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 \
+  sh -c "gofmt -l . && go build ./... && go vet ./... && go test -race ./internal/api/..."
+```
+
+Expected: PASS (5 new tests plus the existing handler suite).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/api/handlers/topics.go backend/internal/api/handlers/topics_handler_test.go \
+        backend/internal/api/handlers/topics_recheck_test.go backend/internal/api/router.go
+git commit -m "feat(api): POST /topics/{id}/recheck to force an immediate check"
+```
+
+---
+
+### Task 3: Frontend row action, bulk action and copy
+
+**Files:**
+- Modify: `frontend/src/components/topics/TopicRow.tsx` (`TopicRowActions` at line 26-31; action buttons at ~line 116-135)
+- Modify: `frontend/src/components/topics/BulkActionBar.tsx`
+- Modify: `frontend/src/pages/Topics.tsx` (mutations ~line 59-72; `BulkActionBar` props ~line 166; row `actions` ~line 208)
+- Modify: `frontend/src/i18n/en.ts`, `frontend/src/i18n/ru.ts`
+- Test: `frontend/src/components/topics/TopicRow.test.tsx` *(new)*
+
+**Interfaces:**
+- Consumes: `POST /topics/{id}/recheck` (Task 2).
+- Produces: `TopicRowActions.onRecheck: () => void`; `BulkActionBarProps.onRecheck: () => void`; i18n keys `topics.recheck`, `topics.bulk.recheck`.
+
+- [ ] **Step 1: Add the copy**
+
+`frontend/src/i18n/en.ts` — beside the existing `topics.bulk.reset` / `topics.reset.*` keys:
+
+```ts
+  "topics.recheck": "Check now",
+  "topics.bulk.recheck": "Check now",
+```
+
+`frontend/src/i18n/ru.ts` — same keys:
+
+```ts
+  "topics.recheck": "Проверить сейчас",
+  "topics.bulk.recheck": "Проверить сейчас",
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `frontend/src/components/topics/TopicRow.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { TopicRow, type TopicRowActions, type TopicRowLookups } from "./TopicRow";
+import type { Topic } from "@/lib/api";
+
+const lookups: TopicRowLookups = {
+  clientById: new Map(),
+  defaultClient: null,
+  notifierById: new Map(),
+};
+
+function makeTopic(status: string): Topic {
+  return {
+    ID: "t1",
+    DisplayName: "Some Show",
+    URL: "https://rutracker.org/forum/viewtopic.php?t=1",
+    TrackerName: "rutracker",
+    Status: status,
+  } as unknown as Topic;
+}
+
+function makeActions(): TopicRowActions {
+  return {
+    onToggleSelect: vi.fn(),
+    onEdit: vi.fn(),
+    onRecheck: vi.fn(),
+    onReset: vi.fn(),
+    onDelete: vi.fn(),
+  };
+}
+
+function renderRow(status: string, actions: TopicRowActions) {
+  render(
+    <TopicRow
+      topic={makeTopic(status)}
+      compact={false}
+      selected={false}
+      deletePending={false}
+      lookups={lookups}
+      actions={actions}
+    />,
+  );
+}
+
+describe("TopicRow check-now action", () => {
+  it("calls onRecheck when clicked", async () => {
+    const actions = makeActions();
+    renderRow("error", actions);
+
+    await userEvent.click(screen.getByRole("button", { name: /check now/i }));
+    expect(actions.onRecheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("is offered for an errored topic — the case the feature exists for", () => {
+    renderRow("error", makeActions());
+    expect(screen.getByRole("button", { name: /check now/i })).toBeInTheDocument();
+  });
+
+  // The scheduler skips paused topics entirely, so a Check now button on one
+  // would silently do nothing. Hiding it is the honest option.
+  it("is hidden for a paused topic", () => {
+    renderRow("paused", makeActions());
+    expect(screen.queryByRole("button", { name: /check now/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+docker run --rm -v "E:/Projects/Stukans/Marauder/frontend:/host:ro" -v marauder-fe-nm:/app -w //app node:22-alpine \
+  sh -c "cp -r /host/src /host/vitest.config.ts /host/vite.config.ts /host/index.html /host/tsconfig*.json /app/ 2>/dev/null; npx vitest run src/components/topics/TopicRow.test.tsx"
+```
+
+Expected: FAIL — `onRecheck` is not a property of `TopicRowActions`, and no such button renders.
+
+- [ ] **Step 4: Implement the row action**
+
+In `frontend/src/components/topics/TopicRow.tsx`:
+
+Import the icon (line 2) and the translator:
+
+```tsx
+import { Pencil, RefreshCw, RotateCcw } from "lucide-react";
+```
+
+Add to `TopicRowActions`:
+
+```tsx
+export interface TopicRowActions {
+  onToggleSelect: () => void;
+  onEdit: () => void;
+  onRecheck: () => void;
+  onReset: () => void;
+  onDelete: () => void;
+}
+```
+
+Insert the button between Edit and Reset. `useT()` is already available in this file if it imports `useT` from `@/i18n`; if it does not, add `import { useT } from "@/i18n";` and `const t = useT();` at the top of the component:
+
+```tsx
+        {topic.Status !== "paused" && (
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("topics.recheck")}
+            title={t("topics.recheck")}
+            onClick={actions.onRecheck}
+          >
+            <RefreshCw className="size-4" />
+          </Button>
+        )}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Same command as Step 3. Expected: PASS (3 tests).
+
+- [ ] **Step 6: Add the bulk entry**
+
+In `frontend/src/components/topics/BulkActionBar.tsx`, extend the icon import and props:
+
+```tsx
+import { Pause, Play, RefreshCw, RotateCcw, Trash2, Check, X } from "lucide-react";
+
+export interface BulkActionBarProps {
+  count: number;
+  onPause: () => void;
+  onResume: () => void;
+  onRecheck: () => void;
+  onReset: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+}
+```
+
+Destructure `onRecheck` alongside the others, and add the button immediately before the Reset button:
+
+```tsx
+        <Button variant="outline" size="sm" onClick={onRecheck}>
+          <RefreshCw className="size-4" />
+          {t("topics.bulk.recheck")}
+        </Button>
+```
+
+- [ ] **Step 7: Wire the page**
+
+In `frontend/src/pages/Topics.tsx`, add the mutation beside `pause`/`resume` (~line 70):
+
+```tsx
+  const recheck = useMutation({
+    mutationFn: (id: string) => api.post<void>(`/topics/${id}/recheck`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: QK.topics }),
+  });
+```
+
+Add a bounded bulk helper next to it. The concurrency cap matters for the same reason bulk reset has one: an unbounded `Promise.all` over a large selection fires every request at once.
+
+```tsx
+  // Matches RESET_CONCURRENCY in ResetTopicCard — a bulk action should not
+  // fire one request per selected topic simultaneously.
+  const RECHECK_CONCURRENCY = 4;
+
+  const bulkRecheck = async (ids: string[]) => {
+    await mapWithConcurrency(ids, RECHECK_CONCURRENCY, (id) =>
+      api.post<void>(`/topics/${id}/recheck`).catch(() => undefined),
+    );
+    await qc.invalidateQueries({ queryKey: QK.topics });
+  };
+```
+
+with `import { mapWithConcurrency } from "@/lib/concurrency";` added to the imports.
+
+> `.catch(() => undefined)` is deliberate: one paused or deleted topic in a large selection returning 409/404 must not abort the rest. The list refetch shows the true outcome.
+
+Pass it to the bulk bar (~line 166):
+
+```tsx
+          onRecheck={() => void bulkRecheck([...selected])}
+```
+
+and to each row's actions (~line 208):
+
+```tsx
+                    onRecheck: () => recheck.mutate(t.ID),
+```
+
+- [ ] **Step 8: Run the full frontend check**
+
+```bash
+docker run --rm -v "E:/Projects/Stukans/Marauder/frontend:/host:ro" -v marauder-fe-nm:/app -w //app node:22-alpine \
+  sh -c "cp -r /host/src /host/vitest.config.ts /host/vite.config.ts /host/index.html /host/tsconfig*.json /app/ 2>/dev/null; npx tsc --noEmit && npx vitest run"
+```
+
+Expected: typecheck clean, all tests pass. Any other component constructing `TopicRowActions` or `BulkActionBarProps` will fail typecheck until it supplies `onRecheck` — fix those call sites if the compiler names any.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/components/topics/TopicRow.tsx frontend/src/components/topics/TopicRow.test.tsx \
+        frontend/src/components/topics/BulkActionBar.tsx frontend/src/pages/Topics.tsx \
+        frontend/src/i18n/en.ts frontend/src/i18n/ru.ts
+git commit -m "feat(topics): Check now action on a row and over a selection"
+```
+
+---
+
+### Task 4: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (the Topic-reset paragraph in the scheduler section)
+- Modify: `CHANGELOG.md` (`[Unreleased]`)
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+Immediately after the "**Topic reset:**" paragraph, add:
+
+```markdown
+**Topic recheck:** `POST /api/v1/topics/{id}/recheck` is the non-destructive
+counterpart to reset — `Topics.QueueRecheck` writes `next_check_at = now()` and
+nothing else, so a topic parked on a backoff (capped at 6h) after a tracker
+outage can be retried the moment the cause is fixed. `status`, `last_error` and
+`last_checked_at` are deliberately untouched: the scheduler clears them on the
+next successful check, and reporting the topic healthy before anything verified
+that would be a lie. Paused topics are excluded in the SQL because
+`DueForCheck` ignores them, so the endpoint answers **409** rather than a 204
+that promises a check which never runs (**404** for unknown/not-owned, which is
+also what a paused topic belonging to someone else returns). Writing
+`next_check_at` moves half of the `(last_checked_at, next_check_at)`
+check-state token, so a recheck landing mid-check discards that worker's result
+exactly as a reset does — bounded, self-correcting, and documented in the reset
+design's "Known limitation". No audit row and no `topic_events` entry (it
+matches pause/resume, not reset); the `check.*` events that follow are the
+record. Frontend: a `RefreshCw` row action hidden for paused topics, plus a
+bulk entry that fans out through `mapWithConcurrency`.
+```
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Under `## [Unreleased]`, add an `### Added` section (or extend an existing one):
+
+```markdown
+### Added
+
+- **Check now** — retry a topic immediately instead of waiting out its backoff.
+  A failing topic can back off for up to six hours, which is right while a
+  tracker is down and wrong once you have fixed the cause; previously the only
+  way to force a check was Reset, which removes the downloaded torrents from
+  your client. Available per row and over a multi-select. Not offered for
+  paused topics, since those are not checked at all.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md CHANGELOG.md
+git commit -m "docs: record the topic recheck action"
+```
+
+---
+
+### Task 5: Verify end to end, then open the PR
+
+- [ ] **Step 1: Full backend + lint**
+
+```bash
+docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golang:1.25 \
+  sh -c "gofmt -l . && go build ./... && go vet ./... && go test -race ./..."
+docker run --rm -v "E:/Projects/Stukans/Marauder/backend:/backend" -w //backend golangci/golangci-lint:v2.12.2 \
+  golangci-lint run --timeout=5m
+```
+
+Expected: no gofmt output, all tests pass, `0 issues`.
+
+- [ ] **Step 2: Run it against the live stack**
+
+```bash
+docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dev.yml up -d --no-deps --build backend frontend
+docker restart deploy-gateway-1
+```
+
+`--no-deps` keeps postgres from being recreated; the gateway restart refreshes nginx's cached upstream IP.
+
+Then, at http://localhost:34080:
+
+1. Park a topic in the future to simulate a backoff:
+   `docker exec deploy-db-1 psql -U marauder -d marauder -c "update topics set next_check_at = now() + interval '6 hours' where tracker_name='rutracker';"`
+2. Click **Check now** on that row → the `TopicCheckStatus` chip shows "Checking…" within a tick, and `next_check_at` returns to a normal interval.
+3. Pause a topic → confirm **Check now** is not offered on that row.
+4. Select two topics → **Check now** in the bulk bar → both are queued.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/topic-recheck
+gh pr create --base main \
+  --title "feat(topics): add a Check now action to retry without resetting" \
+  --body-file <path to a body file>
+```
+
+The title must start with `feat` — `.github/workflows/auto-release.yml` derives the semver bump from the PR title, and this is a user-visible addition (minor).
+
+---
+
+## Self-Review
+
+**Spec coverage**
+
+| Spec requirement | Task |
+|---|---|
+| `QueueRecheck` writes only `next_check_at`, ownership + paused in SQL | 1 |
+| Returns bool; false covers not-found/not-owned/paused | 1 |
+| `POST /topics/{id}/recheck`, 204/409/404 | 2 |
+| Extra `Get` only on the failing path | 2 |
+| No audit entry, no `topic_events` row | 2 (handler writes neither), 4 (documented) |
+| Row action hidden when paused | 3 |
+| Bulk entry via `mapWithConcurrency` | 3 |
+| Invalidate `QK.topics` | 3 |
+| No confirmation dialog, no bespoke progress UI | 3 (neither is added) |
+| i18n in `en` **and** `ru` | 3 |
+| Repo integration tests (5 listed cases) | 1 |
+| Handler tests (204/409/404/400) | 2 — plus a 500 case for the store error |
+| Frontend tests (visibility, click) | 3 |
+| Check-state token interaction documented | 1 (doc comment), 4 (CLAUDE.md) |
+
+**Placeholder scan:** none — every step carries runnable code or an exact command. The one bracketed item is the PR body path in Task 5 Step 3, which is genuinely author-supplied.
+
+**Type consistency:** `QueueRecheck(ctx, id, userID) (bool, error)` is identical in the repo (Task 1), the `topicStore` interface, the fake, and the handler call (Task 2). `onRecheck` is the field name in `TopicRowActions`, `BulkActionBarProps`, the test's `makeActions`, and both wiring sites (Task 3). i18n keys `topics.recheck` / `topics.bulk.recheck` match between definition and use.

--- a/docs/superpowers/specs/2026-08-02-topic-recheck-design.md
+++ b/docs/superpowers/specs/2026-08-02-topic-recheck-design.md
@@ -1,0 +1,188 @@
+# Topic recheck: retry a failing topic without destroying its state
+
+**Date:** 2026-08-02
+**Status:** approved design
+
+## Problem
+
+A topic that fails a check backs off exponentially, capped at six hours
+(`MARAUDER_CHECK_MAX_BACKOFF`). That is the right behaviour for a tracker that
+is down — it stops Marauder hammering it — but it is the wrong behaviour once
+the operator has *fixed* the cause.
+
+The concrete case, observed on 2026-08-01: RuTracker's origin was serving 520s,
+several checks failed, and the topic landed on a six-hour backoff. The
+credential was then repaired and the credential **Test** button confirmed login
+worked — but the topic kept showing
+
+> Login failed or the session expired — check this tracker's credentials
+
+for another three hours, because nothing re-ran the check. The stale error was
+also the *pre-fix* wording, so it actively contradicted the code that was
+running.
+
+There is no way to say "try again now". The only actions available are:
+
+| Action | Why it doesn't fit |
+|---|---|
+| Wait | Up to six hours, with a misleading error on screen the whole time |
+| **Reset** | Removes the already-delivered torrents from the client (optionally deleting their files) and clears delivery history. Enormously destructive for "just retry the check" |
+| Pause + Resume | Does not touch `next_check_at`, so the backoff survives |
+| Edit + Save | Does not touch `next_check_at` either |
+
+Diagnosing this required a hand-written `UPDATE topics SET next_check_at =
+now()`. A timestamp nudge should not require database access.
+
+## Goal
+
+One action — "Check now" — that queues a topic for its next scheduler tick,
+changing nothing else.
+
+Non-goals: checking paused topics, cancelling an in-flight check, any change to
+how backoff itself is computed.
+
+## Design
+
+### Repository
+
+```go
+// QueueRecheck brings a topic's next check forward to now, so the scheduler
+// picks it up on its next tick.
+//
+// Deliberately narrow: it writes next_check_at and nothing else. status and
+// last_error are the scheduler's to clear, and it does so on the next
+// successful check — leaving the old error visible until then is honest, since
+// it IS still the last thing that happened.
+//
+// last_checked_at is untouched for a second reason: see "Interaction with the
+// check-state token" below.
+//
+// Ownership is enforced by the statement rather than by caller discipline,
+// matching ResetCheckState. Paused topics are excluded because DueForCheck
+// ignores them, so writing next_check_at would silently do nothing.
+func (r *Topics) QueueRecheck(ctx context.Context, id, userID uuid.UUID) (bool, error)
+```
+
+```sql
+UPDATE topics
+SET    next_check_at = now()
+WHERE  id = $1 AND user_id = $2 AND status <> 'paused'
+```
+
+The `bool` is "a row was updated". False means *either* not-found/not-yours
+*or* paused; the handler distinguishes them.
+
+### Handler
+
+`POST /api/v1/topics/{id}/recheck`, shaped like the existing `setStatus`
+helper — parse the id, call the repo, return `204 No Content`.
+
+The zero-row path costs one extra `Get` to produce an honest status code:
+
+| Case | Response |
+|---|---|
+| Updated | `204 No Content` |
+| Topic is paused | `409 Conflict` — "topic is paused; resume it first" |
+| Not found / not the caller's | `404 Not Found` |
+
+A `404` for a paused topic would be a lie, and a `204` would be worse: the UI
+would report success for something the scheduler then ignores. The extra `Get`
+runs only on the rare failing path.
+
+No audit entry and no `topic_events` row.
+
+Worth being explicit, because the neighbouring handlers differ: `Reset` writes
+an audit entry (`topic_reset`) while `Pause` and `Resume` write none. Reset
+audits because it destroys state — it removes torrents from a client and can
+delete files, so "who did that, and when" is a question someone will eventually
+ask. Recheck destroys nothing; it moves a timestamp the scheduler rewrites on
+every tick anyway. It belongs with pause/resume.
+
+The check that follows emits `check.started` / `check.completed` /
+`check.failed` through the normal bus, which is a truer record of what happened
+than "a user pressed a button".
+
+### Frontend
+
+- `TopicRow` gains a `RefreshCw` action beside the existing `RotateCcw` reset,
+  **hidden when `status === "paused"`** — per the design decision above, a
+  control that cannot work should not be shown.
+- `BulkActionBar` gains a "Check now" entry, fanning out one request per
+  selected topic through `mapWithConcurrency(topics, RECHECK_CONCURRENCY, …)` —
+  the same bounded helper bulk reset uses (`RESET_CONCURRENCY`, 4), for the same
+  reason: an unbounded `Promise.all` over a large selection points the whole
+  burst at the backend at once. A named constant rather than a literal, matching
+  the reset precedent.
+- Both invalidate `QK.topics` on success.
+- No confirmation dialog. The action is cheap and reversible by doing nothing;
+  `DeleteConfirm`-style arming would be friction without a payoff.
+- No bespoke progress UI. `TopicCheckStatus` already renders a "Checking…"
+  chip driven by `check.*` SSE events, so the feedback path exists.
+- i18n: new keys in both `en` and `ru` dictionaries.
+
+### Interaction with the check-state token
+
+`next_check_at` is half of the optimistic-concurrency token — `(last_checked_at,
+next_check_at)` — that `RecordCheckResult`, `MarkEpisodeDownloaded` and
+`VerifyCheckState` guard on, and which exists so a Reset landing mid-check is
+not silently undone.
+
+Writing `next_check_at` therefore invalidates the token for any check already in
+flight, exactly as `ResetCheckState` does. That worker's result is dropped with
+`repo.ErrStaleCheckResult`, the scheduler logs it at Info, and the queued check
+runs fresh.
+
+This is accepted rather than engineered around:
+
+- It is the same window `Reset` already documents and accepts.
+- It is bounded — one check cycle.
+- It is self-correcting. The dropped write means `last_hash` keeps its old
+  value, so the fresh check may re-detect the same release and re-submit it;
+  `Deliveries.Record` is idempotent on `(topic_id, infohash)` and torrent
+  clients reject a duplicate infohash, so the outcome is a redundant add, not a
+  duplicate download.
+- Closing it properly needs claim-on-dispatch, which is the same open item the
+  Reset design already records.
+
+`QueueRecheck` not writing `last_checked_at` matters here: leaving it alone
+keeps the disruption to the token minimal and keeps "when was this last
+checked?" truthful, since the recheck has not checked anything yet.
+
+## Testing
+
+Repository (integration, `//go:build integration` — the existing harness, since
+the guard is in SQL and pgxmock only pins query text):
+
+- updates `next_check_at` to approximately now for an `active` topic
+- updates it for an `error` topic — the whole point of the feature
+- leaves a `paused` topic untouched and reports false
+- another user's topic is untouched and reports false
+- `status`, `last_error`, `last_error_code` and `last_checked_at` are unchanged
+
+Handler (unit, fake store):
+
+- `204` on success
+- `409` for a paused topic
+- `404` for an unknown or unowned topic
+- `400` for a malformed id
+
+Frontend (Vitest):
+
+- the row action is absent for a paused topic and present for `active`/`error`
+- clicking it POSTs to the right URL and invalidates the topics query
+- the bulk action issues one request per selected topic
+
+## Alternatives considered
+
+**A bulk endpoint** taking an id array. Rejected: every other bulk action in
+the product (pause, resume, delete, reset) fans out from the client, and one
+endpoint breaking that pattern buys nothing measurable at these sizes.
+
+**A "check once" flag the scheduler consumes**, which would let paused topics
+be checked without resuming. Rejected with the paused-topic decision — it adds
+scheduler state to serve a case we decided not to support.
+
+**Clearing `status` and `last_error` on recheck**, so the UI goes clean
+immediately. Rejected: it would claim the topic is healthy before anything has
+verified that. The error is still the last thing that happened until the next
+check says otherwise.

--- a/frontend/src/components/topics/BulkActionBar.tsx
+++ b/frontend/src/components/topics/BulkActionBar.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { Pause, Play, RotateCcw, Trash2, Check, X } from "lucide-react";
+import { Pause, Play, RefreshCw, RotateCcw, Trash2, Check, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useArmedConfirm } from "@/lib/hooks/useArmedConfirm";
@@ -9,6 +9,7 @@ export interface BulkActionBarProps {
   count: number;
   onPause: () => void;
   onResume: () => void;
+  onRecheck: () => void;
   onReset: () => void;
   onDelete: () => void;
   onClear: () => void;
@@ -18,6 +19,7 @@ export function BulkActionBar({
   count,
   onPause,
   onResume,
+  onRecheck,
   onReset,
   onDelete,
   onClear,
@@ -40,6 +42,10 @@ export function BulkActionBar({
         <Button variant="outline" size="sm" onClick={onResume}>
           <Play className="size-4" />
           {t("topics.bulk.resume")}
+        </Button>
+        <Button variant="outline" size="sm" onClick={onRecheck}>
+          <RefreshCw className="size-4" />
+          {t("topics.bulk.recheck")}
         </Button>
         <Button variant="outline" size="sm" onClick={onReset}>
           <RotateCcw className="size-4" />

--- a/frontend/src/components/topics/TopicRow.test.tsx
+++ b/frontend/src/components/topics/TopicRow.test.tsx
@@ -50,24 +50,49 @@ function renderRow(status: Topic["Status"], actions: TopicRowActions) {
   );
 }
 
+// The row's actions live behind an overflow menu, so every assertion about
+// them has to open it first.
+async function openActionsMenu() {
+  await userEvent.click(screen.getByRole("button", { name: /topic actions/i }));
+}
+
 describe("TopicRow check-now action", () => {
-  it("calls onRecheck when clicked", async () => {
+  it("calls onRecheck when chosen", async () => {
     const actions = makeActions();
     renderRow("error", actions);
 
-    await userEvent.click(screen.getByRole("button", { name: /check now/i }));
+    await openActionsMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: /check now/i }));
     expect(actions.onRecheck).toHaveBeenCalledTimes(1);
   });
 
-  it("is offered for an errored topic — the case the feature exists for", () => {
+  it("is offered for an errored topic — the case the feature exists for", async () => {
     renderRow("error", makeActions());
-    expect(screen.getByRole("button", { name: /check now/i })).toBeInTheDocument();
+    await openActionsMenu();
+    expect(await screen.findByRole("menuitem", { name: /check now/i })).toBeInTheDocument();
   });
 
-  // The scheduler skips paused topics entirely, so a Check now button on one
-  // would silently do nothing. Hiding it is the honest option.
-  it("is hidden for a paused topic", () => {
+  // The scheduler skips paused topics entirely, so a Check now entry on one
+  // would silently do nothing. Omitting it is the honest option.
+  it("is hidden for a paused topic", async () => {
     renderRow("paused", makeActions());
-    expect(screen.queryByRole("button", { name: /check now/i })).not.toBeInTheDocument();
+    await openActionsMenu();
+    // The menu is open — Reset proves it — but Check now is absent.
+    expect(await screen.findByRole("menuitem", { name: /reset/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /check now/i })).not.toBeInTheDocument();
+  });
+
+  // Delete stays two-step inside the menu: a written label removes the
+  // ambiguity of an icon, but it does not make the action less destructive.
+  it("requires a second confirm before deleting", async () => {
+    const actions = makeActions();
+    renderRow("active", actions);
+
+    await openActionsMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^delete$/i }));
+    expect(actions.onDelete).not.toHaveBeenCalled();
+
+    await userEvent.click(await screen.findByRole("menuitem", { name: /confirm delete/i }));
+    expect(actions.onDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/topics/TopicRow.test.tsx
+++ b/frontend/src/components/topics/TopicRow.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { TopicRow, type TopicRowActions, type TopicRowLookups } from "./TopicRow";
+import type { Topic } from "@/lib/api";
+
+const lookups: TopicRowLookups = {
+  clientById: new Map(),
+  defaultClient: null,
+  notifierById: new Map(),
+};
+
+function makeTopic(status: string): Topic {
+  return {
+    ID: "t1",
+    DisplayName: "Some Show",
+    URL: "https://rutracker.org/forum/viewtopic.php?t=1",
+    TrackerName: "rutracker",
+    Status: status,
+  } as unknown as Topic;
+}
+
+function makeActions(): TopicRowActions {
+  return {
+    onToggleSelect: vi.fn(),
+    onEdit: vi.fn(),
+    onRecheck: vi.fn(),
+    onReset: vi.fn(),
+    onDelete: vi.fn(),
+  };
+}
+
+function renderRow(status: string, actions: TopicRowActions) {
+  // TopicRow renders DeliveryStatus / TopicCheckStatus / TopicHistoryDisclosure,
+  // which call useQuery — a QueryClientProvider is required or the render throws.
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <TopicRow
+        topic={makeTopic(status)}
+        compact={false}
+        selected={false}
+        deletePending={false}
+        lookups={lookups}
+        actions={actions}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("TopicRow check-now action", () => {
+  it("calls onRecheck when clicked", async () => {
+    const actions = makeActions();
+    renderRow("error", actions);
+
+    await userEvent.click(screen.getByRole("button", { name: /check now/i }));
+    expect(actions.onRecheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("is offered for an errored topic — the case the feature exists for", () => {
+    renderRow("error", makeActions());
+    expect(screen.getByRole("button", { name: /check now/i })).toBeInTheDocument();
+  });
+
+  // The scheduler skips paused topics entirely, so a Check now button on one
+  // would silently do nothing. Hiding it is the honest option.
+  it("is hidden for a paused topic", () => {
+    renderRow("paused", makeActions());
+    expect(screen.queryByRole("button", { name: /check now/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/topics/TopicRow.test.tsx
+++ b/frontend/src/components/topics/TopicRow.test.tsx
@@ -12,7 +12,7 @@ const lookups: TopicRowLookups = {
   notifierById: new Map(),
 };
 
-function makeTopic(status: string): Topic {
+function makeTopic(status: Topic["Status"]): Topic {
   return {
     ID: "t1",
     DisplayName: "Some Show",
@@ -32,7 +32,7 @@ function makeActions(): TopicRowActions {
   };
 }
 
-function renderRow(status: string, actions: TopicRowActions) {
+function renderRow(status: Topic["Status"], actions: TopicRowActions) {
   // TopicRow renders DeliveryStatus / TopicCheckStatus / TopicHistoryDisclosure,
   // which call useQuery — a QueryClientProvider is required or the render throws.
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/components/topics/TopicRow.tsx
+++ b/frontend/src/components/topics/TopicRow.tsx
@@ -56,7 +56,6 @@ export function TopicRow({
   lookups,
   actions,
 }: TopicRowProps) {
-  const t = useT();
   return (
     <motion.div
       initial={{ opacity: 0 }}

--- a/frontend/src/components/topics/TopicRow.tsx
+++ b/frontend/src/components/topics/TopicRow.tsx
@@ -1,10 +1,11 @@
 import { motion } from "framer-motion";
-import { Pencil, RotateCcw } from "lucide-react";
+import { Pencil, RefreshCw, RotateCcw } from "lucide-react";
 
 import type { Topic } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn, formatRelative } from "@/lib/utils";
+import { useT } from "@/i18n";
 import { DeleteConfirm } from "@/components/shared/DeleteConfirm";
 import { PosterImage } from "@/components/topics/PosterImage";
 import { TopicUrl } from "@/components/topics/TopicUrl";
@@ -26,6 +27,7 @@ export interface TopicRowLookups {
 export interface TopicRowActions {
   onToggleSelect: () => void;
   onEdit: () => void;
+  onRecheck: () => void;
   onReset: () => void;
   onDelete: () => void;
 }
@@ -47,6 +49,7 @@ export function TopicRow({
   lookups,
   actions,
 }: TopicRowProps) {
+  const t = useT();
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -122,6 +125,17 @@ export function TopicRow({
         >
           <Pencil className="size-4" />
         </Button>
+        {topic.Status !== "paused" && (
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("topics.recheck")}
+            title={t("topics.recheck")}
+            onClick={actions.onRecheck}
+          >
+            <RefreshCw className="size-4" />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"

--- a/frontend/src/components/topics/TopicRow.tsx
+++ b/frontend/src/components/topics/TopicRow.tsx
@@ -85,7 +85,10 @@ export function TopicRow({
         {!compact && <TopicUrl url={topic.URL} />}
         <TopicError topic={topic} />
         {!compact && <DeliveryStatus topicId={topic.ID} />}
-        {!compact && <TopicCheckStatus topicId={topic.ID} />}
+        {/* Not gated by compact, unlike its siblings above: it's the only
+            feedback a "Check now" click produces (the tick that runs it is
+            up to a minute away), so compact-density users need it too. */}
+        <TopicCheckStatus topicId={topic.ID} />
         {!compact && <TopicHistoryDisclosure topicId={topic.ID} />}
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <Badge variant="default" className="shrink-0 font-mono">

--- a/frontend/src/components/topics/TopicRow.tsx
+++ b/frontend/src/components/topics/TopicRow.tsx
@@ -1,12 +1,19 @@
 import { motion } from "framer-motion";
-import { Pencil, RefreshCw, RotateCcw } from "lucide-react";
+import { Check, Loader2, MoreVertical, Pencil, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
 
 import type { Topic } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn, formatRelative } from "@/lib/utils";
 import { useT } from "@/i18n";
-import { DeleteConfirm } from "@/components/shared/DeleteConfirm";
+import { useArmedConfirm } from "@/lib/hooks/useArmedConfirm";
 import { PosterImage } from "@/components/topics/PosterImage";
 import { TopicUrl } from "@/components/topics/TopicUrl";
 import { TopicError } from "@/components/topics/TopicError";
@@ -119,40 +126,93 @@ export function TopicRow({
           </div>
         </div>
       )}
-      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="Edit topic"
-          onClick={() => actions.onEdit()}
-        >
-          <Pencil className="size-4" />
-        </Button>
-        {topic.Status !== "paused" && (
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label={t("topics.recheck")}
-            title={t("topics.recheck")}
-            onClick={actions.onRecheck}
-          >
-            <RefreshCw className="size-4" />
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="Reset topic"
-          onClick={actions.onReset}
-        >
-          <RotateCcw className="size-4" />
-        </Button>
-        <DeleteConfirm
-          onConfirm={() => actions.onDelete()}
-          isPending={deletePending}
-          label="Delete topic"
-        />
-      </div>
+      <TopicRowActionsMenu
+        status={topic.Status}
+        deletePending={deletePending}
+        actions={actions}
+      />
     </motion.div>
+  );
+}
+
+// TopicRowActionsMenu collapses the row's actions into a single overflow menu.
+//
+// They used to be four hover-revealed icon buttons. Adding "Check now" made the
+// cost obvious: the icons crowded the row's timestamps, only one carried a
+// tooltip, and two of them — RefreshCw for Check now and RotateCcw for Reset —
+// are near-identical circular arrows sitting side by side, one harmless and one
+// destructive. A menu gives every action a written label and costs one click
+// for actions nobody performs in bulk from a row.
+//
+// Delete keeps its two-click arming rather than firing straight from the menu:
+// the menu makes the label unambiguous, but it does not make the action less
+// destructive. Radix closes on select by default, so the arming item suppresses
+// that until the user resolves it.
+function TopicRowActionsMenu({
+  status,
+  deletePending,
+  actions,
+}: {
+  status: Topic["Status"];
+  deletePending: boolean;
+  actions: TopicRowActions;
+}) {
+  const t = useT();
+  const { armed, arm, disarm, confirmAndDisarm } = useArmedConfirm({ timeoutMs: 4000 });
+
+  return (
+    <DropdownMenu onOpenChange={(open) => !open && disarm()}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label={t("topics.actions.menu")}>
+          <MoreVertical className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={() => actions.onEdit()}>
+          <Pencil className="size-4" />
+          {t("topics.actions.edit")}
+        </DropdownMenuItem>
+        {/* The scheduler skips paused topics, so offering a check that can
+            never run would be a dead control. */}
+        {status !== "paused" && (
+          <DropdownMenuItem onSelect={() => actions.onRecheck()}>
+            <RefreshCw className="size-4" />
+            {t("topics.recheck")}
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem onSelect={() => actions.onReset()}>
+          <RotateCcw className="size-4" />
+          {t("topics.actions.reset")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {armed ? (
+          <DropdownMenuItem
+            destructive
+            onSelect={() => confirmAndDisarm(() => actions.onDelete())}
+          >
+            {deletePending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Check className="size-4" />
+            )}
+            {t("topics.actions.confirmDelete")}
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuItem
+            destructive
+            // Keep the menu open so the confirm step replaces this item in
+            // place, instead of the menu vanishing and the click doing nothing
+            // visible.
+            onSelect={(e) => {
+              e.preventDefault();
+              arm();
+            }}
+          >
+            <Trash2 className="size-4" />
+            {t("topics.actions.delete")}
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,66 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[10rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    destructive?: boolean;
+  }
+>(({ className, destructive, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      destructive && "text-destructive focus:bg-destructive/15 focus:text-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+};

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -245,6 +245,11 @@ const en: Record<string, string> = {
 
   // Row action: force an immediate check outside the topic's own schedule
   "topics.recheck": "Check now",
+  "topics.actions.menu": "Topic actions",
+  "topics.actions.edit": "Edit",
+  "topics.actions.reset": "Reset",
+  "topics.actions.delete": "Delete",
+  "topics.actions.confirmDelete": "Confirm delete",
 
   // Reset topic (discard deliveries/progress/error state, re-check from scratch)
   "topics.reset.title": "Reset {name}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -236,11 +236,15 @@ const en: Record<string, string> = {
   "topics.bulk.pause": "Pause",
   "topics.bulk.resume": "Resume",
   "topics.bulk.reset": "Reset",
+  "topics.bulk.recheck": "Check now",
   "topics.bulk.delete": "Delete",
   "topics.bulk.confirmDelete": "Delete {count}?",
   "topics.bulk.yes": "Yes",
   "topics.bulk.no": "No",
   "topics.bulk.clear": "Clear",
+
+  // Row action: force an immediate check outside the topic's own schedule
+  "topics.recheck": "Check now",
 
   // Reset topic (discard deliveries/progress/error state, re-check from scratch)
   "topics.reset.title": "Reset {name}",

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -247,6 +247,11 @@ const ru: Record<string, string> = {
 
   // Действие строки: немедленная проверка вне расписания темы
   "topics.recheck": "Проверить сейчас",
+  "topics.actions.menu": "Действия с темой",
+  "topics.actions.edit": "Изменить",
+  "topics.actions.reset": "Сбросить",
+  "topics.actions.delete": "Удалить",
+  "topics.actions.confirmDelete": "Подтвердить удаление",
 
   // Сброс темы (сброс доставок/прогресса/ошибок, повторная проверка с нуля)
   "topics.reset.title": "Сбросить «{name}»",

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -238,11 +238,15 @@ const ru: Record<string, string> = {
   "topics.bulk.pause": "Приостановить",
   "topics.bulk.resume": "Возобновить",
   "topics.bulk.reset": "Сбросить",
+  "topics.bulk.recheck": "Проверить сейчас",
   "topics.bulk.delete": "Удалить",
   "topics.bulk.confirmDelete": "Удалить тем: {count}?",
   "topics.bulk.yes": "Да",
   "topics.bulk.no": "Нет",
   "topics.bulk.clear": "Снять выбор",
+
+  // Действие строки: немедленная проверка вне расписания темы
+  "topics.recheck": "Проверить сейчас",
 
   // Сброс темы (сброс доставок/прогресса/ошибок, повторная проверка с нуля)
   "topics.reset.title": "Сбросить «{name}»",

--- a/frontend/src/lib/events-stream.ts
+++ b/frontend/src/lib/events-stream.ts
@@ -44,11 +44,18 @@ export function applyEvent(qc: QueryClient, ev: WireEvent): void {
     case "check.started":
       if (topicId) useCheckStatus.getState().setChecking(topicId);
       return;
+    // A finished check moves last_checked_at (and, on failure, last_error), so
+    // the list has to refetch or the row keeps showing the previous check's
+    // "checked N min ago" indefinitely. Without this the Check now action looks
+    // like it did nothing: the work happens, the timestamp on screen does not
+    // move, and the user clicks again.
     case "check.completed":
       if (topicId) useCheckStatus.getState().setChecked(topicId, ev.data?.next_check_at as string | undefined);
+      qc.invalidateQueries({ queryKey: QK.topics });
       return;
     case "check.failed":
       if (topicId) useCheckStatus.getState().setFailed(topicId, ev.body);
+      qc.invalidateQueries({ queryKey: QK.topics });
       return;
     case "topic.reset":
       if (topicId) {

--- a/frontend/src/pages/Topics.test.tsx
+++ b/frontend/src/pages/Topics.test.tsx
@@ -673,16 +673,18 @@ describe("TopicsPage reset", () => {
     renderTopicsPage();
     await screen.findByText("Alpha");
 
-    // Two fixture topics, two reset buttons. Exercise both indices so this
+    // Two fixture topics, two overflow menus. Exercise both indices so this
     // proves each row's action closes over its own topic — clicking index 0
     // and only ever checking "Reset Alpha" would pass identically if every
-    // row's button were (incorrectly) bound to topics[0].
-    const resetButtons = screen.getAllByRole("button", { name: /reset topic/i });
+    // row's action were (incorrectly) bound to topics[0].
+    const menus = screen.getAllByRole("button", { name: /topic actions/i });
 
-    await userEvent.click(resetButtons[0]);
+    await userEvent.click(menus[0]);
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^reset$/i }));
     expect(await screen.findByText(/Reset Alpha/)).toBeInTheDocument();
 
-    await userEvent.click(resetButtons[1]);
+    await userEvent.click(menus[1]);
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^reset$/i }));
     expect(await screen.findByText(/Reset Beta/)).toBeInTheDocument();
   });
 
@@ -721,16 +723,16 @@ describe("TopicsPage recheck", () => {
     renderTopicsPage();
     await screen.findByText("Alpha");
 
-    // Two fixture topics, two row "Check now" buttons. Click the SECOND one —
-    // clicking index 0 would pass identically if every row's action were
-    // (incorrectly) bound to topics[0], e.g. a `/reset` typo that fell
-    // through to the always-first topic. A typo landing on `/reset` instead
-    // of `/recheck` would decode an empty body into defaults and remove the
-    // topic's delivered torrents from the client — exactly what this
-    // non-destructive action exists to avoid.
-    const checkButtons = screen.getAllByRole("button", { name: /check now/i });
-    expect(checkButtons).toHaveLength(2);
-    await userEvent.click(checkButtons[1]);
+    // Two fixture topics, two overflow menus. Open the SECOND one — driving
+    // index 0 would pass identically if every row's action were (incorrectly)
+    // bound to topics[0]. That matters here beyond tidiness: a typo landing on
+    // `/reset` instead of `/recheck` would decode an empty body into defaults
+    // and remove the topic's delivered torrents from the client — exactly what
+    // this non-destructive action exists to avoid.
+    const menus = screen.getAllByRole("button", { name: /topic actions/i });
+    expect(menus).toHaveLength(2);
+    await userEvent.click(menus[1]);
+    await userEvent.click(await screen.findByRole("menuitem", { name: /check now/i }));
 
     await waitFor(() => expect(mockApi.post).toHaveBeenCalledWith("/topics/t2/recheck"));
     expect(mockApi.post).not.toHaveBeenCalledWith("/topics/t1/recheck");
@@ -742,10 +744,10 @@ describe("TopicsPage recheck", () => {
     await screen.findByText("Alpha");
 
     await userEvent.click(screen.getByLabelText("Select all"));
-    // The bulk bar's "Check now" button shares its accessible name with each
-    // row's own recheck button, so scope the query to the bar — identified by
-    // its "N selected" label — the same way the reset test above scopes to
-    // the reset card.
+    // Scope to the bar — identified by its "N selected" label — the same way
+    // the reset test above scopes to the reset card. The rows' own Check now
+    // entries only exist while a menu is open, but scoping keeps this test
+    // honest about which control it is driving.
     const bar = (await screen.findByText(/2 selected/)).closest("div")!;
     await userEvent.click(within(bar).getByRole("button", { name: /check now/i }));
 

--- a/frontend/src/pages/Topics.test.tsx
+++ b/frontend/src/pages/Topics.test.tsx
@@ -704,3 +704,55 @@ describe("TopicsPage reset", () => {
     expect(mockApi.resetTopic.mock.calls.map((c: unknown[]) => c[0]).sort()).toEqual(["t1", "t2"]);
   });
 });
+
+describe("TopicsPage recheck", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.get.mockImplementation((path: string) => {
+      if (path === "/topics") return Promise.resolve({ topics: RESET_ROW_TOPICS });
+      if (path === "/clients") return Promise.resolve({ clients: [] });
+      if (path === "/notifiers") return Promise.resolve({ notifiers: [] });
+      return Promise.resolve({});
+    });
+  });
+
+  it("posts to the clicked row's own recheck endpoint", async () => {
+    mockApi.post.mockResolvedValue({});
+    renderTopicsPage();
+    await screen.findByText("Alpha");
+
+    // Two fixture topics, two row "Check now" buttons. Click the SECOND one —
+    // clicking index 0 would pass identically if every row's action were
+    // (incorrectly) bound to topics[0], e.g. a `/reset` typo that fell
+    // through to the always-first topic. A typo landing on `/reset` instead
+    // of `/recheck` would decode an empty body into defaults and remove the
+    // topic's delivered torrents from the client — exactly what this
+    // non-destructive action exists to avoid.
+    const checkButtons = screen.getAllByRole("button", { name: /check now/i });
+    expect(checkButtons).toHaveLength(2);
+    await userEvent.click(checkButtons[1]);
+
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalledWith("/topics/t2/recheck"));
+    expect(mockApi.post).not.toHaveBeenCalledWith("/topics/t1/recheck");
+  });
+
+  it("issues one recheck request per selected topic from the bulk bar", async () => {
+    mockApi.post.mockResolvedValue({});
+    renderTopicsPage();
+    await screen.findByText("Alpha");
+
+    await userEvent.click(screen.getByLabelText("Select all"));
+    // The bulk bar's "Check now" button shares its accessible name with each
+    // row's own recheck button, so scope the query to the bar — identified by
+    // its "N selected" label — the same way the reset test above scopes to
+    // the reset card.
+    const bar = (await screen.findByText(/2 selected/)).closest("div")!;
+    await userEvent.click(within(bar).getByRole("button", { name: /check now/i }));
+
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalledTimes(2));
+    expect(mockApi.post.mock.calls.map((c: unknown[]) => c[0]).sort()).toEqual([
+      "/topics/t1/recheck",
+      "/topics/t2/recheck",
+    ]);
+  });
+});

--- a/frontend/src/pages/Topics.tsx
+++ b/frontend/src/pages/Topics.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { usePrefs } from "@/lib/prefs";
 import { QK } from "@/lib/queryKeys";
+import { mapWithConcurrency } from "@/lib/concurrency";
 import { AddTopicCard } from "@/components/topics/AddTopicCard";
 import { EditTopicCard } from "@/components/topics/EditTopicCard";
 import { ResetTopicCard } from "@/components/topics/ResetTopicCard";
@@ -71,6 +72,21 @@ export function TopicsPage() {
     mutationFn: (id: string) => api.post<void>(`/topics/${id}/resume`),
     onSuccess: () => qc.invalidateQueries({ queryKey: QK.topics }),
   });
+  const recheck = useMutation({
+    mutationFn: (id: string) => api.post<void>(`/topics/${id}/recheck`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: QK.topics }),
+  });
+
+  // Matches RESET_CONCURRENCY in ResetTopicCard — a bulk action should not
+  // fire one request per selected topic simultaneously.
+  const RECHECK_CONCURRENCY = 4;
+
+  const bulkRecheck = async (ids: string[]) => {
+    await mapWithConcurrency(ids, RECHECK_CONCURRENCY, (id) =>
+      api.post<void>(`/topics/${id}/recheck`).catch(() => undefined),
+    );
+    await qc.invalidateQueries({ queryKey: QK.topics });
+  };
 
   const topics = data?.topics ?? [];
   const allSelected = topics.length > 0 && selected.size === topics.length;
@@ -167,6 +183,7 @@ export function TopicsPage() {
           count={selected.size}
           onPause={() => bulk("pause")}
           onResume={() => bulk("resume")}
+          onRecheck={() => void bulkRecheck([...selected])}
           onReset={() => setResetting(topics.filter((t) => selected.has(t.ID)))}
           onDelete={() => bulk("delete")}
           onClear={() => setSelected(new Set())}
@@ -205,6 +222,7 @@ export function TopicsPage() {
                   actions={{
                     onToggleSelect: () => toggleOne(t.ID),
                     onEdit: () => setEditing(t),
+                    onRecheck: () => recheck.mutate(t.ID),
                     onReset: () => setResetting([t]),
                     onDelete: () => del.mutate(t.ID),
                   }}

--- a/frontend/src/pages/Topics.tsx
+++ b/frontend/src/pages/Topics.tsx
@@ -28,6 +28,10 @@ type TopicsList = { topics: Topic[] | null };
 type ClientsList = { clients: ClientRef[] | null };
 interface NotifiersList { notifiers: NotifierRef[] | null }
 
+// Matches RESET_CONCURRENCY in ResetTopicCard — a bulk action should not
+// fire one request per selected topic simultaneously.
+const RECHECK_CONCURRENCY = 4;
+
 export function TopicsPage() {
   const qc = useQueryClient();
   const { data, isLoading } = useQuery({
@@ -74,18 +78,29 @@ export function TopicsPage() {
   });
   const recheck = useMutation({
     mutationFn: (id: string) => api.post<void>(`/topics/${id}/recheck`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: QK.topics }),
+    onSuccess: (_data, id) => {
+      // Optimistic: the check is only *queued* here, the scheduler starts it
+      // within its next tick — but that's a 1-minute-default wait with no
+      // other visible feedback, so light the existing "Checking…" chip right
+      // away. If no check actually follows (e.g. the request raced a pause),
+      // useCheckStatus's own CHECKING_STALE_MS timer reverts it to idle.
+      useCheckStatus.getState().setChecking(id);
+      qc.invalidateQueries({ queryKey: QK.topics });
+    },
   });
 
-  // Matches RESET_CONCURRENCY in ResetTopicCard — a bulk action should not
-  // fire one request per selected topic simultaneously.
-  const RECHECK_CONCURRENCY = 4;
-
   const bulkRecheck = async (ids: string[]) => {
-    await mapWithConcurrency(ids, RECHECK_CONCURRENCY, (id) =>
-      api.post<void>(`/topics/${id}/recheck`).catch(() => undefined),
-    );
+    await mapWithConcurrency(ids, RECHECK_CONCURRENCY, async (id) => {
+      try {
+        await api.post<void>(`/topics/${id}/recheck`);
+        useCheckStatus.getState().setChecking(id);
+      } catch {
+        // Best-effort, matching the row action: one failed topic must not
+        // stop the rest of the bulk fan-out.
+      }
+    });
     await qc.invalidateQueries({ queryKey: QK.topics });
+    setSelected(new Set());
   };
 
   const topics = data?.topics ?? [];

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -7,8 +7,25 @@
 //    (vitest only auto-cleans when running with the jest-dom preset
 //    in some setups; explicit afterEach is the safe path).
 import "@testing-library/jest-dom/vitest";
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
+
+// 3. Radix primitives (the dropdown menu behind a topic row's actions) call
+//    Pointer Capture and scrollIntoView, neither of which jsdom implements.
+//    Without these stubs opening a menu throws "not a function" and every test
+//    that drives one fails for a reason unrelated to the code under test.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = vi.fn();
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = vi.fn();
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary

A topic that fails a check backs off exponentially, capped at six hours. That is right while a tracker is down and wrong the moment the operator fixes the cause — there was no way to say "try again now".

This adds **Check now**: one action that brings a topic's next scheduled check forward, changing nothing else.

It came out of a real incident on 2026-08-01. RuTracker's origin was serving 520s, several checks failed, the topic landed on a six-hour backoff. The credential was then repaired and the Test button confirmed login worked — but the topic kept showing a stale (and by then *reworded*) error for three more hours. Clearing it took a hand-written `UPDATE topics SET next_check_at = now()` against the database. A timestamp nudge should not require database access.

## Type of change

- [x] New feature (tracker / client / notifier plugin, UI page, etc.)

## What changed

| Layer | Change |
|---|---|
| Repo | `Topics.QueueRecheck` — `UPDATE topics SET next_check_at = now() WHERE id = $1 AND user_id = $2 AND status <> 'paused'` |
| API | `POST /api/v1/topics/{id}/recheck` → `204` / `409` paused / `404` unknown-or-not-yours / `400` malformed |
| UI | `RefreshCw` row action (hidden when paused) + a **Check now** entry in the bulk bar, fanned out through `mapWithConcurrency` |

Three deliberate narrownesses, each of which a reviewer will want to poke at:

- **It writes `next_check_at` and nothing else.** Not `status`, not `last_error`. The scheduler clears those on the next *successful* check; reporting the topic healthy before anything has verified that would be a lie. The old error stays on screen until the check that follows says otherwise.
- **Paused topics are excluded in the SQL**, because `DueForCheck` selects `status IN ('active','error')` — writing `next_check_at` for a paused topic would be a silent no-op. Hence `409` rather than a `204` promising a check that never runs, and hence the row action is hidden rather than disabled.
- **No audit entry and no `topic_events` row.** This matches Pause/Resume. `Reset` audits because it *destroys* state — it removes torrents from a client and can delete files; this moves a timestamp the scheduler rewrites every tick anyway.

## Test plan

- [x] `gofmt -l` silent, `go build ./...`, `go vet ./...`, `go test -race ./...` — all pass
- [x] `golangci-lint run` — **0 issues**
- [x] Repo behaviour covered by **integration tests against a real Postgres** (`//go:build integration`), not pgxmock — see reviewer notes
- [x] Handler tests over the full status matrix: 204 / 409 / 404 / 400 / 500
- [x] Frontend `tsc --noEmit` clean; **160 tests / 29 files** pass, including new `TopicRow.test.tsx` coverage for the paused case
- [x] Verified live against the dev stack:
  - topic parked 6h in the future → `POST /recheck` → `204`, `next_check_at` back to now
  - paused topic → `409` `"topic is paused; resume it first"`
  - unknown id → `404`
  - resume → topic returns to `active`

## Documentation

- [x] `CHANGELOG.md` under `[Unreleased]`
- [x] `CLAUDE.md` — scheduler section, beside the Topic reset paragraph
- [x] New exported method carries a doc comment explaining *why* it is narrow

## Reviewer notes

**The repo tests are integration-tagged on purpose.** This package's other tests use pgxmock, which pins SQL text but never executes it — so a mock cannot tell you whether `status <> 'paused'` actually excludes anything. The behaviour here *is* the WHERE clause, so it needs a real database. The five tests are written to fail if a guard is removed: one asserts the paused row is untouched, one that another user's topic is untouched, one that `status` / `last_error` / `last_hash` / `consecutive_errors` / `last_checked_at` are all unchanged.

**Known interaction, accepted rather than engineered around.** `next_check_at` is half of the `(last_checked_at, next_check_at)` optimistic-concurrency token that `RecordCheckResult` guards on. A recheck landing *during* an in-flight check therefore invalidates that worker's token and its result is dropped — exactly as `Reset` already does. It is bounded to one cycle and self-correcting: the dropped write leaves `last_hash` stale, so the fresh check may re-detect the same release, but `Deliveries.Record` is idempotent on `(topic_id, infohash)` and clients reject a duplicate infohash. Closing it properly needs claim-on-dispatch, which is the same open item the Reset design already records.

**`QueueRecheck` deliberately does not write `last_checked_at`** — partly because the recheck has not checked anything yet and claiming otherwise would be untrue, and partly to keep its disturbance of that token minimal.

Design and plan are checked in: `docs/superpowers/specs/2026-08-02-topic-recheck-design.md`, `docs/superpowers/plans/2026-08-02-topic-recheck.md`.

---

## Review rounds

Automated review found three issues in the outcome classification, each real. The first two were fixed; the third is knowingly accepted.

**1 · Non-atomic paused classification (fixed).** The handler inferred "paused" from "the UPDATE matched nothing", then confirmed with a separate `GetByID`. A resume landing between the two made it tell the user to resume an already-active topic.

**2 · Retry misclassified a concurrent pause (fixed, structurally).** My first patch added a retry, which then reported 404 if the topic was paused again in between. Patching branches only moved which interleaving lied, because the handler was combining three statements that each saw a different snapshot. Replaced with a single statement that reports existence and eligibility together — one snapshot cannot disagree with itself. The `GetByID` and the retry are both gone.

**3 · Stale status drove the update (fixed).** The first version of that statement tested `status <> 'paused'` inside a CTE, which freezes it at the statement snapshot, so a concurrent pause slipped through and returned 204. The predicate now sits in the UPDATE's **own** `WHERE`: under READ COMMITTED, Postgres re-evaluates that against the newest committed row after locking it. Same clause, different concurrency semantics depending on where it lives — worth knowing.

### Knowingly accepted

**Concurrent deletion reports 409 instead of 404.** If a topic is deleted between the statement's snapshot and the update, `Exists` is true and `Queued` is false, so the caller is told "paused" for a topic that is gone.

Real, and not worth more machinery: it requires deleting a topic in the same instant Check now is clicked on it, the only consequence is a wrong error *string* on a topic that no longer exists, and the list refetch corrects the view immediately. Existence and eligibility are two facts that can genuinely change independently, so no single-statement form removes the residue — only row locking or a serializable retry would, which is disproportionate for a message nit on a non-destructive action.

---

## Whole-branch review

A final review pass raised 4 Important and 7 Minor findings. Three (a 404-masking DB error on the fallback lookup, its missing ownership assertion, and a test that didn't bite) were **moot by the time it reported** — the atomic rewrite above had already deleted the `GetByID` fallback they concerned. The rest are addressed:

**Page-level wiring tests were missing** — the design promised them and only the row *prop* was covered. Both now exist in `Topics.test.tsx`, and the row test clicks the **second** row deliberately: clicking the first would pass identically if every row were bound to `topics[0]`. It asserts the exact path, because a `/reset` typo would have passed the entire previous suite — and `Reset` decodes an empty body into defaults, so that typo would have silently removed delivered torrents. Precisely the destructive outcome this feature exists to avoid.

**The action gave no visible feedback.** The design waived progress UI because `TopicCheckStatus` shows a "Checking…" chip — but that chip renders `null` until a `check.*` event arrives, the scheduler tick defaults to **1 minute**, and the chip was hidden in compact density. So in the exact scenario the feature was built for, the screen was byte-identical after the click and the stale error was still on it. A successful recheck now optimistically marks the topic as checking (the store's existing 90s staleness timer clears it if no check follows), and the chip renders in compact too.

**Also fixed:** bulk recheck now clears the selection like every other bulk action; the eligibility predicate mirrors `DueForCheck`'s `status IN ('active','error')` rather than the equivalent-today `status <> 'paused'`, so a future fourth status can't be queued here and ignored there; `RECHECK_CONCURRENCY` hoisted to module scope; test helper typed to the real `Topic["Status"]` union; a stale line count in `CLAUDE.md` corrected.

**Not changed:** `RefreshCw` sits next to `RotateCcw` and the two circular-arrow glyphs are similar. Their aria-labels differ and Reset is behind a confirm card, so changing Reset's established icon seemed worse than the residual risk.

Frontend suite is now **162 tests / 29 files**. Repo integration tests re-run against a real Postgres after the SQL change.
