### PR TITLE
ci: pin every GitHub Actions reference to a commit SHA

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main (full history + tags)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   # ---------------------------------------------------------------- backend
   backend:
-    name: Backend (Go ${{ matrix.go }})
+    name: Backend
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -221,7 +221,7 @@ jobs:
 
   # ---------------------------------------------------------------- frontend
   frontend:
-    name: Frontend (Node ${{ matrix.node }})
+    name: Frontend
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
         working-directory: backend
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -82,17 +82,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
           cache: true
           cache-dependency-path: backend/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Pinned for reproducible CI (the action's `latest` drifts the rule
           # set). v2.12.2 is built with Go 1.25 to match the toolchain; the
@@ -135,10 +135,10 @@ jobs:
           --health-retries 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
           cache: true
@@ -175,10 +175,10 @@ jobs:
         working-directory: cfsolver
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # cfsolver's go.mod requires Go 1.26 (chromedp v0.15.x pulls in
           # go-json-experiment, which needs 1.26). Keep in sync with
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run release-helpers tests
         run: bash .github/scripts/release-helpers_test.sh
@@ -234,10 +234,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.25']
+    # Deliberately NOT a matrix. A job with a strategy.matrix has its matrix values appended to the
+    # check name by GitHub — `name: Backend` plus `go: ['1.25']` reports as "Backend (1.25)", not
+    # "Backend". This job is a required status check, so a name carrying the Go version deadlocks
+    # every pull request the moment the version moves. A single-valued matrix bought nothing.
+    env:
+      GO_VERSION: '1.25'
     defaults:
       run:
         working-directory: backend
@@ -42,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ env.GO_VERSION }}
           cache: true
           cache-dependency-path: backend/go.sum
 
@@ -223,10 +225,10 @@ jobs:
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['22']
+    # Not a matrix, for the same reason as `backend` above: a matrix would put the Node version back
+    # into the check name, and this job is a required status check.
+    env:
+      NODE_VERSION: '22'
     defaults:
       run:
         working-directory: frontend
@@ -237,7 +239,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/client-acceptance.yml
+++ b/.github/workflows/client-acceptance.yml
@@ -34,7 +34,7 @@ jobs:
         client: [qbittorrent, transmission, deluge, utorrent]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Authenticated pulls get a per-account quota instead of the anonymous
       # per-IP pool shared by all GitHub-hosted runners, which rate-limited an
       # entire nightly run (issues #119-#121). No-op until the secrets exist.
@@ -64,7 +64,7 @@ jobs:
         client: [qbittorrent, transmission, deluge]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Docker Hub login (higher pull quota)
         if: env.DOCKERHUB_TOKEN != ''
         run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,10 +32,10 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Set up Go (for autobuild)
         if: matrix.language == 'go'
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # autobuild compiles both modules; cfsolver/go.mod requires 1.26.
           go-version: '1.26'
@@ -54,9 +54,9 @@ jobs:
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
       - name: Approve (minor/patch)
         if: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,13 +38,13 @@ jobs:
             tag: marauder-cfsolver:ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.image.context }}
           push: false
@@ -58,7 +58,7 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.image.tag }}
           format: sarif
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy-${{ matrix.image.name }}.sarif
           category: trivy-${{ matrix.image.name }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Generate .env
         working-directory: deploy

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -22,8 +22,8 @@ jobs:
   lint-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.16.4
       - name: helm lint (both presets)
@@ -49,11 +49,11 @@ jobs:
   kustomize-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.16.4
-      - uses: azure/setup-kubectl@v5
+      - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       - name: kustomize build (base + overlays)
         run: |
           for o in base overlays/simple-db overlays/cnpg; do
@@ -65,12 +65,12 @@ jobs:
   install-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.16.4
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       - name: helm install (simple tier)
         run: |
           helm install marauder deploy/helm/marauder -n marauder --create-namespace \

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -49,13 +49,13 @@ jobs:
             kind: go-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build image natively
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.image.context }}
           push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,16 +55,16 @@ jobs:
             binpath: /usr/local/bin/cfsolver
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/marauder-${{ matrix.image.name }}
           tags: |
@@ -87,7 +87,7 @@ jobs:
 
       - name: Build and push
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.image.context }}
           push: true
@@ -157,7 +157,7 @@ jobs:
           [ "$fail" -eq 0 ]
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Sign image with cosign (keyless)
         env:
@@ -165,7 +165,7 @@ jobs:
         run: cosign sign --yes "$IMG"
 
       - name: Generate SBOM (CycloneDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.OWNER }}/marauder-${{ matrix.image.name }}@${{ steps.push.outputs.digest }}
           format: cyclonedx-json
@@ -173,7 +173,7 @@ jobs:
           output-file: sbom-${{ matrix.image.name }}.cdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ matrix.image.name }}
           path: sbom-${{ matrix.image.name }}.cdx.json
@@ -189,14 +189,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history + tags so the annotated tag object (carrying the PR
           # description from auto-release.yml) is available to read locally.
           fetch-depth: 0
 
       - name: Download SBOMs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: sboms
           pattern: sbom-*
@@ -255,7 +255,7 @@ jobs:
       # release. Keeping asset attachment out of the gating step makes the
       # release reliable and the downstream sync run every time.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
           name: Marauder ${{ steps.changelog.outputs.tag }}
@@ -298,7 +298,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout (tags)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -360,7 +360,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout main
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -44,10 +44,10 @@ jobs:
         working-directory: site
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
@@ -73,7 +73,7 @@ jobs:
           echo "all SEO assets present"
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/dist
 
@@ -87,4 +87,4 @@ jobs:
     steps:
       - name: Deploy to Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Brings marauder's supply-chain posture in line with `code-spire`, which pinned all of
its action references earlier today.

**Contains #144's two commits** as well, because both change `ci.yml` within a few
lines of each other. Merge #144 first and this diff collapses to the pinning commit
on its own; or merge this one and close #144 as superseded.

## What and why

All **56** `uses:` references across eleven workflows move from a moving major tag to
a full 40-character commit SHA.

A tag is mutable — whoever controls the action's repository can repoint `v7` at any
commit, and the next run executes it with that job's permissions. Here that includes
`packages: write` in `docker.yml` and `release.yml`, and `id-token: write` where
releases are signed with cosign: a repointed tag there could publish **and sign** an
image, and the signature would verify.

Two details that are easy to get wrong:

- **Each pin carries its version in a trailing comment.** Dependabot's
  `github-actions` ecosystem parses it; without it the pin is opaque and stops being
  updated, and an unmaintained pin is a *permanently unpatched action* — worse than a
  moving tag. That ecosystem is already configured in `.github/dependabot.yml`, which
  is what makes pinning safe here.
- **Tags were dereferenced through `repos/{owner}/{repo}/commits/{tag}`**, not read off
  the ref. These are annotated tags, so the ref points at the *tag object* and pinning
  that SHA fails at runtime.

## Test Plan

Static checks, before pushing:

- `grep` for `uses: .*@v` across `.github/workflows/` returns **nothing**; 56 refs match a 40-hex SHA
- Diff is **56 insertions / 56 deletions**, and filtering it for any changed line that is not a `uses:` line returns empty
- All eleven workflows parse as YAML

Runtime: CI on this PR resolves and runs the pinned actions.

> **Correction.** This PR was originally opened against `ci/static-required-check-names`
> rather than `main`, and the first run therefore proved much less than claimed:
> `ci.yml` and `codeql.yml` both carry `pull_request: branches: [main]`, so on a PR
> targeting any other branch they do not run at all. Only `helm.yml` executed,
> exercising 4 of the 22 pinned actions (`checkout`, `setup-helm`, `setup-kubectl`,
> `kind-action`). Retargeted to `main` so the backend, frontend, cfsolver, release-script
> and CodeQL jobs actually run against the pins.

## Not included

`.github/dependabot.yml` has no `cooldown` blocks — the complementary half of this
defence, which `code-spire` gained in the same pass. Kept out to hold this PR to one
concern.

`postgres:17-alpine` in `ci.yml` remains an unpinned service-container image. Same
class of mutable reference, different mechanism: Semgrep's action-tag rule inspects
`uses:` and not `image:`, which is exactly how code-spire's own scanner container
survived its sweep unpinned.
