### PR TITLE
fix: guard backoff against a non-positive delay from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1388,7 +1388,7 @@ add LostFilm / RuTracker / Kinozal accounts.
   *"Use the full RPC URL ending in /transmission/rpc. Default
   Transmission Web UI port is 9091; some packages (e.g.
   transmission-daemon) use 8083 or 9091. Example:
-  http://192.168.2.65:8083/transmission/rpc"*. Same treatment for
+  http://192.168.1.10:8083/transmission/rpc"*. Same treatment for
   qBittorrent, Deluge, µTorrent, and the download-folder plugin.
 - **`docs/clients.md`** — new per-client setup guide. One section per
   supported client showing the exact URL format, default port,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A misconfigured backoff ceiling can no longer make a topic due on every
+  tick.** `MARAUDER_CHECK_MAX_BACKOFF` is read straight from the environment
+  and nothing validates it, so setting it to `0` — a plausible reading of "no
+  maximum" — or to a negative duration produced a zero-or-negative retry delay.
+  That puts `next_check_at` at or before `now()`, and since checks are selected
+  with `next_check_at <= now()` the topic came due on every tick: the same
+  unbounded retry against the tracker and the torrent client that the 1.19.4
+  overflow fix removed, reached through configuration instead of arithmetic.
+  A non-positive ceiling now falls back to the documented 6h default, and the
+  delay computation funnels through a single guard that substitutes a one-minute
+  retry for any non-positive result. A deliberately short `check_interval_sec`
+  is untouched — the guard corrects misconfiguration, it does not impose a
+  minimum poll rate.
+
 ## [1.19.4] - 2026-08-16
 
 ### Fixed

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -1023,38 +1023,79 @@ const transientRetryDelay = 60 * time.Second
 // that is genuinely down isn't hammered once a minute forever.
 const transientRetryMax = 5
 
+// defaultMaxBackoff is the ceiling used when the configured one is missing or
+// non-positive. It mirrors the envDefault on Config.CheckMaxBackoff.
+const defaultMaxBackoff = 6 * time.Hour
+
 // backoff computes the next_check_at timestamp. On success we use the topic's
 // configured interval. On a *transient* failure (network blip) we retry quickly
 // so it auto-recovers; on a durable failure we exponentially back off to the cap.
 func (s *Scheduler) backoff(t *domain.Topic, failure bool, cause error) time.Time {
+	return time.Now().UTC().Add(s.backoffDelay(t, failure, cause))
+}
+
+// backoffDelay is the delay half of backoff, split out so that the invariant
+// this computation must never break — the delay is always positive — is
+// enforced in one place and can be asserted directly, without comparing
+// timestamps taken either side of backoff's own clock read. Every return whose
+// value is computed from config or topic state funnels through floorDelay; the
+// transient path is exempt only because it returns a positive constant.
+func (s *Scheduler) backoffDelay(t *domain.Topic, failure bool, cause error) time.Duration {
+	base := time.Duration(t.CheckIntervalSec) * time.Second
 	if !failure {
-		return time.Now().UTC().Add(time.Duration(t.CheckIntervalSec) * time.Second)
+		return floorDelay(base)
 	}
 	if isTransientError(cause) && t.ConsecutiveErrors < transientRetryMax {
-		return time.Now().UTC().Add(transientRetryDelay)
+		return transientRetryDelay
 	}
+
+	// A non-positive ceiling would otherwise flow straight through as the
+	// delay, since the cap is this function's starting value. MARAUDER_CHECK_
+	// MAX_BACKOFF is env-driven and the config package validates nothing, and
+	// "0" is a plausible operator reading of "no maximum".
+	maxBackoff := s.cfg.CheckMaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+
 	attempt := t.ConsecutiveErrors + 1
-	base := time.Duration(t.CheckIntervalSec) * time.Second
 	// Integer math, with the cap as the starting value rather than a clamp
 	// applied afterwards. The previous form computed
 	// time.Duration(float64(base) * math.Pow(2, attempt)), which overflows
-	// int64 once the topic has failed enough times (27 consecutive errors at
-	// a 60s interval). An out-of-range float→Duration conversion is undefined
-	// in Go and saturates to INT64_MIN on amd64, so the result was *negative*
-	// — it passed the `d > CheckMaxBackoff` clamp untouched and scheduled the
-	// next check ~292 years in the past. DueForCheck selects on
-	// next_check_at <= now(), so the topic then came due on every single tick:
-	// exponential backoff inverted into permanent hammering of both the
-	// tracker and the torrent client. Measured 2026-08-16, a topic with 651
-	// consecutive errors held next_check_at = 1734-05-07 and re-checked once
-	// a minute indefinitely.
-	d := s.cfg.CheckMaxBackoff
+	// int64 once the topic has failed enough times — 27 consecutive errors at
+	// a 60s interval, 23 at the 900s default. An out-of-range float→Duration
+	// conversion is undefined in Go and saturates to INT64_MIN on amd64, so the
+	// result was *negative* — it passed the `d > CheckMaxBackoff` clamp
+	// untouched and scheduled the next check ~292 years in the past.
+	// DueForCheck selects on next_check_at <= now(), so the topic then came due
+	// on every single tick: exponential backoff inverted into permanent
+	// hammering of both the tracker and the torrent client. Measured
+	// 2026-08-16, a topic with 651 consecutive errors held
+	// next_check_at = 1734-05-07 and re-checked once a minute indefinitely.
+	d := maxBackoff
+	// The shift count must stay in [1,63): uint() of a negative attempt, and
+	// any attempt >= 64, both yield mult == 0 — which would make the division
+	// below panic rather than merely mis-scale.
 	if attempt >= 1 && attempt < 63 {
-		if mult := time.Duration(1) << uint(attempt); base <= s.cfg.CheckMaxBackoff/mult {
+		if mult := time.Duration(1) << uint(attempt); base <= maxBackoff/mult {
 			d = base * mult
 		}
 	}
-	return time.Now().UTC().Add(d)
+	return floorDelay(d)
+}
+
+// floorDelay substitutes a sane retry for a non-positive delay, which can only
+// arise from misconfiguration (a zero/negative check interval or backoff cap).
+// It deliberately does NOT raise small positive delays: any positive
+// check_interval_sec is accepted at topic creation, so a deliberately short
+// interval is a user's choice, not a defect. A zero or negative delay is a
+// defect — it makes DueForCheck match immediately and forever, which is the
+// failure this whole function exists to avoid.
+func floorDelay(d time.Duration) time.Duration {
+	if d <= 0 {
+		return transientRetryDelay
+	}
+	return d
 }
 
 // Error codes are stable, machine-readable classifications of a check

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -1330,6 +1330,7 @@ func TestBackoff_TableTest(t *testing.T) {
 	base := time.Duration(interval) * time.Second
 	tests := []struct {
 		name              string
+		intervalSec       int // zero uses the shared `interval` above
 		consecutiveErrors int
 		failure           bool
 		cause             error
@@ -1439,16 +1440,46 @@ func TestBackoff_TableTest(t *testing.T) {
 			expectCapped:      true,
 		},
 		{
-			// One past that boundary, float64(base)*2^attempt exceeds int64.
-			// Converting an out-of-range float to a Duration is undefined in Go
-			// and saturates to INT64_MIN on amd64 — a *negative* backoff, which
-			// slips past the `d > CheckMaxBackoff` clamp and schedules the next
-			// check ~292 years in the past. DueForCheck then matches on every
-			// tick, so the topic is hammered once a minute forever. Measured
-			// 2026-08-16: a topic with 651 consecutive errors held
-			// next_check_at = 1734-05-07 and re-checked every 60s.
+			// One past that boundary the old float path saturated to INT64_MIN,
+			// yielding a negative delay that slipped past the cap check. See
+			// backoff's comment for the full account.
 			name:              "overflowing attempt stays capped, never negative",
 			consecutiveErrors: 27,
+			failure:           true,
+			minBackoff:        6 * time.Hour,
+			maxBackoff:        6*time.Hour + 50*time.Millisecond,
+			expectCapped:      true,
+		},
+		{
+			// The overflow threshold moves with the interval, and 900s is the
+			// project's default (topics.defaultCheckIntervalSec), so this is
+			// the boundary real topics actually crossed: 23 errors, not 27.
+			// The rest of this table is pinned to 60s and would not have caught
+			// a regression that only reappears at the default interval.
+			name:              "overflowing attempt at the default 15-minute interval stays capped",
+			intervalSec:       900,
+			consecutiveErrors: 23,
+			failure:           true,
+			minBackoff:        6 * time.Hour,
+			maxBackoff:        6*time.Hour + 50*time.Millisecond,
+			expectCapped:      true,
+		},
+		{
+			// attempt == 63 is the first value the shift guard excludes, and
+			// the only one where 1<<attempt is negative (INT64_MIN) rather
+			// than zero. Pins the bound: widening it to `< 64` must fail here.
+			name:              "attempt at the shift guard boundary stays capped",
+			consecutiveErrors: 62,
+			failure:           true,
+			minBackoff:        6 * time.Hour,
+			maxBackoff:        6*time.Hour + 50*time.Millisecond,
+			expectCapped:      true,
+		},
+		{
+			// attempt == 64: 1<<attempt is zero, which is what would make the
+			// overflow guard's division panic if the bound were dropped.
+			name:              "attempt past the shift guard stays capped",
+			consecutiveErrors: 63,
 			failure:           true,
 			minBackoff:        6 * time.Hour,
 			maxBackoff:        6*time.Hour + 50*time.Millisecond,
@@ -1466,8 +1497,12 @@ func TestBackoff_TableTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			iv := tt.intervalSec
+			if iv == 0 {
+				iv = interval
+			}
 			topic := &domain.Topic{
-				CheckIntervalSec:  interval,
+				CheckIntervalSec:  iv,
 				ConsecutiveErrors: tt.consecutiveErrors,
 			}
 			before := time.Now().UTC()
@@ -1479,10 +1514,101 @@ func TestBackoff_TableTest(t *testing.T) {
 			if delta > tt.maxBackoff {
 				t.Errorf("backoff = %v, want <= %v", delta, tt.maxBackoff)
 			}
-			if tt.expectCapped && delta != 6*time.Hour && delta < 6*time.Hour {
-				t.Errorf("expected backoff to be capped at 6h, got %v", delta)
+			// Assert the cap comes from config rather than a hardcoded 6h, so
+			// changing the fixture's cap cannot silently void this check. The
+			// minBackoff assertion above already covers the lower side.
+			if tt.expectCapped && delta > cfg.CheckMaxBackoff+50*time.Millisecond {
+				t.Errorf("expected backoff capped at %v, got %v", cfg.CheckMaxBackoff, delta)
 			}
 		})
+	}
+}
+
+// TestBackoffDelay_NeverNonPositive pins the one invariant this computation
+// must never break: the delay is always positive. DueForCheck matches on
+// `next_check_at <= now()`, so a zero or negative delay reproduces exactly the
+// unbounded retry the exponential-overflow fix removed — reachable again
+// through configuration, since MARAUDER_CHECK_MAX_BACKOFF is env-driven and the
+// config package has no validation at all.
+//
+// This asserts against backoffDelay rather than backoff on purpose. Going
+// through backoff means comparing timestamps sampled either side of its own
+// time.Now() call, so a delay of exactly zero still yields a few hundred
+// nanoseconds of positive delta and would pass a strictly-future check while
+// being due immediately in practice.
+func TestBackoffDelay_NeverNonPositive(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxBackoff  time.Duration
+		intervalSec int
+		failure     bool
+	}{
+		{
+			// "0" is a plausible operator reading of "no maximum".
+			name:        "zero max backoff on failure",
+			maxBackoff:  0,
+			intervalSec: 900,
+			failure:     true,
+		},
+		{
+			name:        "negative max backoff on failure",
+			maxBackoff:  -1 * time.Hour,
+			intervalSec: 900,
+			failure:     true,
+		},
+		{
+			// Not reachable through the API today — topic create clamps a
+			// non-positive interval to the 900s default and no UPDATE writes
+			// the column — but backoff is the chokepoint for outbound request
+			// rate and should not depend on a clamp two packages away.
+			name:        "zero check interval on failure",
+			maxBackoff:  6 * time.Hour,
+			intervalSec: 0,
+			failure:     true,
+		},
+		{
+			name:        "zero check interval on success",
+			maxBackoff:  6 * time.Hour,
+			intervalSec: 0,
+			failure:     false,
+		},
+		{
+			name:        "negative check interval on success",
+			maxBackoff:  6 * time.Hour,
+			intervalSec: -60,
+			failure:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Scheduler{cfg: &config.Config{CheckMaxBackoff: tt.maxBackoff}}
+			topic := &domain.Topic{
+				CheckIntervalSec:  tt.intervalSec,
+				ConsecutiveErrors: 3,
+			}
+			if got := s.backoffDelay(topic, tt.failure, nil); got <= 0 {
+				t.Errorf("backoffDelay = %v, want > 0; a non-positive delay "+
+					"makes next_check_at <= now(), so the topic is due on "+
+					"every tick and hammers the tracker and torrent client",
+					got)
+			}
+		})
+	}
+}
+
+// TestBackoffDelay_ShortIntervalNotRaised guards the boundary of the rescue
+// above: floorDelay exists to correct misconfiguration, not to impose a minimum
+// poll rate. Topic creation accepts any positive check_interval_sec
+// (topics/create.go only clamps <= 0), so a deliberately short interval is a
+// user's choice and must pass through unchanged.
+func TestBackoffDelay_ShortIntervalNotRaised(t *testing.T) {
+	s := &Scheduler{cfg: &config.Config{CheckMaxBackoff: 6 * time.Hour}}
+	topic := &domain.Topic{CheckIntervalSec: 30}
+
+	if got := s.backoffDelay(topic, false, nil); got != 30*time.Second {
+		t.Errorf("backoffDelay = %v, want 30s; a user-chosen interval below "+
+			"the misconfiguration floor must not be silently raised", got)
 	}
 }
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -60,7 +60,7 @@ written to the audit log.
 
 | Field | Example |
 |---|---|
-| RPC URL | `http://192.168.2.65:8083/transmission/rpc` |
+| RPC URL | `http://192.168.1.10:8083/transmission/rpc` |
 | Username (optional) | (only if Transmission's RPC password is enabled) |
 | Password (optional) | |
 

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -378,7 +378,7 @@ function fieldsForPlugin(name: string): Field[] {
           label: "RPC URL",
           placeholder: "http://192.168.1.10:9091/transmission/rpc",
           helpText:
-            "Use the full RPC URL ending in /transmission/rpc. Default Transmission Web UI port is 9091; some packages (e.g. transmission-daemon) use 8083 or 9091. Example: http://192.168.2.65:8083/transmission/rpc",
+            "Use the full RPC URL ending in /transmission/rpc. Default Transmission Web UI port is 9091; some packages (e.g. transmission-daemon) use 8083 or 9091. Example: http://192.168.1.10:8083/transmission/rpc",
         },
         { key: "username", label: "Username (optional)" },
         { key: "password", label: "Password (optional)", password: true },


### PR DESCRIPTION
Follow-up to #152, addressing findings from `/code-review` (security-officer, code-reviewer, rules-compliance, qa) and Greptile.

## Summary

**The bug #152 fixed is reachable again through configuration.** That fix made `CheckMaxBackoff` the *starting* value of the delay rather than a clamp applied afterwards — which is the right shape — but it means a non-positive ceiling now flows straight through to `next_check_at`. `MARAUDER_CHECK_MAX_BACKOFF` is read from the environment and the config package has no validation at all (there is no `Validate()` in `config.go`), so:

- `MARAUDER_CHECK_MAX_BACKOFF=0` — a plausible operator reading of "no maximum" — or any negative duration yields a zero/negative delay.
- `next_check_at <= now()` is exactly what `DueForCheck` selects on, so the topic comes due on **every tick**: the same unbounded retry against the tracker and the user's torrent client that #152 removed, reached through configuration instead of arithmetic.
- A zero or negative `check_interval_sec` reaches the same state on the success path.

Fixed by falling back to the documented 6h default when the configured ceiling is non-positive, and by splitting the delay computation out of `backoff` so the invariant is enforced in one place.

**Why the split matters:** asserting through `backoff` means comparing timestamps taken either side of its own `time.Now()` call. At zero delay those differ only by the clock read itself (~200ns), so a strictly-future assertion **passes while the topic is due immediately** — I confirmed that empirically before changing the test. `backoffDelay` returns a `Duration`, so the invariant is asserted with no clock involved.

`floorDelay` deliberately rescues only non-positive delays. Topic creation accepts any positive `check_interval_sec` (`topics/create.go:104` clamps only `<= 0`), so a deliberately short interval is a user's choice and must not be silently raised to a minimum poll rate. `TestBackoffDelay_ShortIntervalNotRaised` pins that boundary from the other side.

## Test coverage from the review

- **The overflow threshold moves with the check interval**, and the table was pinned to 60s. **900s is the project default** (`topics.defaultCheckIntervalSec`), where the threshold is **23** consecutive errors rather than 27 — so the boundary real topics actually crossed had no coverage at all. The table gains an `intervalSec` field and a 900s case. *(Greptile P2, independently confirmed and sharpened by the qa agent.)*
- **`attempt == 63` and `64` now covered.** 63 is the only value where `1<<attempt` is negative (`INT64_MIN`) rather than zero; 64 is what would make the overflow guard's division **panic** if its bound were dropped. Both agents confirmed the `< 63` bound is load-bearing, not decorative — an `attempt` of 652 (i.e. the 651-error topic that surfaced this) gives `mult == 0` and would divide by zero without it.
- **`expectCapped` asserted nothing.** Every row that sets it also sets `minBackoff: 6h`, so the earlier check fires first with a better message, making the branch unreachable; it also hardcoded `6h` instead of reading the fixture's cap. It now checks the upper side against `cfg.CheckMaxBackoff`.
- The post-mortem narrative was duplicated verbatim across the code comment, the test comment and the changelog. Trimmed to one home (the code comment) plus a cross-reference.

## Also folded in

`192.168.2.65` — a real LAN host — was shipped as the Transmission example in `Clients.tsx`, `docs/clients.md` and a historical CHANGELOG entry, while every neighbouring example (including Transmission's own input `placeholder` two lines above the affected help string) uses `192.168.1.10`. Aligned; the `8083` port is kept since the non-default port is the point of that example.

## Test plan

New invariant cases confirmed RED before the fix:

```
--- FAIL: TestBackoffDelay_NeverNonPositive/zero_max_backoff_on_failure
    backoffDelay = 0s, want > 0
--- FAIL: TestBackoffDelay_NeverNonPositive/negative_max_backoff_on_failure
    backoffDelay = -1h0m0s, want > 0
--- FAIL: TestBackoffDelay_NeverNonPositive/zero_check_interval_on_failure
--- FAIL: TestBackoffDelay_NeverNonPositive/zero_check_interval_on_success
--- FAIL: TestBackoffDelay_NeverNonPositive/negative_check_interval_on_success
```

All green after, with the existing ladder unchanged (success reset, transient fast-retry, 2x/4x/8x/16x/32x, `transientRetryMax` fallback, 6h cap):

```
gofmt: clean
go build ./... && go vet ./...   # clean
go test -race ./...              # no failures across all packages
TestBackoff_TableTest            # 17/17 subtests pass
TestBackoffDelay_NeverNonPositive     # 5/5
TestBackoffDelay_ShortIntervalNotRaised  # pass
```

Frontend (`Clients.tsx` touched): `tsc --noEmit` clean, 172 tests across 31 files pass.

Review outcome: 0 critical, 0 rules violations, 0 Semgrep findings.
