### PR TITLE
chore(site): link every page from the footer, drop internal redirects

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,28 +1,40 @@
 ---
 import { SITE } from "@/data/seo";
+import { trackers } from "@/data/trackers";
+import { trackerPages } from "@/data/trackerPages";
+
+// The per-tracker pages are the site's highest-intent landing pages but are
+// reachable only from the /trackers/ hub and the homepage grid. Footer links
+// re-present them on every page so discovery does not depend on a crawler
+// following one specific card in one specific grid.
+const trackerLinks = trackerPages.map((p) => ({
+  href: `/trackers/${p.slug}/`,
+  text: trackers.find((t) => t.slug === p.slug)?.name ?? p.slug,
+}));
 
 const sections = [
   {
     title: "Product",
     links: [
-      { href: "/features", text: "Features" },
-      { href: "/trackers", text: "Trackers" },
-      { href: "/integrations", text: "Integrations" },
-      { href: "/install", text: "Install" },
+      { href: "/features/", text: "Features" },
+      { href: "/trackers/", text: "Trackers" },
+      { href: "/integrations/", text: "Integrations" },
+      { href: "/install/", text: "Install" },
     ],
   },
   {
     title: "Compare",
     links: [
-      { href: "/vs/sonarr", text: "vs Sonarr / Radarr" },
-      { href: "/vs/monitorrent", text: "vs monitorrent" },
-      { href: "/vs/flexget", text: "vs FlexGet" },
+      { href: "/vs/sonarr/", text: "vs Sonarr / Radarr" },
+      { href: "/vs/prowlarr/", text: "vs Prowlarr" },
+      { href: "/vs/monitorrent/", text: "vs monitorrent" },
+      { href: "/vs/flexget/", text: "vs FlexGet" },
     ],
   },
   {
     title: "Documentation",
     links: [
-      { href: "/docs", text: "Documentation" },
+      { href: "/docs/", text: "Documentation" },
       { href: SITE.github + "/blob/main/docs/PRD.md", text: "PRD", external: true },
       { href: SITE.github + "/blob/main/docs/plugin-development.md", text: "Plugin guide", external: true },
       { href: SITE.github + "/blob/main/docs/oidc.md", text: "Keycloak / OIDC", external: true },
@@ -37,8 +49,12 @@ const sections = [
       { href: SITE.github + "/issues", text: "Issues", external: true },
       { href: SITE.github + "/blob/main/CONTRIBUTING.md", text: "Contributing", external: true },
       { href: SITE.github + "/blob/main/LICENSE", text: "Apache 2.0 License", external: true },
-      { href: "/legal", text: "Disclaimer" },
+      { href: "/legal/", text: "Disclaimer" },
     ],
+  },
+  {
+    title: "Trackers",
+    links: trackerLinks,
   },
 ];
 
@@ -46,7 +62,7 @@ const year = new Date().getFullYear();
 ---
 <footer class="mt-32 border-t border-border/60 bg-background/40">
   <div class="mx-auto max-w-6xl px-6 py-14">
-    <div class="grid grid-cols-2 gap-10 md:grid-cols-4">
+    <div class="grid grid-cols-2 gap-10 md:grid-cols-3 lg:grid-cols-5">
       {sections.map((section) => (
         <nav aria-labelledby={`footer-${section.title.toLowerCase()}`}>
           <h2 id={`footer-${section.title.toLowerCase()}`} class="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -83,7 +99,7 @@ const year = new Date().getFullYear();
         </p>
       </div>
       <p class="text-xs text-muted-foreground">
-        <a href="/ru" class="underline hover:text-foreground">Русский</a> &middot;
+        <a href="/ru/" class="underline hover:text-foreground">Русский</a> &middot;
         Built with <a href="https://astro.build" class="underline hover:text-foreground" rel="noopener external">Astro</a> &middot; Hosted on GitHub Pages
       </p>
     </div>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -2,11 +2,11 @@
 import { SITE } from "@/data/seo";
 
 const nav = [
-  { href: "/features", label: "Features" },
-  { href: "/trackers", label: "Trackers" },
-  { href: "/integrations", label: "Integrations" },
-  { href: "/install", label: "Install" },
-  { href: "/docs", label: "Docs" },
+  { href: "/features/", label: "Features" },
+  { href: "/trackers/", label: "Trackers" },
+  { href: "/integrations/", label: "Integrations" },
+  { href: "/install/", label: "Install" },
+  { href: "/docs/", label: "Docs" },
 ];
 
 const current = Astro.url.pathname;
@@ -29,7 +29,7 @@ const current = Astro.url.pathname;
 
     <ul class="hidden md:flex items-center gap-1 text-sm">
       {nav.map((item) => {
-        const active = current === item.href || current.startsWith(item.href + "/");
+        const active = current.startsWith(item.href);
         return (
           <li>
             <a href={item.href}

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -42,7 +42,7 @@ const sitewideSchemas = [organizationSchema(), websiteSchema(), ...schemas];
           Marauder v1.0 is young: the core is validated end-to-end, but many
           tracker plugins are still alpha — structurally complete and unit-tested,
           not yet validated against live services. Expect rough edges.
-          <a href="/trackers" class="underline decoration-warning/50 underline-offset-4 hover:decoration-warning">See plugin status →</a>
+          <a href="/trackers/" class="underline decoration-warning/50 underline-offset-4 hover:decoration-warning">See plugin status →</a>
         </span>
       </div>
     </div>

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -19,8 +19,8 @@ const seo = {
     </p>
     <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
       <a href="/" class="btn-primary">Home</a>
-      <a href="/install" class="btn-outline">Install guide</a>
-      <a href="/docs" class="btn-outline">Documentation</a>
+      <a href="/install/" class="btn-outline">Install guide</a>
+      <a href="/docs/" class="btn-outline">Documentation</a>
     </div>
   </section>
 </Page>

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -225,11 +225,11 @@ const cmdLogin = `curl -sS -X POST http://localhost:34080/api/v1/auth/login \\
     <section class="mb-14" aria-labelledby="next">
       <h2 id="next" class="text-2xl font-semibold tracking-tight">Next steps</h2>
       <div class="mt-6 grid gap-4 sm:grid-cols-2">
-        <a href="/integrations" class="glass-card rounded-xl p-5 transition-colors hover:border-foreground/30">
+        <a href="/integrations/" class="glass-card rounded-xl p-5 transition-colors hover:border-foreground/30">
           <h3 class="font-semibold text-foreground">Configure a torrent client</h3>
           <p class="mt-1 text-sm text-muted-foreground">qBittorrent, Transmission, Deluge, µTorrent, or a watch folder.</p>
         </a>
-        <a href="/trackers" class="glass-card rounded-xl p-5 transition-colors hover:border-foreground/30">
+        <a href="/trackers/" class="glass-card rounded-xl p-5 transition-colors hover:border-foreground/30">
           <h3 class="font-semibold text-foreground">Add tracker credentials</h3>
           <p class="mt-1 text-sm text-muted-foreground">Configure logins for the 13 supported trackers.</p>
         </a>

--- a/site/src/pages/ru.astro
+++ b/site/src/pages/ru.astro
@@ -102,7 +102,7 @@ open http://localhost:34080`;
         ваш торрент-клиент.
       </p>
       <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
-        <a href="/install" class="btn-primary">
+        <a href="/install/" class="btn-primary">
           Установить за 5 минут
           <Icon name="arrow-right" size={16} />
         </a>
@@ -173,7 +173,7 @@ open http://localhost:34080`;
       ))}
     </div>
     <div class="mt-8 text-center">
-      <a href="/trackers" class="btn-outline">Все трекеры и их статус</a>
+      <a href="/trackers/" class="btn-outline">Все трекеры и их статус</a>
     </div>
   </section>
 
@@ -190,8 +190,8 @@ open http://localhost:34080`;
           ни Go, ни Node, ни Postgres ставить не надо.
         </p>
         <div class="mt-8 flex flex-wrap gap-3">
-          <a href="/install" class="btn-primary">Полная инструкция</a>
-          <a href="/integrations" class="btn-outline">Интеграции</a>
+          <a href="/install/" class="btn-primary">Полная инструкция</a>
+          <a href="/integrations/" class="btn-outline">Интеграции</a>
         </div>
       </div>
       <div class="glass-card rounded-xl overflow-hidden">

--- a/site/src/pages/trackers.astro
+++ b/site/src/pages/trackers.astro
@@ -101,7 +101,7 @@ const indexers = trackers.filter((t) => t.category === "indexer");
               <tr id={t.slug} class="hover:bg-muted/20">
                 <td class="px-4 py-3 font-mono text-foreground">
                   {trackerPageSlugs.includes(t.slug)
-                    ? <a href={`/trackers/${t.slug}`} class="underline decoration-foreground/30 underline-offset-4 hover:decoration-foreground">{t.name}</a>
+                    ? <a href={`/trackers/${t.slug}/`} class="underline decoration-foreground/30 underline-offset-4 hover:decoration-foreground">{t.name}</a>
                     : t.name}
                 </td>
                 <td class="px-4 py-3 text-muted-foreground">{t.region}</td>

--- a/site/src/pages/trackers/[slug].astro
+++ b/site/src/pages/trackers/[slug].astro
@@ -42,7 +42,7 @@ const schemas = [
       <ol class="flex items-center gap-2">
         <li><a href="/" class="hover:text-foreground">Marauder</a></li>
         <li aria-hidden="true">›</li>
-        <li><a href="/trackers" class="hover:text-foreground">Trackers</a></li>
+        <li><a href="/trackers/" class="hover:text-foreground">Trackers</a></li>
         <li aria-hidden="true">›</li>
         <li class="text-foreground">{tracker.name}</li>
       </ol>
@@ -90,8 +90,8 @@ const schemas = [
         ))}
       </ol>
       <div class="mt-6 flex flex-wrap gap-3">
-        <a href="/install" class="btn-primary">Install Marauder</a>
-        <a href="/trackers" class="btn-outline">All supported trackers</a>
+        <a href="/install/" class="btn-primary">Install Marauder</a>
+        <a href="/trackers/" class="btn-outline">All supported trackers</a>
       </div>
     </section>
 

--- a/site/src/pages/vs/flexget.astro
+++ b/site/src/pages/vs/flexget.astro
@@ -131,8 +131,8 @@ const matrix = [
       <h2 id="cta" class="text-2xl font-semibold tracking-tight">Want the forum-tracker job done without YAML?</h2>
       <p class="mt-3 text-muted-foreground">Paste a topic URL, pick a client, walk away.</p>
       <div class="mt-6 flex flex-wrap justify-center gap-3">
-        <a href="/install" class="btn-primary">Install in 5 minutes</a>
-        <a href="/vs/monitorrent" class="btn-outline">Coming from monitorrent?</a>
+        <a href="/install/" class="btn-primary">Install in 5 minutes</a>
+        <a href="/vs/monitorrent/" class="btn-outline">Coming from monitorrent?</a>
       </div>
     </section>
   </article>

--- a/site/src/pages/vs/monitorrent.astro
+++ b/site/src/pages/vs/monitorrent.astro
@@ -153,7 +153,7 @@ const matrix = [
       <p class="mt-4 text-xs text-muted-foreground">
         monitorrent details are from its public README and release history
         (latest release v1.4.0, July 2023). Marauder is in active development;
-        see the <a href="/trackers" class="underline decoration-foreground/40 underline-offset-4 hover:text-foreground">tracker status page</a> for which plugins are end-to-end validated versus alpha.
+        see the <a href="/trackers/" class="underline decoration-foreground/40 underline-offset-4 hover:text-foreground">tracker status page</a> for which plugins are end-to-end validated versus alpha.
       </p>
     </section>
 
@@ -164,7 +164,7 @@ const matrix = [
         databases — but moving over is mostly copy-paste:
       </p>
       <ol class="mt-4 space-y-2 text-muted-foreground">
-        <li>1. Stand up Marauder with <a href="/install" class="underline decoration-foreground/40 underline-offset-4 hover:text-foreground">one docker compose command</a>.</li>
+        <li>1. Stand up Marauder with <a href="/install/" class="underline decoration-foreground/40 underline-offset-4 hover:text-foreground">one docker compose command</a>.</li>
         <li>2. Add the same tracker accounts under <strong class="text-foreground">Credentials</strong>.</li>
         <li>3. Point Marauder at the same torrent client you already use.</li>
         <li>4. Re-add each topic URL you were watching in monitorrent. Marauder resolves the title and poster automatically.</li>
@@ -176,8 +176,8 @@ const matrix = [
       <h2 id="cta" class="text-2xl font-semibold tracking-tight">Give your monitorrent setup a 2026 rebuild</h2>
       <p class="mt-3 text-muted-foreground">Same trackers, same clients, modern stack. Runs in one docker compose file.</p>
       <div class="mt-6 flex flex-wrap justify-center gap-3">
-        <a href="/install" class="btn-primary">Install in 5 minutes</a>
-        <a href="/trackers" class="btn-outline">See supported trackers</a>
+        <a href="/install/" class="btn-primary">Install in 5 minutes</a>
+        <a href="/trackers/" class="btn-outline">See supported trackers</a>
       </div>
     </section>
   </article>


### PR DESCRIPTION
## Why

Search Console shows six of the site's sixteen URLs as **"unknown to Google"** — never discovered, never crawled — including `/vs/prowlarr/` and `/trackers/rutracker/`, the two pages written for the site's #1 and #2 queries (`prowlarr rutracker` / `rutracker prowlarr`, 231 lifetime impressions). It also reports internal links to only **8** pages, and lists 4 URLs as not-indexed with reason "Page with redirect".

All three symptoms trace to internal linking.

## What was wrong

**1. Every internal link 301-redirected.** `astro.config.mjs` sets `trailingSlash: "always"`, but the header nav, footer and several page bodies linked `/trackers`, `/install`, `/docs`. GitHub Pages 301s those to the slashed form, so each page shipped ~10 redirecting links — and the unslashed variants are the 4 "Page with redirect" duplicates.

**2. The trackers hub reached its own detail pages through a redirect.** `trackers.astro` built ``href={`/trackers/${t.slug}`}``. `/trackers/kinozal/`, linked in slashed form from the homepage grid, was discovered normally; `/trackers/rutracker/`, linked unslashed from the hub, has zero recorded internal links and is unknown to Google. The redirect hop is the only difference between them.

**3. `/vs/prowlarr/` and the four tracker detail pages were in no navigation at all** — not the header, not the footer. Nothing re-presented them when a crawl landed on any other page.

## Changes

- Normalise every internal `href` to the slashed form that `trailingSlash: "always"` canonicalises to (10 files).
- Fix the trackers hub's dynamic link to its detail pages.
- Add a **Trackers** footer column plus `/vs/prowlarr/` under Compare. The tracker links are generated from `trackerPages` + `trackers`, not hardcoded, so a new tracker page cannot silently orphan itself.
- Header active-state matching becomes a plain `startsWith`. The hrefs now end in `/`, so the previous `item.href + "/"` would double-slash and stop highlighting Trackers on its sub-pages.

No content, copy, canonical, `hreflang` or JSON-LD changes — those were already correct.

## Verification

`astro check` and `astro build` clean, 17 pages, sitemap 16 URLs. Against the built output:

```
non-slash internal hrefs in dist/  ->  none

inbound internal links per URL:
  /trackers/ 66 · /install/ 49 · /integrations/ 38 · /docs/ 35
  /features/ 34 · /vs/sonarr/ 19 · /vs/prowlarr/ 19 · /vs/monitorrent/ 19
  /trackers/rutracker/ 19 · /trackers/nnmclub/ 19 · /trackers/lostfilm/ 19
  /trackers/kinozal/ 19 · /vs/flexget/ 17 · /ru/ 17 · /legal/ 17
```

All 16 URLs now carry 17-66 inbound internal links, against the 8 pages Search Console previously saw.

## Notes

Titled `chore(site):` deliberately. This is a real fix, but `fix:` would trigger `auto-release` and cut a version — rebuilding and publishing container images for a marketing-site change. Merging redeploys marauder.cc via `site.yml`, which is the intent.

Success check: `/vs/prowlarr/` and `/trackers/rutracker/` move off "unknown to Google" in Search Console, and the 4 "Page with redirect" URLs drop out of the not-indexed report.