### PR TITLE
ci: give the required backend and frontend checks static names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   # ---------------------------------------------------------------- backend
   backend:
-    name: Backend (Go ${{ matrix.go }})
+    name: Backend
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -221,7 +221,7 @@ jobs:
 
   # ---------------------------------------------------------------- frontend
   frontend:
-    name: Frontend (Node ${{ matrix.node }})
+    name: Frontend
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.25']
+    # Deliberately NOT a matrix. A job with a strategy.matrix has its matrix values appended to the
+    # check name by GitHub — `name: Backend` plus `go: ['1.25']` reports as "Backend (1.25)", not
+    # "Backend". This job is a required status check, so a name carrying the Go version deadlocks
+    # every pull request the moment the version moves. A single-valued matrix bought nothing.
+    env:
+      GO_VERSION: '1.25'
     defaults:
       run:
         working-directory: backend
@@ -42,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ env.GO_VERSION }}
           cache: true
           cache-dependency-path: backend/go.sum
 
@@ -223,10 +225,10 @@ jobs:
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['22']
+    # Not a matrix, for the same reason as `backend` above: a matrix would put the Node version back
+    # into the check name, and this job is a required status check.
+    env:
+      NODE_VERSION: '22'
     defaults:
       run:
         working-directory: frontend
@@ -237,7 +239,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 


### PR DESCRIPTION
## Summary

`Backend (Go ${{ matrix.go }})` and `Frontend (Node ${{ matrix.node }})` are both
**required status checks** on the default-branch ruleset, and both bake a matrix
value into the check name.

That is a latent deadlock. Bump the matrix to Go 1.26 or Node 24 and the required
context `Backend (Go 1.25)` is never produced again — GitHub waits forever for a
check that no longer exists, and every PR becomes unmergeable except by bypass. It
would surface as "CI is stuck" on an unrelated change, not as a settings problem.

Both matrices are single-valued (`go: ['1.25']`, `node: ['22']`), so the version in
the job title was already redundant with the matrix and the setup step that reads
it. Static names also match `quil` and `code-spire`, whose required contexts are
all static.

Found while aligning the branch rulesets across the three repositories onto one
standard.

## Related ruleset change

Applied alongside this, so the two stay consistent:

- Required contexts renamed to `Backend` / `Frontend`
- `Analyze (go)` / `Analyze (javascript-typescript)` **removed** as required
  contexts and replaced by the purpose-built `code_scanning` rule (CodeQL,
  `high_or_higher` security alerts, `errors`). Those names are matrix-derived too,
  so requiring them carried the same fragility this PR removes
- `Backend integration (Postgres)` added — it runs unconditionally on every PR and
  was the one real CI job not gated

## Test Plan

This PR is its own test: it renames the very checks the ruleset requires, so it can
only merge if the new contexts are produced and matched. A stale required context
would leave it permanently pending.
