### PR TITLE
ci: separate registry failures from client regressions in canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,19 @@ jobs:
       - name: Run verify-arch tests
         run: bash .github/scripts/verify-arch_test.sh
 
+  acceptance-scripts:
+    name: Acceptance helper tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Pure text classifier, no Docker: it decides whether a failed nightly
+      # was the client or the registry, and a wrong answer either silences the
+      # canary or files issues against clients we never reached (#166-#168).
+      - name: Run acceptance lib tests
+        run: bash deploy/acceptance/lib_test.sh
+
   # ---------------------------------------------------------------- frontend
   frontend:
     name: Frontend

--- a/.github/workflows/client-acceptance.yml
+++ b/.github/workflows/client-acceptance.yml
@@ -27,7 +27,7 @@ jobs:
   pinned:
     name: pinned / ${{ matrix.client }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -37,24 +37,36 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Authenticated pulls get a per-account quota instead of the anonymous
       # per-IP pool shared by all GitHub-hosted runners, which rate-limited an
-      # entire nightly run (issues #119-#121). No-op until the secrets exist.
+      # entire nightly run (issues #119-#121). No-op until the secrets exist —
+      # which is why acceptance.sh also retries and reports EX_INFRA (75).
       - name: Docker Hub login (higher pull quota)
         if: env.DOCKERHUB_TOKEN != ''
         run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+      # A registry outage must not redden the baseline: this job also runs on
+      # release tags, and the pinned tags are immutable, so exit 75 says
+      # nothing about this client.
       - name: Acceptance (pinned baseline)
-        run: bash deploy/acceptance/acceptance.sh ${{ matrix.client }} pinned
+        run: |
+          set +e
+          bash deploy/acceptance/acceptance.sh ${{ matrix.client }} pinned
+          code=$?
+          set -e
+          if [ "$code" -eq 75 ]; then
+            echo "::warning::${{ matrix.client }} pinned baseline could not fetch its images (registry rate limit or outage) — not a client regression"
+            exit 0
+          fi
+          exit "$code"
 
   latest:
     name: latest-canary / ${{ matrix.client }}
     # Canary only — never gate releases, so skip on tag pushes. Requiring a
     # green pinned baseline keeps the canary honest: pinned tags are immutable,
-    # so a red baseline means broken infrastructure (registry rate limits,
-    # runner trouble), not an upstream release — filing issues would be noise.
-    # Sequencing after pinned also halves the concurrent pull burst.
+    # so a red baseline means a real break in the harness, not an upstream
+    # release. Sequencing after pinned also halves the concurrent pull burst.
     needs: pinned
     if: github.event_name != 'push' && needs.pinned.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
       issues: write
@@ -68,12 +80,29 @@ jobs:
       - name: Docker Hub login (higher pull quota)
         if: env.DOCKERHUB_TOKEN != ''
         run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+      # Three outcomes, not two. A green pinned baseline does NOT prove the
+      # registry stayed healthy for this job — the quota is time-based and hit
+      # only the canary legs on 2026-08-28, filing #166-#168 against three
+      # clients that were never contacted. Exit 75 means the images never
+      # arrived, so there is no upstream signal to report.
       - name: Acceptance (latest image)
         id: acc
-        continue-on-error: true
-        run: bash deploy/acceptance/acceptance.sh ${{ matrix.client }} latest
+        run: |
+          set +e
+          bash deploy/acceptance/acceptance.sh ${{ matrix.client }} latest
+          code=$?
+          set -e
+          case "$code" in
+            0)  echo "result=pass"  >> "$GITHUB_OUTPUT" ;;
+            75) echo "result=infra" >> "$GITHUB_OUTPUT" ;;
+            *)  echo "result=fail"  >> "$GITHUB_OUTPUT" ;;
+          esac
+      - name: Note registry failure (no issue filed)
+        if: steps.acc.outputs.result == 'infra'
+        run: |
+          echo "::warning::${{ matrix.client }} latest canary could not fetch its images (registry rate limit or outage) — the client was never contacted, so no canary issue was filed"
       - name: File deduped canary issue on failure
-        if: steps.acc.outcome == 'failure'
+        if: steps.acc.outputs.result == 'fail'
         env:
           GH_TOKEN: ${{ github.token }}
           CLIENT: ${{ matrix.client }}
@@ -92,10 +121,10 @@ jobs:
               --body "Still failing on the latest image. Run: ${RUN_URL}"
           else
             gh issue create --title "${TITLE}" --label client-canary --body \
-          "The acceptance test for \`${CLIENT}\` against its **latest** image failed while the pinned baseline is expected green. A new upstream release likely changed the client's API contract. Investigate and, if confirmed, adapt the plugin and bump the pinned baseline. Run: ${RUN_URL}"
+          "The acceptance test for \`${CLIENT}\` against its **latest** image failed while the pinned baseline is expected green. The stack came up and the client rejected the plugin handshake, so a new upstream release likely changed the client's API contract. Investigate and, if confirmed, adapt the plugin and bump the pinned baseline. Run: ${RUN_URL}"
           fi
       - name: Surface canary failure as a red (non-blocking) check
-        if: steps.acc.outcome == 'failure'
+        if: steps.acc.outputs.result == 'fail'
         run: |
           echo "::warning::${{ matrix.client }} latest canary failed — issue filed"
           exit 1

--- a/.github/workflows/client-acceptance.yml
+++ b/.github/workflows/client-acceptance.yml
@@ -35,10 +35,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Authenticated pulls get a per-account quota instead of the anonymous
-      # per-IP pool shared by all GitHub-hosted runners, which rate-limited an
-      # entire nightly run (issues #119-#121). No-op until the secrets exist —
-      # which is why acceptance.sh also retries and reports EX_INFRA (75).
+      # A hedge for the Docker Hub half of our pulls (postgres, nginx, and the
+      # golang/node/alpine build bases): an authenticated per-account quota
+      # instead of the per-IP pool shared by all GitHub-hosted runners. It is
+      # NOT what fixed the false canary issues — #166-#168 were lscr.io
+      # refusals, and Docker Hub served `db` and `gateway` in the same jobs
+      # seconds earlier. No-op until the secrets exist, which they never have;
+      # acceptance.sh retrying and reporting EX_INFRA (75) is the real defence.
       - name: Docker Hub login (higher pull quota)
         if: env.DOCKERHUB_TOKEN != ''
         run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
@@ -81,10 +84,10 @@ jobs:
         if: env.DOCKERHUB_TOKEN != ''
         run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
       # Three outcomes, not two. A green pinned baseline does NOT prove the
-      # registry stayed healthy for this job — the quota is time-based and hit
-      # only the canary legs on 2026-08-28, filing #166-#168 against three
-      # clients that were never contacted. Exit 75 means the images never
-      # arrived, so there is no upstream signal to report.
+      # registries stayed healthy for this job — quotas are time-based, and on
+      # 2026-08-28 lscr.io refused all three canary legs after the pinned legs
+      # had passed, filing #166-#168 against clients never contacted. Exit 75
+      # means the images never arrived, so there is no upstream signal at all.
       - name: Acceptance (latest image)
         id: acc
         run: |
@@ -121,7 +124,7 @@ jobs:
               --body "Still failing on the latest image. Run: ${RUN_URL}"
           else
             gh issue create --title "${TITLE}" --label client-canary --body \
-          "The acceptance test for \`${CLIENT}\` against its **latest** image failed while the pinned baseline is expected green. The stack came up and the client rejected the plugin handshake, so a new upstream release likely changed the client's API contract. Investigate and, if confirmed, adapt the plugin and bump the pinned baseline. Run: ${RUN_URL}"
+          "The acceptance test for \`${CLIENT}\` against its **latest** image failed while the pinned baseline is expected green. The images were fetched, the stack came up, and the client rejected the plugin handshake — so a new upstream release likely changed the client's API contract. Investigate and, if confirmed, adapt the plugin and bump the pinned baseline. Run: ${RUN_URL}"
           fi
       - name: Surface canary failure as a red (non-blocking) check
         if: steps.acc.outputs.result == 'fail'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The nightly client canary blamed torrent clients for Docker Hub outages**
+  (issues #166, #167, #168 — a repeat of #119-#121). On 2026-08-28 all three
+  `latest` acceptance legs died on `toomanyrequests` from the anonymous Docker
+  Hub quota that every GitHub-hosted runner shares, before a single container
+  started. Three issues were filed saying *"a new upstream release likely
+  changed the client's API contract"* about qBittorrent, Transmission and
+  Deluge — none of which had been contacted. `acceptance.sh` exited `1` for
+  every failure, so the workflow had no way to tell the two apart.
+
+  The July guard (a green pinned baseline implies a real canary failure) did
+  not hold: the quota is time-based, and that night it hit only the later
+  canary jobs while the pinned legs had already finished.
+
+  - `acceptance.sh` now retries the stack bring-up up to three times with a
+    30s/60s backoff, and exits `75` (`EX_TEMPFAIL`) when the images still
+    cannot be fetched, instead of `1`.
+  - The canary workflow reads that code: `75` becomes a run annotation and
+    files nothing, and only a genuine failure — the stack came up and the
+    client rejected the plugin handshake — files or comments on an issue.
+  - A registry failure no longer reddens the pinned baseline either, which
+    also runs on release tags against immutable image tags.
+  - New `deploy/acceptance/lib.sh` holds the registry-failure classifier,
+    unit-tested by `lib_test.sh` against the real log lines from the run that
+    filed the false issues, and run in CI as the `Acceptance helper tests` job.
+    The patterns are deliberately narrow: a broad match would classify a real
+    upstream regression as infrastructure and silence the canary.
+
 ## [1.19.6] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **The nightly client canary blamed torrent clients for Docker Hub outages**
+- **The nightly client canary blamed torrent clients for a registry outage**
   (issues #166, #167, #168 — a repeat of #119-#121). On 2026-08-28 all three
-  `latest` acceptance legs died on `toomanyrequests` from the anonymous Docker
-  Hub quota that every GitHub-hosted runner shares, before a single container
-  started. Three issues were filed saying *"a new upstream release likely
+  `latest` acceptance legs died on `toomanyrequests` before a single container
+  started, and three issues were filed saying *"a new upstream release likely
   changed the client's API contract"* about qBittorrent, Transmission and
   Deluge — none of which had been contacted. `acceptance.sh` exited `1` for
   every failure, so the workflow had no way to tell the two apart.
 
-  The July guard (a green pinned baseline implies a real canary failure) did
-  not hold: the quota is time-based, and that night it hit only the later
-  canary jobs while the pinned legs had already finished.
+  The refusals came from **lscr.io**, which serves the linuxserver client
+  images; Docker Hub had already served `db` and `gateway` in the same jobs
+  seconds earlier. The July guard (a green pinned baseline implies a real
+  canary failure) did not hold either: registry quotas are time-based, and that
+  night the limit was hit only by the later canary legs.
 
   - `acceptance.sh` now retries the stack bring-up up to three times with a
     30s/60s backoff, and exits `75` (`EX_TEMPFAIL`) when the images still
     cannot be fetched, instead of `1`.
   - The canary workflow reads that code: `75` becomes a run annotation and
-    files nothing, and only a genuine failure — the stack came up and the
-    client rejected the plugin handshake — files or comments on an issue.
+    files nothing, and only a genuine failure — the images arrived, the stack
+    came up, and the client rejected the plugin handshake — files or comments
+    on an issue.
   - A registry failure no longer reddens the pinned baseline either, which
     also runs on release tags against immutable image tags.
   - New `deploy/acceptance/lib.sh` holds the registry-failure classifier,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,28 +456,30 @@ isolated `marauder-acceptance` Compose project (so it never touches a running
 succeeds — i.e. the plugin `Test()` passed. The `latest` channel overrides the
 client image tag via `MARAUDER_TEST_*_TAG=latest`.
 
-The canary has **three** outcomes, not two, because every image is pulled on the
-anonymous Docker Hub quota shared by all GitHub-hosted runners and a
-`toomanyrequests` there says nothing about the client under test.
+The canary has **three** outcomes, not two. Images come from two registries and
+either can throttle a GitHub-hosted runner, whose egress IP is shared with
+thousands of jobs: **Docker Hub** (postgres, nginx, and the golang/node/alpine
+build bases) and **lscr.io** (the linuxserver client image under test).
 `acceptance.sh` retries the bring-up 3x (30s/60s backoff) and, if the images
 still never arrive, exits **75** (`EX_TEMPFAIL`) instead of `1`; the workflow
-turns 75 into a run annotation and files nothing, and only exit 1 — the stack
-came up and the client rejected the handshake — files or comments on a deduped
-`client-canary` issue. 75 also does not redden the `pinned` job, which runs on
-release tags against immutable tags. The classifier that decides which it was
-lives in `deploy/acceptance/lib.sh` (`acceptance_is_registry_failure`, pure
-text) and is unit-tested by `lib_test.sh` — CI job `Acceptance helper tests` —
-against the real log lines from the run that mis-filed. **Keep its patterns
-narrow**: a broad match reclassifies a genuine upstream regression as
-infrastructure and silences the canary entirely. Both jobs additionally
-`docker login` when `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets exist, for an
-authenticated per-account quota; those secrets have never been set, so that step
-has been skipped on every run since it was added — which is why the exit-code
-split, not the login, is what actually stopped the noise. The `latest` job still
-runs only after a green `pinned` baseline, but that gate is not an infra
-detector on its own: the quota is time-based, and on 2026-08-28 it hit only the
-canary legs after the pinned legs had passed, filing false issues #166-#168 (a
-repeat of #119-#121).
+turns 75 into a run annotation and files nothing, and only exit 1 — the images
+arrived, the stack came up, and the client rejected the handshake — files or
+comments on a deduped `client-canary` issue. 75 also does not redden the
+`pinned` job, which runs on release tags against immutable tags. The classifier
+that decides which it was lives in `deploy/acceptance/lib.sh`
+(`acceptance_is_registry_failure`, pure text) and is unit-tested by
+`lib_test.sh` — CI job `Acceptance helper tests` — against the real log lines
+from the run that mis-filed. **Keep its patterns narrow**: a broad match
+reclassifies a genuine upstream regression as infrastructure and silences the
+canary entirely. Both jobs also `docker login` to Docker Hub when
+`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` exist, but treat that as a hedge, not a
+fix — those secrets have never been set, and Docker Hub was **not** the culprit
+in #166-#168: it served `db` and `gateway` in the same jobs seconds before
+lscr.io refused the client images. Do not "solve" a recurrence by buying a
+Docker Hub account without first reading which registry the log names. The
+`latest` job still runs only after a green `pinned` baseline, but that gate is
+not an infra detector on its own: quotas are time-based, and on 2026-08-28 the
+limit was hit only by the canary legs, after the pinned legs had passed.
 
 ### Release automation (no manual version/tag)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,12 +454,30 @@ baseline). The runner brings up the base stack plus one client under the
 isolated `marauder-acceptance` Compose project (so it never touches a running
 `deploy` dev stack or `deploy/.env`) and asserts `POST /api/v1/clients`
 succeeds — i.e. the plugin `Test()` passed. The `latest` channel overrides the
-client image tag via `MARAUDER_TEST_*_TAG=latest`; on failure the workflow files
-a deduped `client-canary` GitHub issue. The `latest` job runs only after a green
-`pinned` baseline (immutable tags — a red baseline means infra, not upstream; see
-issues #119-#121, a Docker Hub rate-limit false alarm), and both jobs
-`docker login` when `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets exist to use
-an authenticated pull quota instead of the runners' shared anonymous pool.
+client image tag via `MARAUDER_TEST_*_TAG=latest`.
+
+The canary has **three** outcomes, not two, because every image is pulled on the
+anonymous Docker Hub quota shared by all GitHub-hosted runners and a
+`toomanyrequests` there says nothing about the client under test.
+`acceptance.sh` retries the bring-up 3x (30s/60s backoff) and, if the images
+still never arrive, exits **75** (`EX_TEMPFAIL`) instead of `1`; the workflow
+turns 75 into a run annotation and files nothing, and only exit 1 — the stack
+came up and the client rejected the handshake — files or comments on a deduped
+`client-canary` issue. 75 also does not redden the `pinned` job, which runs on
+release tags against immutable tags. The classifier that decides which it was
+lives in `deploy/acceptance/lib.sh` (`acceptance_is_registry_failure`, pure
+text) and is unit-tested by `lib_test.sh` — CI job `Acceptance helper tests` —
+against the real log lines from the run that mis-filed. **Keep its patterns
+narrow**: a broad match reclassifies a genuine upstream regression as
+infrastructure and silences the canary entirely. Both jobs additionally
+`docker login` when `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets exist, for an
+authenticated per-account quota; those secrets have never been set, so that step
+has been skipped on every run since it was added — which is why the exit-code
+split, not the login, is what actually stopped the noise. The `latest` job still
+runs only after a green `pinned` baseline, but that gate is not an infra
+detector on its own: the quota is time-based, and on 2026-08-28 it hit only the
+canary legs after the pinned legs had passed, filing false issues #166-#168 (a
+repeat of #119-#121).
 
 ### Release automation (no manual version/tag)
 

--- a/deploy/acceptance/acceptance.sh
+++ b/deploy/acceptance/acceptance.sh
@@ -14,6 +14,8 @@ CHANNEL="${2:?usage: acceptance.sh <client> <pinned|latest>}"
 
 # Run from the deploy/ directory (this script lives in deploy/acceptance/).
 DEPLOY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=acceptance/lib.sh
+source "$DEPLOY_DIR/acceptance/lib.sh"
 cd "$DEPLOY_DIR"
 
 # Isolated project + non-default API port so a running dev stack is untouched.
@@ -47,6 +49,7 @@ esac
 
 # Fresh, throwaway env (never touch the developer's deploy/.env).
 ENV_FILE="$(mktemp)"
+UP_LOG="$(mktemp)"
 cp .env.example "$ENV_FILE"
 MASTER=$(openssl rand -base64 32)
 METRICS=$(openssl rand -hex 32)
@@ -56,13 +59,39 @@ COMPOSE+=(--env-file "$ENV_FILE")
 
 cleanup() {
   "${COMPOSE[@]}" down -v >/dev/null 2>&1 || true
-  rm -f "$ENV_FILE"
+  rm -f "$ENV_FILE" "$UP_LOG"
 }
 trap cleanup EXIT
 
+# Bring the stack up, retrying registry failures. Every image here is pulled on
+# the anonymous Docker Hub quota shared by all GitHub-hosted runners, so a
+# `toomanyrequests` reports the busy hour, not the client under test. Retrying
+# clears most of them; the ones that survive exit EX_INFRA so the caller can
+# tell "could not fetch the images" from "the client rejected us" instead of
+# filing an upstream-regression issue about a registry (issues #119-#121, #166-#168).
+UP_ATTEMPTS=3
 echo "==> $CLIENT/$CHANNEL: bringing up base stack + $SERVICE"
-"${COMPOSE[@]}" up -d --wait --wait-timeout 180 \
-  db backend frontend gateway "$SERVICE"
+for attempt in $(seq 1 "$UP_ATTEMPTS"); do
+  if "${COMPOSE[@]}" up -d --wait --wait-timeout 180 \
+       db backend frontend gateway "$SERVICE" >"$UP_LOG" 2>&1; then
+    cat "$UP_LOG"
+    break
+  fi
+  cat "$UP_LOG" >&2
+  if ! acceptance_is_registry_failure "$(cat "$UP_LOG")"; then
+    echo "FAIL: $CLIENT/$CHANNEL: stack did not come up" >&2
+    exit 1
+  fi
+  if [ "$attempt" -eq "$UP_ATTEMPTS" ]; then
+    echo "INFRA: $CLIENT/$CHANNEL: registry unavailable after $UP_ATTEMPTS attempts" >&2
+    exit "$ACCEPTANCE_EX_INFRA"
+  fi
+  # Docker Hub's quota windows are minute-scale, so back off in tens of seconds.
+  BACKOFF=$((attempt * 30))
+  echo "==> registry failure (attempt $attempt/$UP_ATTEMPTS); retrying in ${BACKOFF}s" >&2
+  "${COMPOSE[@]}" down -v >/dev/null 2>&1 || true
+  sleep "$BACKOFF"
+done
 
 # Resolve per-client credentials.
 USERNAME=admin; PASSWORD=""

--- a/deploy/acceptance/acceptance.sh
+++ b/deploy/acceptance/acceptance.sh
@@ -63,12 +63,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Bring the stack up, retrying registry failures. Every image here is pulled on
-# the anonymous Docker Hub quota shared by all GitHub-hosted runners, so a
-# `toomanyrequests` reports the busy hour, not the client under test. Retrying
-# clears most of them; the ones that survive exit EX_INFRA so the caller can
-# tell "could not fetch the images" from "the client rejected us" instead of
-# filing an upstream-regression issue about a registry (issues #119-#121, #166-#168).
+# Bring the stack up, retrying registry failures. Images come from Docker Hub
+# (postgres, nginx, the golang/node/alpine build bases) and lscr.io (the client
+# under test), and either can throttle a GitHub-hosted runner whose egress IP is
+# shared with thousands of other jobs — so a `toomanyrequests` reports the busy
+# hour, not the client. Retrying clears most of them; the ones that survive exit
+# EX_INFRA so the caller can tell "could not fetch the images" from "the client
+# rejected us" instead of filing an upstream-regression issue about a registry
+# (issues #119-#121, then #166-#168).
 UP_ATTEMPTS=3
 echo "==> $CLIENT/$CHANNEL: bringing up base stack + $SERVICE"
 for attempt in $(seq 1 "$UP_ATTEMPTS"); do

--- a/deploy/acceptance/lib.sh
+++ b/deploy/acceptance/lib.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the client acceptance harness. Sourced by acceptance.sh;
+# the classifier is pure text and is unit-tested by lib_test.sh (no Docker).
+
+# Exit status acceptance.sh reports when the run never reached its assertion
+# because the container images could not be fetched. Distinct from 1 ("the
+# client really rejected us") so the canary workflow can tell an upstream API
+# break from registry trouble and stop filing issues about the wrong thing.
+# 75 is EX_TEMPFAIL from sysexits.h — "try again later".
+# shellcheck disable=SC2034  # read by acceptance.sh, which sources this file.
+ACCEPTANCE_EX_INFRA=75
+
+# acceptance_is_registry_failure <combined-compose-output>
+#
+# True when the output shows an image manifest or layer could not be fetched,
+# rather than a failure of the client under test. Every pull in this harness
+# goes through the anonymous Docker Hub quota shared by ALL GitHub-hosted
+# runners, so `toomanyrequests` reflects the hour of the day, not our client
+# plugins (issues #119-#121, then #166-#168 on the same wording).
+#
+# Patterns stay narrow on purpose. A broad match here would classify a genuine
+# upstream regression as "infrastructure" and silence the canary — the exact
+# failure the canary exists to catch.
+acceptance_is_registry_failure() {
+  local log="$1"
+  case "$log" in
+    # Docker Hub quota, both the daemon wording and the human one.
+    *toomanyrequests*|*"pull rate limit"*) return 0 ;;
+    # Registry answered, but unhealthy: 5xx / gateway errors.
+    *"received unexpected HTTP status: 5"*|*"Service Unavailable"*|*"502 Bad Gateway"*)
+      return 0 ;;
+    # Transport to the registry never completed: TLS or DNS.
+    *"TLS handshake timeout"*|*"lookup registry-1.docker.io"*|*"lookup auth.docker.io"*)
+      return 0 ;;
+    # BuildKit wording for a layer fetch that came back non-200 mid-build,
+    # and the classic engine wording for a failed config blob fetch.
+    *"httpReadSeeker: failed open"*|*"error pulling image configuration"*) return 0 ;;
+  esac
+  return 1
+}

--- a/deploy/acceptance/lib.sh
+++ b/deploy/acceptance/lib.sh
@@ -14,10 +14,13 @@ ACCEPTANCE_EX_INFRA=75
 # acceptance_is_registry_failure <combined-compose-output>
 #
 # True when the output shows an image manifest or layer could not be fetched,
-# rather than a failure of the client under test. Every pull in this harness
-# goes through the anonymous Docker Hub quota shared by ALL GitHub-hosted
-# runners, so `toomanyrequests` reflects the hour of the day, not our client
-# plugins (issues #119-#121, then #166-#168 on the same wording).
+# rather than a failure of the client under test. Runs pull from two registries
+# and either can throttle a GitHub-hosted runner, whose egress IP is shared with
+# thousands of other jobs: Docker Hub (postgres, nginx, and the golang/node/
+# alpine build bases) and lscr.io (the linuxserver client images). On
+# 2026-08-28 it was lscr.io — Docker Hub had already served `db` and `gateway`
+# in the same job seconds earlier — and three innocent clients were reported as
+# having changed their APIs (issues #166-#168; #119-#121 was the same shape).
 #
 # Patterns stay narrow on purpose. A broad match here would classify a genuine
 # upstream regression as "infrastructure" and silence the canary — the exact
@@ -25,14 +28,14 @@ ACCEPTANCE_EX_INFRA=75
 acceptance_is_registry_failure() {
   local log="$1"
   case "$log" in
-    # Docker Hub quota, both the daemon wording and the human one.
+    # Registry quota, both the daemon wording and Docker Hub's human one.
     *toomanyrequests*|*"pull rate limit"*) return 0 ;;
     # Registry answered, but unhealthy: 5xx / gateway errors.
     *"received unexpected HTTP status: 5"*|*"Service Unavailable"*|*"502 Bad Gateway"*)
       return 0 ;;
-    # Transport to the registry never completed: TLS or DNS.
-    *"TLS handshake timeout"*|*"lookup registry-1.docker.io"*|*"lookup auth.docker.io"*)
-      return 0 ;;
+    # Transport to a registry never completed: TLS or DNS.
+    *"TLS handshake timeout"*|*"lookup registry-1.docker.io"*|*"lookup auth.docker.io"*\
+      |*"lookup lscr.io"*|*"lookup ghcr.io"*) return 0 ;;
     # BuildKit wording for a layer fetch that came back non-200 mid-build,
     # and the classic engine wording for a failed config blob fetch.
     *"httpReadSeeker: failed open"*|*"error pulling image configuration"*) return 0 ;;

--- a/deploy/acceptance/lib_test.sh
+++ b/deploy/acceptance/lib_test.sh
@@ -49,8 +49,10 @@ check "registry gateway error" 0 \
   'received unexpected HTTP status: 502 Bad Gateway'
 check "registry TLS timeout" 0 \
   'net/http: TLS handshake timeout'
-check "registry DNS failure" 0 \
+check "docker hub DNS failure" 0 \
   'dial tcp: lookup registry-1.docker.io on 127.0.0.53:53: server misbehaving'
+check "lscr.io DNS failure" 0 \
+  'dial tcp: lookup lscr.io on 127.0.0.53:53: no such host'
 check "buildkit layer fetch" 0 \
   'failed to copy: httpReadSeeker: failed open: unexpected status code 429'
 check "engine config blob fetch" 0 \

--- a/deploy/acceptance/lib_test.sh
+++ b/deploy/acceptance/lib_test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Table-driven tests for acceptance_is_registry_failure. No Docker needed —
+# the fixtures are real compose output captured from nightly run 33192434421
+# (the run that filed the false client-canary issues #166-#168) plus the
+# harness's own failure wording.
+#   bash deploy/acceptance/lib_test.sh
+# Exits non-zero if any assertion fails.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$DIR/lib.sh"
+
+pass=0
+fail=0
+
+# Assert the classifier's exit status (0 = registry/infra, 1 = real failure).
+check() {
+  local label="$1" want="$2" log="$3" got
+  if acceptance_is_registry_failure "$log"; then got=0; else got=1; fi
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: %s\n  want-exit=%s got-exit=%s\n  log=%q\n' \
+      "$label" "$want" "$got" "$log"
+  fi
+}
+
+# ------------------------------------------------ real registry failures (0)
+
+# Verbatim from run 33192434421, the three latest-canary legs.
+check "docker hub quota, qbittorrent leg" 0 \
+  ' qbittorrent-521 Error toomanyrequests: retry-after: 999.152µs, allowed: 44000/minute'
+check "docker hub quota, daemon wording" 0 \
+  'Error response from daemon: toomanyrequests: retry-after: 656.247µs, allowed: 44000/minute'
+check "docker hub quota, deluge leg" 0 \
+  ' deluge-220 Error toomanyrequests: retry-after: 1.248776ms, allowed: 44000/minute'
+
+# The same quota reported in Docker Hub's human wording.
+check "docker hub quota, human wording" 0 \
+  'toomanyrequests: You have reached your pull rate limit. https://www.docker.com/increase-rate-limit'
+
+check "registry 5xx" 0 \
+  'failed to fetch oauth token: unexpected status from GET request: 503 Service Unavailable'
+check "registry gateway error" 0 \
+  'received unexpected HTTP status: 502 Bad Gateway'
+check "registry TLS timeout" 0 \
+  'net/http: TLS handshake timeout'
+check "registry DNS failure" 0 \
+  'dial tcp: lookup registry-1.docker.io on 127.0.0.53:53: server misbehaving'
+check "buildkit layer fetch" 0 \
+  'failed to copy: httpReadSeeker: failed open: unexpected status code 429'
+check "engine config blob fetch" 0 \
+  'error pulling image configuration: download failed after attempts=6'
+
+# Multi-line, as the harness actually captures it: the marker can sit anywhere.
+check "quota buried in a long log" 0 \
+  ' gateway Pulling
+ db Pulled
+ qbittorrent-521 Error toomanyrequests: retry-after: 999.152µs, allowed: 44000/minute
+Error response from daemon: toomanyrequests'
+
+# -------------------------------------------------- real client failures (1)
+
+# Produced by acceptance.sh itself once the stack is up — never infra.
+check "plugin handshake rejected" 1 \
+  'FAIL: qbittorrent/latest create-client -> HTTP 502'
+check "client container never healthy" 1 \
+  'container marauder-acceptance-deluge-220-1 is unhealthy'
+check "compose wait timed out" 1 \
+  'error: timeout waiting for containers to be healthy'
+check "marauder login failed" 1 \
+  'Marauder login failed'
+check "empty output" 1 ''
+
+# Benign: compose warns about the locally-built images on every single run
+# (they have a build: section and no registry copy). Classifying that as a
+# registry failure would make EVERY failure look like infrastructure.
+check "build-service pull warning is not infra" 1 \
+  " backend Warning pull access denied for marauder-backend, repository does not exist or may require 'docker login': denied: requested access to the resource is denied"
+
+# Guard: a 4xx that is NOT the quota must stay a real failure, so a bad tag
+# (typo, withdrawn release) is reported instead of retried forever.
+check "manifest unknown is not infra" 1 \
+  'manifest for linuxserver/qbittorrent:latest not found: manifest unknown'
+
+# ---------------------------------------------------------------------- tally
+if [[ "$fail" -gt 0 ]]; then
+  printf '\n%d passed, %d FAILED\n' "$pass" "$fail"
+  exit 1
+fi
+printf '%d passed, 0 failed\n' "$pass"

--- a/docs/blog-source/INDEX.md
+++ b/docs/blog-source/INDEX.md
@@ -1,0 +1,7 @@
+# Blog source notes — Marauder
+
+Tier-1 notes captured from real work. See `~/.claude/rules/blog-material-capture.md`.
+
+| Date | Note | Category | Hook |
+|---|---|---|---|
+| 2026-08-31 | [canary-blamed-the-wrong-thing](notes/2026-08-31-canary-blamed-the-wrong-thing.md) | war-story, architecture | A nightly canary filed three bug reports about software it never contacted |

--- a/docs/blog-source/notes/2026-08-31-canary-blamed-the-wrong-thing.md
+++ b/docs/blog-source/notes/2026-08-31-canary-blamed-the-wrong-thing.md
@@ -1,0 +1,42 @@
+---
+date: 2026-08-31
+project: marauder
+category: [war-story, architecture]
+status: note
+sources:
+  - "deploy/acceptance/acceptance.sh"
+  - "deploy/acceptance/lib.sh"
+  - ".github/workflows/client-acceptance.yml"
+  - "commit:ba86f42"
+  - "issue:#119"
+  - "issue:#166"
+related:
+  - "silent-no-op-guards"
+---
+
+# My canary filed three bug reports about software it never contacted
+
+**Why interesting:** A nightly job accused qBittorrent, Transmission and Deluge
+of breaking their APIs. All three were innocent. The runner had been refused the
+container images by a registry rate limit, so not one of those programs was ever
+started. The test harness had a single exit code for "the thing under test is
+broken" and "I could not obtain the thing under test", and a monitor that cannot
+tell those apart does not report faults — it manufactures them.
+
+**Substance:** The same failure had already happened once and been "fixed". That
+fix added an authenticated registry login guarded by `if: env.TOKEN != ''`, and
+the token was never created — so the protective step was silently skipped every
+night for six weeks while looking present in the config. The second half of the
+fix was an inference: "the pinned baseline passed, so a later failure must be
+real." Rate limits are time-based, so the quota ran out *between* the two stages
+and the inference held the wrong way round. The durable fix was neither
+credentials nor a smarter heuristic: it was giving the harness a second failure
+exit code, and teaching the classifier narrow, evidence-backed patterns — narrow
+because a generous "looks like infrastructure" match would silence the canary for
+real regressions, converting a noisy monitor into a useless one.
+
+## Sources
+- `deploy/acceptance/lib.sh` — the registry-failure classifier and `EX_TEMPFAIL`
+- `deploy/acceptance/lib_test.sh` — tested against the real log lines that mis-filed
+- `.github/workflows/client-acceptance.yml` — three outcomes: pass, fail, infra
+- commit `ba86f42` — the earlier fix whose guard silently no-opped

--- a/docs/blog-source/notes/2026-08-31-canary-blamed-the-wrong-thing.md
+++ b/docs/blog-source/notes/2026-08-31-canary-blamed-the-wrong-thing.md
@@ -17,9 +17,8 @@ related:
 # My canary filed three bug reports about software it never contacted
 
 **Why interesting:** A nightly job accused qBittorrent, Transmission and Deluge
-of breaking their APIs. All three were innocent. The runner had been refused the
-container images by a registry rate limit, so not one of those programs was ever
-started. The test harness had a single exit code for "the thing under test is
+of breaking their APIs. All three were innocent. The registry that serves those images had refused them
+to the runner, so not one of those programs was ever started. The test harness had a single exit code for "the thing under test is
 broken" and "I could not obtain the thing under test", and a monitor that cannot
 tell those apart does not report faults — it manufactures them.
 
@@ -40,3 +39,11 @@ real regressions, converting a noisy monitor into a useless one.
 - `deploy/acceptance/lib_test.sh` — tested against the real log lines that mis-filed
 - `.github/workflows/client-acceptance.yml` — three outcomes: pass, fail, infra
 - commit `ba86f42` — the earlier fix whose guard silently no-opped
+
+**Second twist, found by the reviewer:** the "fix" that was never wired was a
+*Docker Hub* login — and Docker Hub was not the registry that refused us. The
+same job had pulled two Docker Hub images successfully seconds before a
+different registry rejected the one image that mattered. So even if the missing
+credential had been created, it would have changed nothing. A plausible cause,
+an unread log, and a fix aimed at the wrong system: the debugging failure and
+the monitoring failure had the same shape.


### PR DESCRIPTION
## What

The nightly client canary filed issues #166, #167 and #168 against qBittorrent, Transmission and Deluge. **All three are false alarms.** Run [33192434421](https://github.com/artyomsv/marauder/actions/runs/33192434421) never contacted any of them — every `latest` leg died on `toomanyrequests` before a container started.

## Which registry actually refused us

Not Docker Hub. From the transmission leg, in order:

```
gateway Pulled          <- nginx:1.27-alpine     (Docker Hub)  OK
db      Pulled          <- postgres:18.4-alpine  (Docker Hub)  OK
toomanyrequests: retry-after: 656.247µs, allowed: 44000/minute
                        <- lscr.io/linuxserver/transmission    REFUSED
```

Docker Hub served two images fine, seconds earlier, in the same job. The three refusals were all `lscr.io/linuxserver/*` — the client images. `allowed: 44000/minute` is not a Docker Hub figure either; anonymous Docker Hub is 100 pulls per 6h per IP.

Per acceptance job we pull ~6 images from Docker Hub (postgres, nginx, and the golang/node/alpine build bases) and exactly 1 from lscr.io. The one that broke is the one there is only one of.

Nightlies on 29, 30 and 31 August are all green.

## Why the July fix (ba86f42) did not hold

Three reasons, all worth recording:

1. **It was aimed at the wrong registry.** It added a Docker Hub login. Docker Hub was not refusing us.
2. **It never ran anyway.** The step is guarded on `if: env.DOCKERHUB_TOKEN != ''`, and those secrets were never created — it has reported `skipped` on every run since. Protection present in the config, absent at runtime.
3. **"Pinned green ⇒ a canary failure is real" is a false inference.** Quotas are time-based, not usage-based. That night the limit was hit only by the later canary legs.

## Root cause

`acceptance.sh` exited `1` for every failure. A monitor that cannot tell *"I could not obtain the thing under test"* from *"the thing under test is broken"* does not report faults — it manufactures them.

## Change

- `acceptance.sh` retries the bring-up 3x (30s/60s backoff), then exits **75** (`EX_TEMPFAIL`) when the images still never arrive.
- The canary now has three outcomes. `75` becomes a run annotation and files nothing; only exit `1` — the images arrived, the stack came up, and the client rejected the handshake — files or comments on a `client-canary` issue. The issue body now states that, so the claim is falsifiable from the run log.
- `75` no longer reddens the `pinned` job either, which runs on release tags against immutable image tags.
- New `deploy/acceptance/lib.sh` holds the classifier; `lib_test.sh` tests it against the real log lines from the run that mis-filed, wired into CI as the `Acceptance helper tests` job.
- `timeout-minutes` 15 → 25 (three bring-ups plus backoff no longer fit).
- The Docker Hub login step stays, documented as a hedge for the six Docker Hub pulls each job does make — explicitly **not** as the fix. `CLAUDE.md` warns against "solving" a recurrence by buying a Docker Hub account before reading which registry the log names.

The classifier patterns are deliberately narrow — a broad "looks like infrastructure" match would reclassify a genuine upstream regression as infra and silence the canary, which is worse than the noise it replaces. `manifest unknown` therefore stays a real failure.

## Verification

Run locally, not inferred:

| Case | Result |
|---|---|
| Real stack + real container, `transmission pinned` | `PASS: create-client -> HTTP 201`, exit 0 |
| Stubbed `toomanyrequests` | retried 2x, `INFRA: registry unavailable`, exit **75** |
| Stubbed unhealthy container | `FAIL: stack did not come up`, exit **1**, no retry |
| `bash deploy/acceptance/lib_test.sh` | 19 passed, 0 failed |
| `actionlint` on both workflows | clean |

Also checked the tests have teeth: an always-true classifier fails 7 of them.

## No action needed from anyone

Earlier revisions of this PR asked for a Docker Hub account. Withdrawn — it would not have prevented this. The retry and the exit-code split are the whole fix.

Closes #166
Closes #167
Closes #168
