### PR TITLE
chore(license): relicense from MIT to Apache-2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,9 +231,30 @@ We will not merge:
   cookie-based authentication and the existing Cloudflare interstitial
   handling (this is a personal-use automation tool, not a circumvention
   library).
-- Removal of the MIT license header from any file.
+- Removal or alteration of the copyright, licence, or attribution notices in
+  LICENSE, NOTICE, or THIRD-PARTY files.
 
 ---
+
+## Licensing of contributions
+
+Marauder is licensed under the [Apache License 2.0](LICENSE). By opening a pull
+request you agree that your contribution is licensed under the same terms —
+this is Apache-2.0 section 5, which applies by default to anything you
+deliberately submit for inclusion, unless you state otherwise in the PR.
+
+There is no CLA and no copyright assignment. You keep your copyright.
+
+Two consequences worth knowing, because they are easy to get wrong:
+
+- **Only contribute code you have the right to contribute.** Your own work, or
+  work under a licence compatible with Apache-2.0 — and if it is the latter,
+  say where it came from in the PR description so the attribution can be
+  carried into [`NOTICE`](NOTICE).
+- **The name is not covered by the licence.** Apache-2.0 grants rights over the
+  code and explicitly not over trade names or marks. If you are distributing a
+  modified build rather than contributing one, read [TRADEMARK.md](TRADEMARK.md)
+  — the short version is that forks are welcome and should carry their own name.
 
 ## Code style
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,3 @@
-Marauder is transitioning from the MIT License to the Apache License, Version
-2.0 ("Apache-2.0"). All new contributions are licensed under Apache-2.0.
-
-Contributions for which relicensing consent has been obtained are licensed
-under Apache-2.0. Contributions made by authors who originally licensed their
-work under the MIT License and who have not granted explicit permission to
-relicense remain licensed under the MIT License, the text of which is
-reproduced in MIT-LICENSE.txt.
-
-No rights beyond those granted by the applicable original license are conveyed
-for such contributions.
-
-Releases published before this change remain under the MIT License they
-shipped with.
-
----
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,219 @@
-MIT License
+Marauder is transitioning from the MIT License to the Apache License, Version
+2.0 ("Apache-2.0"). All new contributions are licensed under Apache-2.0.
 
-Copyright (c) 2026 Artjoms Stukans
+Contributions for which relicensing consent has been obtained are licensed
+under Apache-2.0. Contributions made by authors who originally licensed their
+work under the MIT License and who have not granted explicit permission to
+relicense remain licensed under the MIT License, the text of which is
+reproduced in MIT-LICENSE.txt.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+No rights beyond those granted by the applicable original license are conveyed
+for such contributions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Releases published before this change remain under the MIT License they
+shipped with.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+---
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Artjoms Stukans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -4,9 +4,35 @@ Copyright 2026 Artjoms Stukans
 This product includes software developed at
 https://github.com/artyomsv/marauder
 
-Licensed under the Apache License, Version 2.0. Some contributions remain under
-the MIT License pending relicensing consent from their authors; see LICENSE and
-MIT-LICENSE.txt.
+Licensed under the Apache License, Version 2.0 (the "License"). You may obtain
+a copy in the LICENSE file, or at http://www.apache.org/licenses/LICENSE-2.0
+
+--- Licensing transition -------------------------------------------------------
+
+Marauder is transitioning from the MIT License to the Apache License, Version
+2.0. All new contributions are licensed under Apache-2.0.
+
+Contributions for which relicensing consent has been obtained are licensed
+under Apache-2.0. Contributions made by authors who originally licensed their
+work under the MIT License and who have not granted explicit permission to
+relicense remain licensed under the MIT License, the text of which is
+reproduced in MIT-LICENSE.txt.
+
+No rights beyond those granted by the applicable original license are conveyed
+for such contributions.
+
+Releases published before August 2026 remain under the MIT License they
+shipped with.
+
+This statement lives here rather than in LICENSE deliberately. LICENSE is kept
+byte-identical to the canonical Apache-2.0 text, because GitHub's licence
+detector matches the whole file and any preamble drops it below the confidence
+threshold — which reports the project as "Other", and empties the
+org.opencontainers.image.licenses label on the published container images.
+NOTICE is also the file Apache-2.0 section 4(d) requires derivatives to carry,
+so the caveat travels further here than it would there.
+
+--- Trademarks -----------------------------------------------------------------
 
 "Marauder" and the Marauder mark are trademarks of Artjoms Stukans. The Apache
 License grants no rights to them; see TRADEMARK.md.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+Marauder
+Copyright 2026 Artjoms Stukans
+
+This product includes software developed at
+https://github.com/artyomsv/marauder
+
+Licensed under the Apache License, Version 2.0. Some contributions remain under
+the MIT License pending relicensing consent from their authors; see LICENSE and
+MIT-LICENSE.txt.
+
+"Marauder" and the Marauder mark are trademarks of Artjoms Stukans. The Apache
+License grants no rights to them; see TRADEMARK.md.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **A modern, self-hosted torrent topic monitor for the trackers the *arr stack can't reach.**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Release: v1.19.5](https://img.shields.io/badge/release-v1.19.5-success.svg)](CHANGELOG.md)
 
 [![CI](https://github.com/artyomsv/marauder/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/artyomsv/marauder/actions/workflows/ci.yml)
@@ -260,7 +260,7 @@ marauder/
 ├── deploy/             docker-compose files, .env.example, nginx configs
 ├── docs/               VISION / COMPETITORS / PRD / ROADMAP / guides
 ├── CHANGELOG.md        Keep a Changelog format
-├── LICENSE             MIT
+├── LICENSE             Apache-2.0
 └── README.md
 ```
 
@@ -284,7 +284,11 @@ For now:
 
 ## License & credits
 
-Marauder is released under the [MIT License](LICENSE).
+Marauder is released under the [Apache License 2.0](LICENSE).
+
+"Marauder" and the Marauder mark are trademarks of Artjoms Stukans. The licence
+covers the code, not the name — see [TRADEMARK.md](TRADEMARK.md) if you are
+distributing a modified build.
 
 Built inspired by [monitorrent](https://github.com/werwolfby/monitorrent) — the
 project that pioneered the forum-tracker monitoring niche. Marauder is an

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,76 @@
+# Marauder Trademark Policy
+
+"Marauder", the Marauder name, and the Marauder brand mark are trademarks of
+Artjoms Stukans.
+
+This policy is separate from the software licence, and deliberately so.
+Marauder's code is licensed under [Apache License 2.0](LICENSE), which grants
+broad rights to use, modify and redistribute it. **A software licence governs
+copying; it does not govern names.** Apache-2.0 says so explicitly in section 6:
+it grants no permission to use the licensor's trade names or product names. This
+file sets out what that means in practice, so nobody has to guess.
+
+The goal is narrow: a person who downloads something called Marauder should be
+able to tell whose Marauder it is. Nothing here is intended to discourage forks.
+
+## What you may do without asking
+
+- **Say what your software is built from.** "Based on Marauder", "a fork of
+  Marauder", "compatible with Marauder", "works with Marauder" — accurate,
+  descriptive statements are fine and always will be. This is nominative use and
+  no licence is needed for it.
+- **Keep the name while you contribute.** Branches, pull requests, forks kept
+  for the purpose of sending changes back upstream — use the name freely.
+- **Write about Marauder.** Articles, talks, reviews, tutorials, comparisons,
+  criticism. Use the name and the mark as needed to refer to the project.
+- **Run unmodified images and releases** under the name Marauder, including
+  self-hosting them for yourself or your organisation.
+- **Package it.** Distribution and chart maintainers may ship Marauder under its
+  own name, including with the patches packaging normally requires.
+
+## What needs a different name
+
+If you distribute a **modified** version to anyone else, give it your own name.
+
+Concretely, without written permission, please do not:
+
+- Name a modified distribution "Marauder", or a name likely to be confused with
+  it.
+- Publish container images or Helm charts under a name that implies they are the
+  official ones.
+- Use the Marauder brand mark or logo as the icon or brand of your distribution.
+- Use the name in a way that suggests the project endorses, maintains, or is
+  responsible for your version.
+- Register "Marauder", a confusingly similar name, or a domain built around one.
+
+Renaming is the expected outcome of a fork that diverges, not a penalty. It is
+also the thing that protects *you*: users of your build should be reporting its
+bugs to you, not to this repository.
+
+## Attribution, which is a separate ask
+
+Renaming does not remove the Apache-2.0 obligations in section 4. If you
+distribute a derivative work, you must retain the copyright, patent, trademark
+and attribution notices from the source, and carry the contents of
+[`NOTICE`](NOTICE) into your distribution.
+
+Beyond the licence, a request rather than a requirement: Marauder has a
+**Settings → About** screen. If your build keeps one, please leave a line saying
+it derives from Marauder, with a link to this repository. It costs one row and
+it is how the people using your build find out where the work came from.
+
+## Questions, and permission
+
+Uses this policy does not cover are not automatically forbidden — they are just
+not pre-approved. If you want to do something the list above does not allow,
+ask: open an issue, or contact the maintainer through the address in the repo
+metadata. Permission is often given.
+
+If you believe your use is nominative or otherwise permitted by law regardless
+of this policy, that argument is not waived by anything written here.
+
+## Scope
+
+This policy covers the trademarks only. It does not modify, restrict or add
+conditions to the Apache License 2.0, and nothing in it should be read as
+limiting the rights that licence grants over the code.

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -16,7 +16,7 @@ monitors have stalled.
 
 | Project | Focus | Covers forum trackers (RuTracker, LostFilm, NNM-Club)? | Actively maintained? | License | UI |
 |---|---|---|---|---|---|
-| **Marauder** *(this project)* | Forum-tracker monitoring + client delivery | ✅ Yes, first-class | ✅ | MIT | Modern React 19 |
+| **Marauder** *(this project)* | Forum-tracker monitoring + client delivery | ✅ Yes, first-class | ✅ | Apache-2.0 | Modern React 19 |
 | [Sonarr](https://sonarr.tv/) | TV show automation | ❌ Torznab only | ✅ | GPLv3 | Good |
 | [Radarr](https://radarr.video/) | Movie automation | ❌ Torznab only | ✅ | GPLv3 | Good |
 | [Lidarr](https://lidarr.audio/) | Music automation | ❌ Torznab only | ✅ | GPLv3 | Good |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -21,7 +21,7 @@ links to the user's torrent client(s). It is built with a Go backend, a React 19
 designed to be easy to extend.
 
 Public URL: **`https://marauder.cc`**
-License: **MIT**
+License: **Apache-2.0**
 Repository: **[artyomsv/marauder](https://github.com/artyomsv/marauder)**
 
 ---
@@ -840,7 +840,7 @@ Pipelines (all run on PR and on push to `main`):
 | Memory growth under 1 000+ topics | Medium | Medium | Nightly soak test in CI; pprof endpoint (gated) for diagnostics. |
 | User points Marauder at a tracker they don't have rights to use | N/A | Legal/ethical | README disclaimer; Marauder does not ship pre-configured URLs; behavior is user's responsibility. |
 | Supply chain: a Go dep is compromised | Low | High | `govulncheck` in CI; `go.sum` committed; no auto-updates to `main`; renovate bot in dry-run mode. |
-| Single-maintainer bus factor | Medium | High | MIT license, plugin-centric architecture, and first-class CONTRIBUTING guide lower the bar for others to take over. |
+| Single-maintainer bus factor | Medium | High | Apache-2.0 licence, plugin-centric architecture, and first-class CONTRIBUTING guide lower the bar for others to take over. |
 
 ---
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -260,7 +260,7 @@ function AboutCard() {
           </Row>
         )}
         <Row label={t("settings.about.license")}>
-          <span className="font-mono text-foreground">MIT</span>
+          <span className="font-mono text-foreground">Apache-2.0</span>
         </Row>
         <Row label={t("settings.about.links")}>
           <div className="flex flex-wrap gap-3 text-xs">

--- a/site/public/og/default.svg
+++ b/site/public/og/default.svg
@@ -43,16 +43,16 @@
     Auto-deliver to qBittorrent, Transmission, Deluge or a watch folder.
   </text>
   <g transform="translate(80, 555)">
-    <rect x="0" y="0" rx="20" ry="20" width="180" height="40" fill="none" stroke="#a855f7" stroke-width="2"/>
-    <text x="90" y="27" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" font-weight="600" fill="#a855f7">
-      Open Source · MIT
+    <rect x="0" y="0" rx="20" ry="20" width="215" height="40" fill="none" stroke="#a855f7" stroke-width="2"/>
+    <text x="108" y="27" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" font-weight="600" fill="#a855f7">
+      Open Source · Apache 2.0
     </text>
-    <rect x="200" y="0" rx="20" ry="20" width="160" height="40" fill="none" stroke="#06b6d4" stroke-width="2"/>
-    <text x="280" y="27" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" font-weight="600" fill="#06b6d4">
+    <rect x="235" y="0" rx="20" ry="20" width="160" height="40" fill="none" stroke="#06b6d4" stroke-width="2"/>
+    <text x="315" y="27" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" font-weight="600" fill="#06b6d4">
       13 Trackers
     </text>
-    <rect x="380" y="0" rx="20" ry="20" width="180" height="40" fill="none" stroke="#10b981" stroke-width="2"/>
-    <text x="470" y="27" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" font-weight="600" fill="#10b981">
+    <rect x="415" y="0" rx="20" ry="20" width="180" height="40" fill="none" stroke="#10b981" stroke-width="2"/>
+    <text x="505" y="27" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" font-weight="600" fill="#10b981">
       Go · React 19 · PG 18
     </text>
   </g>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -36,7 +36,7 @@ const sections = [
       { href: SITE.github, text: "GitHub", external: true },
       { href: SITE.github + "/issues", text: "Issues", external: true },
       { href: SITE.github + "/blob/main/CONTRIBUTING.md", text: "Contributing", external: true },
-      { href: SITE.github + "/blob/main/LICENSE", text: "MIT License", external: true },
+      { href: SITE.github + "/blob/main/LICENSE", text: "Apache 2.0 License", external: true },
       { href: "/legal", text: "Disclaimer" },
     ],
   },
@@ -79,7 +79,7 @@ const year = new Date().getFullYear();
         </span>
         <p class="text-xs text-muted-foreground">
           © {year} Marauder &middot; Released under the
-          <a href={SITE.github + "/blob/main/LICENSE"} class="underline hover:text-foreground" rel="noopener external">MIT License</a>
+          <a href={SITE.github + "/blob/main/LICENSE"} class="underline hover:text-foreground" rel="noopener external">Apache License 2.0</a>
         </p>
       </div>
       <p class="text-xs text-muted-foreground">

--- a/site/src/data/faq.ts
+++ b/site/src/data/faq.ts
@@ -37,7 +37,7 @@ export const homeFaq: FaqItem[] = [
   {
     question: "Is Marauder free?",
     answer:
-      "Yes. Marauder is open source under the MIT License. There is no paid tier, no hosted version, no telemetry. You self-host it on your own machine.",
+      "Yes. Marauder is open source under the Apache License 2.0. There is no paid tier, no hosted version, no telemetry. You self-host it on your own machine.",
   },
   {
     question: "How do I install it?",

--- a/site/src/data/seo.ts
+++ b/site/src/data/seo.ts
@@ -35,7 +35,7 @@ export const SITE = {
    *  except to correct drift. */
   software: {
     version: "1.19.5",
-    license: "MIT",
+    license: "Apache-2.0",
     operatingSystem: "Linux, Docker, macOS, Windows",
     applicationCategory: "Utility",
     runtime: "Self-hosted",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -107,7 +107,7 @@ open http://localhost:34080`;
     <div class="mx-auto max-w-6xl px-6 pt-20 pb-24 text-center sm:pt-28 sm:pb-32">
       <p class="mb-4 inline-flex items-center gap-2 rounded-full border border-warning/40 bg-warning/10 px-3 py-1 text-xs font-medium text-warning">
         <span class="size-1.5 rounded-full bg-warning animate-pulse"></span>
-        v{SITE.software.version} · MIT licensed · Self-hosted
+        v{SITE.software.version} · Apache 2.0 · Self-hosted
       </p>
       <h1 class="mx-auto max-w-3xl text-4xl font-bold tracking-tight text-foreground sm:text-6xl">
         Watch every torrent thread.
@@ -359,7 +359,7 @@ open http://localhost:34080`;
         Stop copy-pasting magnet links.
       </h2>
       <p class="relative mx-auto mt-3 max-w-xl text-muted-foreground">
-        Marauder is open source, MIT-licensed, and runs in a single docker compose stack.
+        Marauder is open source, Apache-2.0 licensed, and runs in a single docker compose stack.
         Try it tonight.
       </p>
       <div class="relative mt-8 flex flex-wrap items-center justify-center gap-3">

--- a/site/src/pages/legal.astro
+++ b/site/src/pages/legal.astro
@@ -50,7 +50,7 @@ const schemas = [
       Releases published before August 2026 were licensed under the MIT License
       and remain so. Some contributions are still licensed under MIT pending
       relicensing consent from their authors; the
-      <a href="https://github.com/artyomsv/marauder/blob/main/LICENSE" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">LICENSE</a>
+      <a href="https://github.com/artyomsv/marauder/blob/main/NOTICE" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">NOTICE</a>
       file says which.
     </p>
 
@@ -62,6 +62,12 @@ const schemas = [
       your software as "based on Marauder" or "compatible with Marauder" needs
       no permission at all. The full policy is in
       <a href="https://github.com/artyomsv/marauder/blob/main/TRADEMARK.md" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">TRADEMARK.md</a>.
+    </p>
+    <p class="mt-3 text-muted-foreground">
+      All other trademarks mentioned on this site (RuTracker, Kinozal, Sonarr,
+      Radarr, Prowlarr, qBittorrent, Transmission, Deluge, µTorrent,
+      Keycloak, etc.) belong to their respective owners. References are for
+      identification only and do not imply endorsement.
     </p>
 
     <h2 class="mt-10 text-2xl font-semibold tracking-tight">No warranty</h2>
@@ -89,12 +95,5 @@ const schemas = [
       only to administrators in the Marauder UI.
     </p>
 
-    <h2 class="mt-10 text-2xl font-semibold tracking-tight">Trademarks</h2>
-    <p class="text-muted-foreground">
-      All trademarks mentioned on this site (RuTracker, Kinozal, Sonarr,
-      Radarr, Prowlarr, qBittorrent, Transmission, Deluge, µTorrent,
-      Keycloak, etc.) belong to their respective owners. References are for
-      identification only and do not imply endorsement.
-    </p>
   </article>
 </Page>

--- a/site/src/pages/legal.astro
+++ b/site/src/pages/legal.astro
@@ -39,8 +39,29 @@ const schemas = [
     <h2 class="mt-10 text-2xl font-semibold tracking-tight">License</h2>
     <p class="text-muted-foreground">
       Marauder is released under the
-      <a href="https://github.com/artyomsv/marauder/blob/main/LICENSE" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">MIT License</a>.
-      You may use, modify, and redistribute it freely.
+      <a href="https://github.com/artyomsv/marauder/blob/main/LICENSE" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">Apache License 2.0</a>.
+      You may use, modify, and redistribute it freely, including commercially,
+      provided you retain the copyright, patent, trademark and attribution
+      notices, carry the
+      <a href="https://github.com/artyomsv/marauder/blob/main/NOTICE" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">NOTICE</a>
+      file, and state which files you changed.
+    </p>
+    <p class="mt-3 text-muted-foreground">
+      Releases published before August 2026 were licensed under the MIT License
+      and remain so. Some contributions are still licensed under MIT pending
+      relicensing consent from their authors; the
+      <a href="https://github.com/artyomsv/marauder/blob/main/LICENSE" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">LICENSE</a>
+      file says which.
+    </p>
+
+    <h2 class="mt-10 text-2xl font-semibold tracking-tight">Trademarks</h2>
+    <p class="text-muted-foreground">
+      "Marauder" and the Marauder mark are trademarks of Artjoms Stukans. The
+      Apache License covers the code and not the name — section 6 says so
+      explicitly. Forks are welcome and should carry their own name; describing
+      your software as "based on Marauder" or "compatible with Marauder" needs
+      no permission at all. The full policy is in
+      <a href="https://github.com/artyomsv/marauder/blob/main/TRADEMARK.md" rel="noopener external" class="text-foreground underline decoration-foreground/40 underline-offset-4 hover:decoration-foreground">TRADEMARK.md</a>.
     </p>
 
     <h2 class="mt-10 text-2xl font-semibold tracking-tight">No warranty</h2>

--- a/site/src/pages/ru.astro
+++ b/site/src/pages/ru.astro
@@ -59,7 +59,7 @@ const ruFaq = [
   {
     question: "Marauder бесплатный?",
     answer:
-      "Да. Marauder — открытый исходный код под лицензией MIT. Нет платных тарифов, нет облачной версии, нет телеметрии. Вы запускаете его на своём оборудовании.",
+      "Да. Marauder — открытый исходный код под лицензией Apache 2.0. Нет платных тарифов, нет облачной версии, нет телеметрии. Вы запускаете его на своём оборудовании.",
   },
 ];
 
@@ -89,7 +89,7 @@ open http://localhost:34080`;
     <div class="mx-auto max-w-6xl px-6 pt-20 pb-20 text-center sm:pt-28">
       <p class="mb-4 inline-flex items-center gap-2 rounded-full border border-warning/40 bg-warning/10 px-3 py-1 text-xs font-medium text-warning">
         <span class="size-1.5 rounded-full bg-warning animate-pulse"></span>
-        Open source · MIT · Self-hosted
+        Open source · Apache 2.0 · Self-hosted
       </p>
       <h1 class="mx-auto max-w-3xl text-4xl font-bold tracking-tight text-foreground sm:text-6xl">
         Следите за каждой торрент-темой.


### PR DESCRIPTION
Moves Marauder from MIT to the **Apache License 2.0**, mirroring the same change in `artyomsv/quil`.

## Why

Three things MIT is silent on:

- **A patent grant** from contributors, with termination for anyone who sues over one.
- **Change marking** — modified distributions must state which files they altered.
- **An explicit statement** that the licence covers the code and not the project's name.

Nothing about Marauder's openness changes. Apache-2.0 is OSI-approved and permissive; use, forking, modification and redistribution are unaffected.

## What's in it

| File | |
|---|---|
| `LICENSE` | Apache-2.0, prefaced by the transition statement below |
| `MIT-LICENSE.txt` | new — the MIT text, for the contributions still under it |
| `NOTICE` | new — what Apache §4(d) requires derivatives to carry |
| `TRADEMARK.md` | new — what the licence deliberately does not cover |
| `CONTRIBUTING.md` | new "Licensing of contributions" section: §5 inbound = outbound, no CLA, no assignment |

## On the contribution this does not yet cover

One outside contributor holds copyright in the tree and has been asked for consent. They are not required to answer.

Rather than block, `LICENSE` opens with a preamble stating that contributions whose authors have not granted permission **remain under MIT**, with the text reproduced in `MIT-LICENSE.txt`. This is the shape `modelcontextprotocol/go-sdk` uses for the same situation.

Merging now is deliberate: `CONTRIBUTING.md` binds new pull requests to Apache-2.0 from the moment it lands, so every day spent on MIT is another day contributions arrive under the licence being left behind. Nothing here asserts consent nobody gave. When consent lands, the preamble comes out and `LICENSE` becomes plain Apache-2.0.

## Every place the licence is stated, not just the config value

A `SITE.software.license` constant made most of these easy to miss, so this was swept by grepping for the *value*:

- **The app** — `Settings → About` shows the licence to every user. Now Apache-2.0.
- **The site, both languages** — `index.astro` ×2, `ru.astro` ×2, `faq.ts`, `Footer.astro` ×2, `legal.astro`.
- **The OG card** — `og/default.svg` had "Open Source · MIT" baked into a fixed-width pill. Widened from 180 to 215 and the two pills after it shifted, rather than truncating the text.
- **Docs** — `README.md` ×3, `docs/PRD.md` ×2, `docs/COMPETITORS.md`.
- `schemas.ts` builds its URL from `SITE.software.license`, so it now resolves to `opensource.org/licenses/Apache-2.0` on its own.

`docs/ROADMAP.md` still records "MIT license" in a checked-off M0 milestone. Left as-is deliberately — it is a historical record of what was created then, and rewriting it would claim Apache existed in that milestone.

The `CONTRIBUTING.md` rule against removing "the MIT license header from any file" described headers no file has ever carried; it now protects the notices that do exist.

The legal page also gains a **Trademarks** section, which it never had.

## Verification

- `LICENSE` is the canonical Apache-2.0 text from GitHub's licence API — 9 sections, patent grant and trademark clauses present.
- `site`: `npx astro check` → 0 errors, 0 warnings across 29 files.
- `frontend`: `tsc --noEmit` → exit 0.