### PR TITLE
fix: stop check backoff overflowing into permanent retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A topic that keeps failing is no longer re-checked every tick forever.**
+  Exponential backoff computed the delay as
+  `time.Duration(float64(base) * math.Pow(2, attempt))`, which overflows an
+  int64 once a topic has failed enough times — 27 consecutive errors at a
+  60s check interval, 23 at 15 minutes. An out-of-range float-to-Duration
+  conversion is undefined in Go and saturates to the minimum int64, so the
+  delay came out *negative*: it passed the "cap at 6h" clamp untouched
+  (a negative value is not greater than the cap) and set the next check
+  roughly 292 years in the past. The topic was then due on every scheduler
+  tick, so backoff silently inverted into hammering the tracker and the
+  torrent client once a minute, indefinitely. Seen on a topic with 651
+  consecutive errors holding `next_check_at = 1734-05-07`. The delay is now
+  computed with integer math that cannot overflow, and the cap is the
+  starting value rather than a clamp applied afterwards.
+
 ## [1.19.3] - 2026-08-15
 
 ### Fixed

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"regexp"
 	"strings"
@@ -1036,10 +1035,24 @@ func (s *Scheduler) backoff(t *domain.Topic, failure bool, cause error) time.Tim
 	}
 	attempt := t.ConsecutiveErrors + 1
 	base := time.Duration(t.CheckIntervalSec) * time.Second
-	mult := math.Pow(2, float64(attempt))
-	d := time.Duration(float64(base) * mult)
-	if d > s.cfg.CheckMaxBackoff {
-		d = s.cfg.CheckMaxBackoff
+	// Integer math, with the cap as the starting value rather than a clamp
+	// applied afterwards. The previous form computed
+	// time.Duration(float64(base) * math.Pow(2, attempt)), which overflows
+	// int64 once the topic has failed enough times (27 consecutive errors at
+	// a 60s interval). An out-of-range float→Duration conversion is undefined
+	// in Go and saturates to INT64_MIN on amd64, so the result was *negative*
+	// — it passed the `d > CheckMaxBackoff` clamp untouched and scheduled the
+	// next check ~292 years in the past. DueForCheck selects on
+	// next_check_at <= now(), so the topic then came due on every single tick:
+	// exponential backoff inverted into permanent hammering of both the
+	// tracker and the torrent client. Measured 2026-08-16, a topic with 651
+	// consecutive errors held next_check_at = 1734-05-07 and re-checked once
+	// a minute indefinitely.
+	d := s.cfg.CheckMaxBackoff
+	if attempt >= 1 && attempt < 63 {
+		if mult := time.Duration(1) << uint(attempt); base <= s.cfg.CheckMaxBackoff/mult {
+			d = base * mult
+		}
 	}
 	return time.Now().UTC().Add(d)
 }

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -1427,6 +1427,41 @@ func TestBackoff_TableTest(t *testing.T) {
 			maxBackoff:        6*time.Hour + 50*time.Millisecond,
 			expectCapped:      true,
 		},
+		{
+			// Last error count whose 2^attempt scaling still fits in an int64
+			// Duration at a 60s interval. Guards the boundary from below so a
+			// future change to the cap or the exponent can't silently move it.
+			name:              "highest non-overflowing attempt stays capped",
+			consecutiveErrors: 26,
+			failure:           true,
+			minBackoff:        6 * time.Hour,
+			maxBackoff:        6*time.Hour + 50*time.Millisecond,
+			expectCapped:      true,
+		},
+		{
+			// One past that boundary, float64(base)*2^attempt exceeds int64.
+			// Converting an out-of-range float to a Duration is undefined in Go
+			// and saturates to INT64_MIN on amd64 — a *negative* backoff, which
+			// slips past the `d > CheckMaxBackoff` clamp and schedules the next
+			// check ~292 years in the past. DueForCheck then matches on every
+			// tick, so the topic is hammered once a minute forever. Measured
+			// 2026-08-16: a topic with 651 consecutive errors held
+			// next_check_at = 1734-05-07 and re-checked every 60s.
+			name:              "overflowing attempt stays capped, never negative",
+			consecutiveErrors: 27,
+			failure:           true,
+			minBackoff:        6 * time.Hour,
+			maxBackoff:        6*time.Hour + 50*time.Millisecond,
+			expectCapped:      true,
+		},
+		{
+			name:              "extreme failure count stays capped, never negative",
+			consecutiveErrors: 651,
+			failure:           true,
+			minBackoff:        6 * time.Hour,
+			maxBackoff:        6*time.Hour + 50*time.Millisecond,
+			expectCapped:      true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Exponential backoff computed the next-check delay with `time.Duration(float64(base) * math.Pow(2, attempt))`. Past enough consecutive failures the product exceeds int64 — **27 errors at a 60s check interval, 23 at 15 minutes**. An out-of-range float→Duration conversion is undefined in Go and saturates to `INT64_MIN` on amd64, so the delay came out **negative**.
- A negative delay is not greater than `CheckMaxBackoff`, so it slipped past the cap check untouched and set `next_check_at` ~292 years in the past. `DueForCheck` selects on `next_check_at <= now()`, so the topic came due on **every scheduler tick** — backoff inverted into hammering both the tracker and the torrent client once a minute, indefinitely.
- Delay is now computed with integer math that cannot overflow, and the cap is the starting value rather than a clamp applied afterwards, so an unrepresentable delay degrades *to* the cap instead of past it.

Found while diagnosing a topic that kept erroring after #151. #151 itself is working correctly — it classified the failure as `client` and left the tracker's domain alone. The reason the errors looked unchanged is this bug: one topic with 651 consecutive errors held `next_check_at = 1734-05-07` and re-checked every 60s, producing a continuous wall of identical error lines.

```
id       | consecutive_errors | next_check_at
ec9203ac |                651 | 1734-05-07 10:17:22.352779+00   <- overflowed
0a3bb7d0 |                 17 | 2026-08-16 15:05:37             <- correct, 6h cap
```

Note the two topics above sit either side of the threshold, which is what made this visible at all.

## Test plan

Boundary covered from both sides in `TestBackoff_TableTest` — the highest non-overflowing attempt count and the first one past it, plus the observed 651:

| consecutive_errors | before | after |
|---|---|---|
| 26 | 6h | 6h |
| 27 | **-2562047h47m16s** | 6h |
| 651 | **-2562047h47m16s** | 6h |

Verified the new cases fail before the fix and pass after:

```
--- FAIL: TestBackoff_TableTest/overflowing_attempt_stays_capped,_never_negative
    scheduler_test.go:1477: backoff = -2562047h47m16.854775608s, want >= 6h0m0s
--- FAIL: TestBackoff_TableTest/extreme_failure_count_stays_capped,_never_negative
    scheduler_test.go:1477: backoff = -2562047h47m16.854775008s, want >= 6h0m0s
```

Full backend suite after the fix:

```
gofmt: clean
go build ./... && go vet ./...   # clean
go test -race ./...              # no failures across all packages
```

Existing backoff expectations (success reset, transient fast-retry, the 2x/4x/8x/16x/32x ladder, `transientRetryMax` fallback, 6h cap at 20 errors) are unchanged.
